### PR TITLE
Change command group help formatting

### DIFF
--- a/mreg_cli/cli.py
+++ b/mreg_cli/cli.py
@@ -29,6 +29,25 @@ class Flag:
         self.action = action
 
 
+def _create_command_group(parent):
+    parent_name = parent.prog.strip()
+
+    if parent_name:
+        title = 'subcommands'
+    else:
+        title = 'commands'
+
+    metavar = '<command>'
+    description = "Run '{}' for more details".format(
+        ' '.join(word for word in (parent_name, metavar, '-h') if word))
+
+    return parent.add_subparsers(
+        title=title,
+        description=description,
+        metavar=metavar,
+    )
+
+
 class Command(Completer):
     """Command is a class which acts as a wrapper around argparse and
     prompt_toolkit.
@@ -58,9 +77,11 @@ class Command(Completer):
         :return: the Command object of the new command.
         """
         if not self.sub:
-            self.sub = self.parser.add_subparsers()
-        parser = self.sub.add_parser(prog, description=description,
-                                     epilog=epilog)
+            self.sub = _create_command_group(self.parser)
+        parser = self.sub.add_parser(prog,
+                                     description=description,
+                                     epilog=epilog,
+                                     help=short_desc)
         for f in flags:
             # Need to create a dict with the parameters so only used
             # parameters are sent, or else exceptions are raised. Ex: if
@@ -193,7 +214,7 @@ def _quit(args):
 cli.add_command(
     prog='quit',
     description='Exit application.',
-    short_desc='Exit application.',
+    short_desc='Quit',
     callback=_quit,
 )
 
@@ -203,8 +224,8 @@ def logout(args):
 
 cli.add_command(
     prog='logout',
-    description='Logout from mreg and exit. Will delete token',
-    short_desc='Logout from mreg and exit.',
+    description='Log out from mreg and exit. Will delete token',
+    short_desc='Log out from mreg',
     callback=logout,
 )
 
@@ -258,8 +279,8 @@ def _source(args):
 # Always need the source command.
 cli.add_command(
     prog='source',
-    description='Read commands from the given source files.',
-    short_desc='Read from file(s).',
+    description='Read and run commands from the given source files.',
+    short_desc='Run commands from file(s)',
     callback=_source,
     flags=[
         Flag('files',

--- a/mreg_cli/dhcp.py
+++ b/mreg_cli/dhcp.py
@@ -9,7 +9,8 @@ from .util import format_mac, get_list, host_info_by_name, is_valid_ip, is_valid
 
 dhcp = cli.add_command(
     prog='dhcp',
-    description='Manage dhcp.',
+    description='Manage DHCP associations.',
+    short_desc='Manage DHCP',
 )
 
 def _dhcp_get_ip_by_arg(arg):

--- a/mreg_cli/group.py
+++ b/mreg_cli/group.py
@@ -12,7 +12,8 @@ from .util import delete, get, get_list, host_info_by_name, patch, post
 
 group = cli.add_command(
     prog='group',
-    description='Manage hostgroups',
+    description='Manage hostgroups.',
+    short_desc='Manage hostgroups',
 )
 
 # Utils

--- a/mreg_cli/history.py
+++ b/mreg_cli/history.py
@@ -246,6 +246,7 @@ history = History()
 history_ = cli.add_command(
     prog='history',
     description='Undo, redo or print history for this program session.',
+    short_desc='Session history'
 )
 
 
@@ -254,7 +255,7 @@ history_ = cli.add_command(
 #########################################
 
 def print_(args):
-    print('pringing history.')
+    print('printing history.')
 
 
 history_.add_command(

--- a/mreg_cli/host.py
+++ b/mreg_cli/host.py
@@ -42,6 +42,7 @@ from .util import (
 host = cli.add_command(
     prog='host',
     description='Manage hosts.',
+    short_desc='Manage hosts',
 )
 
 

--- a/mreg_cli/network.py
+++ b/mreg_cli/network.py
@@ -30,6 +30,7 @@ from .util import (
 network = cli.add_command(
     prog='network',
     description='Manage networks.',
+    short_desc='Manage networks',
 )
 
 

--- a/mreg_cli/permission.py
+++ b/mreg_cli/permission.py
@@ -13,6 +13,7 @@ from .util import convert_wildcard_to_regex, delete, get_list, is_valid_network,
 permission = cli.add_command(
     prog='permission',
     description='Manage permissions.',
+    short_desc='Manage permissions',
 )
 
 

--- a/mreg_cli/policy.py
+++ b/mreg_cli/policy.py
@@ -13,7 +13,8 @@ from .util import (convert_wildcard_to_regex, delete, get, get_list, host_info_b
 
 policy = cli.add_command(
     prog='policy',
-    description='Manage hostpolicy',
+    description='Manage policies for hosts.',
+    short_desc='Manage policies',
 )
 
 # Utils


### PR DESCRIPTION
This change alters the output when using `-h`/`--help` on command groups.  Rather than list all the commands *twice* (once in usage, once in the positional args section), we use metavar as a placeholder and list valid values *once* with a short description (the `short_desc` command attr).