### PR TITLE
Document that FILTERs are regular expressions.

### DIFF
--- a/mreg_cli/policy.py
+++ b/mreg_cli/policy.py
@@ -392,7 +392,7 @@ policy.add_command(
     callback=list_atoms,
     flags=[
         Flag('name',
-             description='Atom name filter',
+             description='Atom name filter (regexp)',
              metavar='FILTER'),
     ]
 )
@@ -422,7 +422,7 @@ policy.add_command(
     callback=list_roles,
     flags=[
         Flag('name',
-             description='Role name filter',
+             description='Role name filter (regexp)',
              metavar='FILTER'),
     ]
 )


### PR DESCRIPTION
  - For list_roles and list_atoms, mreg-cli requires a FILTER.
    This filter does not automatically glob, but expects a
    valid regular expression (but helpfully maps '*' to '.*')