### PR TITLE
dhcp: Do not print association message when nothing was done.

### DIFF
--- a/mreg_cli/dhcp.py
+++ b/mreg_cli/dhcp.py
@@ -79,8 +79,9 @@ def assoc(args):
     ip = _dhcp_get_ip_by_arg(args.name)
     new_mac = assoc_mac_to_ip(args.mac, ip, force=args.force)
 
-    cli_info("associated mac address {} with ip {}"
-             .format(new_mac, ip["ipaddress"]), print_msg=True)
+    if new_mac is not None:
+        cli_info("associated mac address {} with ip {}"
+                 .format(new_mac, ip["ipaddress"]), print_msg=True)
 
 
 dhcp.add_command(


### PR DESCRIPTION
This fixes a confusing message when attempting to associate an existing DHCP<->MAC association.

```
mreg> dhcp assoc 10.0.20.3 aa:bb:cc:dd:ee:ff
WARNING: : mac aa:bb:cc:dd:ee:ff already in use by: 1.2.3.4, 10.0.20.3. Use force to add 10.0.20.3 -> aa:bb:cc:dd:ee:ff as well.
mreg> dhcp assoc 10.0.20.3 aa:bb:cc:dd:ee:ff -force
OK: : new and old mac are identical. Ignoring.
OK: : associated mac address None with ip 10.0.20.3
```

With this patch, the last line is gone.