### PR TITLE
Feature: Hosts can have a BACnet Instance Number

### DIFF
--- a/mreg_cli/bacnet.py
+++ b/mreg_cli/bacnet.py
@@ -1,0 +1,105 @@
+from .cli import Flag, cli
+from .exceptions import HostNotFoundWarning
+from .history import history
+from .host import host
+from .log import cli_error, cli_info, cli_warning
+from .util import (
+    clean_hostname,
+    host_info_by_name,
+    _host_info_by_name,
+    resolve_input_name,
+    print_table,
+    get,
+    get_list,
+    post,
+    delete,
+)
+
+def bacnetid_add(args):
+    info = host_info_by_name(args.name)
+    if 'bacnetid' in info and info['bacnetid'] is not None:
+        cli_error("{} already has BACnet ID {}.".format(info['name'],info['bacnetid']['id']))
+    postdata = {'hostname': info['name']}
+    path = '/api/v1/bacnet/ids/'
+    bacnetid = getattr(args, 'id')
+    if bacnetid:
+        response = get(path+bacnetid, ok404=True)
+        if response:
+            j = response.json()
+            cli_error('BACnet ID {} is already in use by {}'.format(j['id'], j['hostname']))
+        postdata['id'] = bacnetid
+    history.record_post(path, '', postdata)
+    post(path, **postdata)
+    info = host_info_by_name(args.name)
+    if 'bacnetid' in info and info['bacnetid'] is not None:
+        b = info['bacnetid']
+        cli_info("Assigned BACnet ID {} to {}".format(b['id'], info['name']), print_msg=True)
+
+
+host.add_command(
+    prog='bacnetid_add',
+    description='Assign a BACnet ID to the host.',
+    short_desc='Add BACnet ID',
+    callback=bacnetid_add,
+    flags=[
+        Flag('name',
+             description='Name of host.',
+             metavar='NAME'),
+        Flag('-id',
+             description='ID value (0-4194302)',
+             metavar='ID'),
+    ],
+)
+
+def bacnetid_remove(args):
+    info = host_info_by_name(args.name)
+    if 'bacnetid' not in info or info["bacnetid"] is None:
+        cli_error("{} does not have a BACnet ID assigned.".format(info['name']))
+    path = '/api/v1/bacnet/ids/{}'.format(info['bacnetid']['id'])
+    history.record_delete(path, info['bacnetid'])
+    delete(path)
+    cli_info("Unassigned BACnet ID {} from {}".format(info['bacnetid']['id'], info['name']), print_msg=True)
+
+host.add_command(
+    prog='bacnetid_remove',
+    description='Unassign the BACnet ID from the host.',
+    short_desc='Remove BACnet ID',
+    callback=bacnetid_remove,
+    flags=[
+        Flag('name',
+             description='Name of host.',
+             metavar='NAME'),
+    ],
+)
+
+
+def bacnetid_list(args):
+    minval = 0
+    if args.min is not None:
+        minval = args.min
+        if minval < 0:
+            cli_error("The minimum ID value is 0.")
+    maxval = 4194302
+    if args.max is not None:
+        maxval = args.max
+        if maxval > 4194302:
+            cli_error("The maximum ID value is 4194302.")
+    r = get_list("/api/v1/bacnet/ids/",{'id__range':'{},{}'.format(minval,maxval)})
+    print_table(('ID','Hostname'), ('id','hostname'), r)
+
+host.add_command(
+    prog='bacnetid_list',
+    description='Find/list BACnet IDs and hostnames',
+    short_desc='List used BACnet IDs',
+    callback=bacnetid_list,
+    flags=[
+        Flag('-min',
+             description='Minimum ID value (0-4194302)',
+             type=int,
+             metavar='MIN'),
+        Flag('-max',
+             description='Maximum ID value (0-4194302)',
+             type=int,
+             metavar='MAX'),
+    ],
+)

--- a/mreg_cli/bacnet.py
+++ b/mreg_cli/bacnet.py
@@ -4,10 +4,7 @@ from .history import history
 from .host import host
 from .log import cli_error, cli_info, cli_warning
 from .util import (
-    clean_hostname,
     host_info_by_name,
-    _host_info_by_name,
-    resolve_input_name,
     print_table,
     get,
     get_list,

--- a/mreg_cli/host.py
+++ b/mreg_cli/host.py
@@ -459,6 +459,14 @@ def print_txt(txt: str, padding: int = 14) -> None:
     print("{1:<{0}}{2}".format(padding, "TXT:", txt))
 
 
+def print_bacnetid(bacnetid: dict, padding: int = 14) -> None:
+    """Pretty print given txt"""
+    if bacnetid is None:
+        return
+    assert isinstance(bacnetid, dict)
+    print("{1:<{0}}{2}".format(padding, "BACnet ID:", bacnetid['id']))
+
+
 def _print_host_info(info):
     # Pretty print all host info
     print_host_name(info["name"])
@@ -480,6 +488,8 @@ def _print_host_info(info):
     _srv_show(host_id=info['id'])
     _naptr_show(info)
     _sshfp_show(info)
+    if "bacnetid" in info:
+        print_bacnetid(info.get("bacnetid"))
     cli_info("printed host info for {}".format(info["name"]))
 
 
@@ -1978,7 +1988,7 @@ def _naptr_show(info):
     history.record_get(path)
     naptrs = get_list(path, params=params)
     headers = ("NAPTRs:", "Preference", "Order", "Flag", "Service", "Regex", "Replacement")
-    row_format = '{:<14}' * len(headers) 
+    row_format = '{:<14}' * len(headers)
     if naptrs:
         print(row_format.format(*headers))
         for naptr in naptrs:

--- a/mreg_cli/main.py
+++ b/mreg_cli/main.py
@@ -146,6 +146,7 @@ def main():
     from . import permission  # noqa: F401
     from . import policy  # noqa: F401
     from . import zone      # noqa: F401
+    from . import bacnet  # must be imported after host
 
     # session is a PromptSession object from prompt_toolkit which handles
     # some configurations of the prompt for us: the text of the prompt; the

--- a/mreg_cli/util.py
+++ b/mreg_cli/util.py
@@ -665,7 +665,7 @@ def print_table(headers, keys, data, indent=0):
     for key, header in zip(keys, headers):
         longest = len(header)
         for d in data:
-            longest = max(longest, len(d[key]))
+            longest = max(longest, len(str(d[key])))
         raw_format += '{:<%d}   ' % longest
 
     print(raw_format.format(*headers))


### PR DESCRIPTION
This commit adds subcommands to the host command to assign BACnet IDs to hosts.
A BACnet ID (instance number) is an integer in the range 0-4194302, and hosts can't share the same ID.