### PR TITLE
Atomic CNAME updates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
         options: >-
           --name mreg
         env:
-          GUNICORN_ARGS: --bind=0.0.0.0
+          GUNICORN_CMD_ARGS: --bind=0.0.0.0
           MREG_DB_HOST: postgres
           MREG_DB_PASSWORD: postgres
         ports:

--- a/mreg_cli/host.py
+++ b/mreg_cli/host.py
@@ -1382,6 +1382,46 @@ host.add_command(
     ],
 )
 
+###################################################
+#  Implementation of sub command 'cname_replace'  #
+###################################################
+
+def cname_replace(args):
+    """Move a CNAME entry from one host to another.
+    """
+
+    cname = clean_hostname(args.cname)
+    host = clean_hostname(args.host)
+
+    cname_info = host_info_by_name(cname)
+    host_info = host_info_by_name(host)
+
+    if cname_info['id'] == host_info['id']:
+        cli_error(f"The CNAME {cname} already points to {host}.")
+
+    # Update CNAME record.
+    data = {'host': host_info['id'], 'name': cname }
+    path = f"/api/v1/cnames/{cname}"
+    history.record_patch(path, "", data, undoable=False)
+    patch(path, **data)
+    cli_info(f"Moved CNAME alias {cname}: {cname_info['name']} -> {host}",
+             print_msg=True)
+
+host.add_command(
+    prog='cname_replace',
+    description='Move a CNAME record from one host to another.',
+    short_desc='Replace a CNAME record.',
+    callback=cname_replace,
+    flags=[
+        Flag('cname',
+             description='The CNAME to modify.',
+             metavar='CNAME'),
+        Flag('host',
+             description='The new host for the CNAME.',
+             metavar='HOST'),
+    ],
+)
+
 
 ################################################
 #  Implementation of sub command 'cname_show'  #

--- a/mreg_cli/host.py
+++ b/mreg_cli/host.py
@@ -1398,20 +1398,7 @@ def cname_show(args):
         cli_info("showed cname aliases for {}".format(info["name"]))
         return
     except HostNotFoundWarning:
-        # Try again with the alias
-        pass
-
-    name = clean_hostname(args.name)
-    path = "/api/v1/hosts/"
-    params = {
-        "cnames__name": name,
-    }
-    history.record_get(path)
-    hosts = get_list(path, params=params)
-    if len(hosts):
-        print_cname(name, hosts[0]["name"])
-    else:
-        cli_warning("No cname found for {}".format(name))
+        cli_warning("No cname found for {}".format(args.name))
 
 
 # Add 'cname_show' as a sub command to the 'host' command


### PR DESCRIPTION
...as well as a fix for #152 while at it.

This PR adds a `cname_replace` command that can move a CNAME from one host to another in the same transaction.

The first commit is unrelated, but can simplify things in the mreg Docker container.