### PR TITLE
Improve & Refactor Type Annotations

### DIFF
--- a/mreg_cli/__init__.pyi
+++ b/mreg_cli/__init__.pyi
@@ -1,0 +1,1 @@
+from .log import *

--- a/mreg_cli/host.py
+++ b/mreg_cli/host.py
@@ -1,5 +1,6 @@
 import ipaddress
-import typing
+from typing import Iterable, Optional
+
 
 from .cli import Flag, cli
 from .dhcp import assoc_mac_to_ip
@@ -53,7 +54,7 @@ def print_hinfo(hinfo: dict, padding: int = 14) -> None:
     print("{1:<{0}}cpu={2} os={3}".format(padding, "Hinfo:", hinfo['cpu'], hinfo['os']))
 
 
-def zoneinfo_for_hostname(host: str) -> dict:
+def zoneinfo_for_hostname(host: str) -> Optional[dict]:
     """Return zoneinfo for a hostname, or None if not found or invalid"""
     if "." not in host:
         return None
@@ -374,8 +375,9 @@ def print_comment(comment: str, padding: int = 14) -> None:
     print("{1:<{0}}{2}".format(padding, "Comment:", comment))
 
 
-def print_ipaddresses(ipaddresses: typing.Iterable[dict], names: bool = False,
-                      padding: int = 14) -> None:
+def print_ipaddresses(
+    ipaddresses: Iterable[dict], names: bool = False, padding: int = 14
+) -> None:
     """Pretty print given ip addresses"""
     def _find_padding(lst, attr):
         return max(padding, max([len(i[attr]) for i in lst])+1)

--- a/mreg_cli/log.py
+++ b/mreg_cli/log.py
@@ -2,6 +2,7 @@ import getpass
 import inspect
 import re
 from datetime import datetime
+from typing import NoReturn, Optional, Type
 
 from .exceptions import CliError, CliWarning
 
@@ -30,7 +31,9 @@ def _write_log(entry: str, end: str = "\n") -> None:
             f.write(entry + end)
 
 
-def cli_error(msg: str, raise_exception: bool = True, exception=CliError) -> None:
+def cli_error(
+    msg: str, raise_exception: bool = True, exception: Type[Exception] = CliError
+) -> Optional[NoReturn]:
     """Write a ERROR log entry."""
     pre = _prefix_from_stack()
     s = "{} {} [ERROR] {}: {}".format(
@@ -52,9 +55,12 @@ def cli_error(msg: str, raise_exception: bool = True, exception=CliError) -> Non
             mt.compare_with_expected_output(msg)
         # Raise the exception
         raise exception(msg)
+    return None
 
 
-def cli_warning(msg: str, raise_exception: bool = True, exception=CliWarning) -> None:
+def cli_warning(
+    msg: str, raise_exception: bool = True, exception: Type[Exception] = CliWarning
+) -> Optional[NoReturn]:
     """Write a WARNING log entry."""
     pre = _prefix_from_stack()
     s = "{} {} [WARNING] {}: {}".format(
@@ -75,6 +81,7 @@ def cli_warning(msg: str, raise_exception: bool = True, exception=CliWarning) ->
             # If playing back traffic, verify the console output is as expected
             mt.compare_with_expected_output(msg)
         raise exception(msg)
+    return None
 
 
 def cli_info(msg: str, print_msg: bool = False) -> None:

--- a/mreg_cli/log.pyi
+++ b/mreg_cli/log.pyi
@@ -1,0 +1,57 @@
+from typing import Literal, NoReturn, Optional, Type, overload
+
+
+@overload
+def cli_error(msg: str) -> NoReturn:
+    ...
+
+
+@overload
+def cli_error(
+    msg: str, raise_exception: Literal[True] = True, exception: Type[Exception] = ...
+) -> NoReturn:
+    ...
+
+
+@overload
+def cli_error(
+    msg: str, raise_exception: Literal[False] = False, exception: Type[Exception] = ...
+) -> None:
+    ...
+
+
+@overload
+def cli_error(
+    msg: str, raise_exception: bool = ..., exception: Type[Exception] = ...
+) -> Optional[NoReturn]:
+    ...
+
+@overload
+def cli_warning(msg: str) -> NoReturn:
+    ...
+
+
+@overload
+def cli_warning(
+    msg: str, raise_exception: Literal[True] = True, exception: Type[Exception] = ...
+) -> NoReturn:
+    ...
+
+
+@overload
+def cli_warning(
+    msg: str, raise_exception: Literal[False] = False, exception: Type[Exception] = ...
+) -> None:
+    ...
+
+
+@overload
+def cli_warning(
+    msg: str, raise_exception: bool = ..., exception: Type[Exception] = ...
+) -> Optional[NoReturn]:
+    ...
+
+
+
+def cli_info(msg: str, print_msg: bool = ...) -> None:
+    ...

--- a/mreg_cli/log.pyi
+++ b/mreg_cli/log.pyi
@@ -1,4 +1,6 @@
-from typing import Literal, NoReturn, Optional, Type, overload
+from typing import NoReturn, Optional, Type, overload
+from typing_extensions import Literal
+
 
 
 @overload

--- a/mreg_cli/util.py
+++ b/mreg_cli/util.py
@@ -28,13 +28,15 @@ logger = logging.getLogger(__name__)
 
 HTTP_TIMEOUT = 20
 
+config = {}  # initialized by set_config
+
 
 def error(msg, code=os.EX_UNAVAILABLE):
     print(f"ERROR: {msg}", file=sys.stderr)
     sys.exit(code)
 
 
-def set_config(cfg):
+def set_config(cfg: dict) -> None:
     global config
     config = cfg
 

--- a/mreg_cli/util.py
+++ b/mreg_cli/util.py
@@ -16,8 +16,8 @@ from .history import history
 from .log import cli_error, cli_warning
 from . import mocktraffic
 
-location_tags = []
-category_tags = []
+location_tags = []  # type: List[str]
+category_tags = []  # type: List[str]
 
 session = requests.Session()
 session.headers.update({'User-Agent': 'mreg-cli'})

--- a/mreg_cli/util.py
+++ b/mreg_cli/util.py
@@ -4,7 +4,7 @@ import logging
 import os
 import re
 import sys
-import typing
+from typing import Any, Optional, List, Tuple, Union
 import urllib.parse
 
 import requests
@@ -75,7 +75,7 @@ def host_info_by_name_or_ip(name_or_ip: str) -> dict:
     return host_info_by_name(name)
 
 
-def _host_info_by_name(name: str, follow_cname: bool = True) -> dict:
+def _host_info_by_name(name: str, follow_cname: bool = True) -> Optional[dict]:
     hostinfo = get(f"/api/v1/hosts/{urllib.parse.quote(name)}", ok404=True)
 
     if hostinfo:
@@ -113,7 +113,7 @@ def host_info_by_name(name: str, follow_cname: bool = True) -> dict:
     return hostinfo
 
 
-def _cname_info_by_name(name: str) -> dict:
+def _cname_info_by_name(name: str) -> Optional[dict]:
     path = "/api/v1/cnames/"
     params = {
         "name": name,
@@ -124,7 +124,7 @@ def _cname_info_by_name(name: str) -> dict:
     return None
 
 
-def _srv_info_by_name(name: str) -> dict:
+def _srv_info_by_name(name: str) -> Optional[dict]:
     path = "/api/v1/srvs/"
     params = {
         "name": name,

--- a/mreg_cli/util.py
+++ b/mreg_cli/util.py
@@ -418,16 +418,20 @@ def resolve_input_name(name: str) -> str:
 #                                                                              #
 ################################################################################
 
-def clean_hostname(name: typing.AnyStr) -> str:
+
+def clean_hostname(name: Union[str, bytes]) -> str:
     """ Converts from short to long hostname, if no domain found. """
     # bytes?
     if not isinstance(name, (str, bytes)):
         cli_warning("Invalid input for hostname: {}".format(name))
 
+    if isinstance(name, bytes):
+        name = name.decode()
+
     name = name.lower()
 
     # invalid characters?
-    if re.search("^(\*\.)?([a-z0-9_][a-z0-9\-]*\.?)+$", name) is None:
+    if re.search(r"^(\*\.)?([a-z0-9_][a-z0-9\-]*\.?)+$", name) is None:
         cli_warning("Invalid input for hostname: {}".format(name))
 
     # Assume user is happy with domain, but strip the dot.
@@ -589,7 +593,7 @@ def is_valid_ttl(ttl: typing.Union[int, str, bytes]) -> bool:  # int?
     return 300 <= ttl <= 68400
 
 
-def is_valid_email(email: typing.AnyStr) -> bool:
+def is_valid_email(email: Union[str, bytes]) -> bool:
     """Check if email looks like a valid email"""
     if not isinstance(email, str):
         try:

--- a/mreg_cli/util.py
+++ b/mreg_cli/util.py
@@ -137,7 +137,7 @@ def _srv_info_by_name(name: str) -> Optional[dict]:
     return None
 
 
-def get_info_by_name(name: str) -> typing.Tuple[str, dict]:
+def get_info_by_name(name: str) -> Tuple[str, dict]:
     """
     Get host, cname or srv by name.
     """
@@ -320,7 +320,9 @@ def get(path: str, params: dict = {}, ok404=False) -> requests.Response:
     return _request_wrapper("get", path, params=params, ok404=ok404)
 
 
-def get_list(path: str, params: dict = {}, ok404=False) -> requests.Response:
+def get_list(
+    path: Optional[str], params: dict = {}, ok404=False
+) -> List[requests.Response]:
     """Uses requests to make a get request.
        Will iterate over paginated results and return result as list."""
     ret = []
@@ -527,7 +529,7 @@ def get_network_reserved_ips(ip_range: str):
     return get(path).json()
 
 
-def string_to_int(value, error_tag):
+def string_to_int(value: Any, error_tag: str) -> int:
     try:
         return int(value)
     except ValueError:
@@ -581,7 +583,7 @@ def is_valid_mac(mac: str) -> bool:
     return bool(re.match(r"^([a-fA-F0-9]{2}[\.:-]?){5}[a-fA-F0-9]{2}$", mac))
 
 
-def is_valid_ttl(ttl: typing.Union[int, str, bytes]) -> bool:  # int?
+def is_valid_ttl(ttl: Union[int, str, bytes]) -> bool:  # int?
     """Check application specific ttl restrictions."""
     if ttl in ("", "default"):
         return True

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ install_requirements = [
     'python-dateutil',
     'prompt_toolkit>=2',
     'requests',
-    'typing_extensions'
+    'typing_extensions;python_version<"3.8"'
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ install_requirements = [
     'python-dateutil',
     'prompt_toolkit>=2',
     'requests',
+    'typing_extensions'
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ install_requirements = [
     'python-dateutil',
     'prompt_toolkit>=2',
     'requests',
-    'typing_extensions;python_version<"3.8"'
+    'typing_extensions'
 ]
 
 


### PR DESCRIPTION
This pull requests improves or expands upon the type annotations found in `host.py`, `log.py` and  `util.py`. 

This pull request does not change any actual functionality within `mreg_cli` and is purely aimed at improving the developer experience.

Each change is documented in its own section below.


## Change `AnyStr` Annotations to `Union[str, bytes]`

`AnyStr` annotations are changed to `Union[str, bytes]` to signify that the argument can be converted from `bytes` to `str` (and vice versa) inside the function body.


### Rationale 

The way that `AnyStr` is currently used in the code is not legal and causes type checkers to complain. `AnyStr` is an alias for a generic type that can be `str` _or_ `bytes`, but is _not_ equivalent to `Union[str, bytes]`. 

`AnyStr` works roughly like this:

```py
AnyStr = TypeVar("AnyStr", str, bytes)

# Allows for:

def foo(s: AnyStr) -> AnyStr:
    if isinstance(s, str):
        s = s + "!"
        return s
    else:
        s = s + b"!"
        return s


# But does NOT allow:
def bar(s: AnyStr) -> AnyStr:
    if isinstance(str, bytes):
        s = s.decode() # s was bytes, is now str
    return s + "!" 


def baz(s: AnyStr) -> AnyStr:
    if isinstance(s, str):
        s = s.encode() # s was str, is now bytes
    return s + b"!"
```

During the variable's lifetime inside the function body, it should not change type.

Since all functions in `mreg_cli` with the `AnyStr` type annotation are manipulating the argument and changing its type, the type annotation `Union[str, bytes]` is more appropriate to allow for the variable's type to change within the given constraints (`str` or `bytes`).

### Commits

These changes are implemented in the following commits:

* 88bfa260a53ba079efb8dc11a613260c2551deeb

## Add Stubs with Overloads for Union Types

Functions that return `Union[T, S, ...]` should have `typing.overload` overloads either in the source file itself or in a separate stub file to specify the conditions that return `T` and `S`.

Example:

```py
from typing import overload, Literal, Union


@overload
def foo(s: str, as_list: Literal[True]) -> list:
    ...


@overload
def foo(s: str, as_list: Literal[False]) -> str:
    ...


def foo(s: str, as_list: bool) -> Union[str, list]:
    if as_list:
        return [c for c in s]
    return s + "!"
```

By specifying these overloads, type checkers are able to discern whether or not the function will return a `list` or `str` based on the arguments passed to the function.

### Implementation

The files `__init__.pyi`, `log.pyi`, as well as `py.typed` (see: [PEP 561](https://peps.python.org/pep-0561/)) have been added to provide additional type information for the `cli_<level>` functions in `log.py`. These functions are a bit problematic with regards to typing because they can either return `None` or raise an Exception. 

In order to communicate to the type checker that these functions sometimes don't return, their return type annotations have been set to `Optional[NoReturn]`. `NoReturn` signfies that the function never returns. However, that is only the case for these functions when `raise_exception` is `True`, and as such there is a need to declare overloaded definitions for these functions.

https://github.com/unioslo/mreg-cli/blob/8015897f74ab3f19c7a5b093b12edea0e696a5a8/mreg_cli/log.py#L61-L63
https://github.com/unioslo/mreg-cli/blob/8d980045473096598a8e93af344ae553d6376986/mreg_cli/log.pyi#L34-L45

#### Type Stubs

The overloaded function definitions are placed in a separate `log.pyi` stub file in order to not clutter the original `log.py` with these. Whether or not to create separate `.pyi` files is up to preference, and both conventions seem to be used. 

Examples:
* [more-itertools](https://github.com/more-itertools/more-itertools/tree/master/more_itertools) (Uses `.pyi` stubs)
* [pytest](https://github.com/pytest-dev/pytest/blob/58cf20edf08d84c5baf08f0566cc9bccbc4ec7fd/src/_pytest/fixtures.py#L1213-L1240) (Defined in source file)
<!-- TODO: find more examples -->


### Commits

Stubs and `NoReturn` annotations are added in the following commits:

* 8015897f74ab3f19c7a5b093b12edea0e696a5a8
* 8d980045473096598a8e93af344ae553d6376986
* 03021bc33d94fc42f65d1d8ea17e25a0ad41b342

## Add `Optional[]` Annotations to Functions That Can Return `None`

Functions that can return `None` are annotated with `Optional[T]`. This change is only implemented for functions that already have a type annotation; no new annotations are added.

### Commits

This is added in the following commits:

* e36475280a23f9c8a8c070692232ca2e2b6e31d0

## Add `typing_extensions` Dependency

Certain `typing` classes, such as `Literal` are not available in Python \<3.8. To access these in Python 3.7 and below, the [`typing_extension`](https://pypi.org/project/typing-extensions/) package has been added as a dependency. This is a relatively small dependency (25.6 kB), and as such should not affect the build time or distribution size of `mreg_cli` notably.

### Commits

Added in:

* c3c428f33544232faa760044da928ab63e5734a4
