### PR TITLE
Add `util.py` Type Annotations

### DIFF
--- a/mreg_cli/mocktraffic.py
+++ b/mreg_cli/mocktraffic.py
@@ -109,7 +109,8 @@ class MockTraffic(object):
                 self.status_code = status_code
                 self.ok = ok
                 self.reason = reason
-            def json(self):
+
+            def json(self, *args, **kwargs):
                 return self.json_data
         return MockResponse(obj.get('json_data',None), obj.get('status',0), obj.get('ok',False), obj.get('reason',''))
 

--- a/mreg_cli/types.py
+++ b/mreg_cli/types.py
@@ -1,0 +1,21 @@
+from typing import Any
+from typing_extensions import Protocol
+
+
+class ResponseLike(Protocol):
+    """Interface for objects that resemble a requests.Response object."""
+
+    @property
+    def ok(self) -> bool:
+        ...
+
+    @property
+    def status_code(self) -> int:
+        ...
+
+    @property
+    def reason(self) -> str:
+        ...
+
+    def json(self, **kwargs: Any) -> Any:
+        ...


### PR DESCRIPTION
This pull request adds type annotations to all untyped variables and parameters in `util.py`.

Furthermore, it declares a new protocol type `ResponseLike`, which is used in places where both `requests.Response` and `MockTraffic` objects are expected. The Protocol type serves to explain some of the metaprogramming magic that happens in `util._request_wrapper()` and the various functions derived from it. 

https://github.com/unioslo/mreg-cli/blob/8146bc806e0d82510b60a1f2545c711126dc12bf/mreg_cli/types.py#L5-L21

The interface is based on `requests.Response`, and as such `MockTraffic.json()` now accepts `**kwargs` to conform with the interface.

The interface has been assigned to the return types of all HTTP functions (`get`, `post`, etc.), and overloads have been added for `get` to account for the argument `ok404=True` causing the function to return `None`.

```py
# get_types.py
from typing_extensions import reveal_type
from mreg_cli.util import get, get_list

reveal_type(get("/foo"))
reveal_type(get("/foo", ok404=True))
reveal_type(get_list("/foo"))
```

```
$ mypy get_types.py
note: Revealed type is "mreg_cli.types.ResponseLike"
note: Revealed type is "Union[mreg_cli.types.ResponseLike, None]"
note: Revealed type is "builtins.list[builtins.dict[Any, Any]]
```


## Handling `None` in `util.get_list()`

A potential case where `.json()` could be attempted to be called on a `None` value returned by `util.get(..., ok404=True)` in `util.get_list()` was uncovered when adding type annotations. The problem is resolved by first checking if the value is `None` before attempting to call `.json()` on it. 

Before:
https://github.com/unioslo/mreg-cli/blob/36ac74cb6728f67baca91038643e51228a40fb08/mreg_cli/util.py#L329-L330

After:
https://github.com/unioslo/mreg-cli/blob/50301c47f2110cb30a0414e26ecac7542f7cddf9/mreg_cli/util.py#L382-L386