### PR TITLE
Use bytes.decode() instead of str() for byte string emails

### DIFF
--- a/mreg_cli/util.py
+++ b/mreg_cli/util.py
@@ -599,7 +599,7 @@ def is_valid_email(email: Union[str, bytes]) -> bool:
     """Check if email looks like a valid email"""
     if not isinstance(email, str):
         try:
-            email = str(email)
+            email = email.decode()
         except ValueError:
             return False
     return True if re.match(r"^[^\s@]+@[^\s@]+\.[^\s@]+$", email) else False


### PR DESCRIPTION
Passing a byte string to `str()` will return the `__repr__`/`__str__` of the bytes object, not its UTF-8 string representation.

```pyconsole
>>> str(b"user@example.com")
"b'user@example.com'"
```

In order to parse the email correctly, it should be decoded via `.decode()`:

```pyconsole
>>> b"user@example.com".decode()
'user@example.com'
```

The default encoding is UTF-8, and that seems like a reasonable assumption to make when attempting to decode an arbitrary byte string.