### PR TITLE
Don't import typing_extensions on runtime 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-20.04]
         python-version:
           - '3.6'
           - '3.7'

--- a/mreg_cli/log.pyi
+++ b/mreg_cli/log.pyi
@@ -1,6 +1,6 @@
-from typing import NoReturn, Optional, Type, overload
-from typing_extensions import Literal
-
+from typing import NoReturn, Optional, Type, overload, TYPE_CHECKING
+if TYPE_CHECKING:
+    from typing_extensions import Literal
 
 
 @overload
@@ -10,14 +10,14 @@ def cli_error(msg: str) -> NoReturn:
 
 @overload
 def cli_error(
-    msg: str, raise_exception: Literal[True] = True, exception: Type[Exception] = ...
+    msg: str, raise_exception: "Literal[True]" = True, exception: Type[Exception] = ...
 ) -> NoReturn:
     ...
 
 
 @overload
 def cli_error(
-    msg: str, raise_exception: Literal[False] = False, exception: Type[Exception] = ...
+    msg: str, raise_exception: "Literal[False]" = False, exception: Type[Exception] = ...
 ) -> None:
     ...
 
@@ -35,14 +35,14 @@ def cli_warning(msg: str) -> NoReturn:
 
 @overload
 def cli_warning(
-    msg: str, raise_exception: Literal[True] = True, exception: Type[Exception] = ...
+    msg: str, raise_exception: "Literal[True]" = True, exception: Type[Exception] = ...
 ) -> NoReturn:
     ...
 
 
 @overload
 def cli_warning(
-    msg: str, raise_exception: Literal[False] = False, exception: Type[Exception] = ...
+    msg: str, raise_exception: "Literal[False]" = False, exception: Type[Exception] = ...
 ) -> None:
     ...
 

--- a/mreg_cli/types.py
+++ b/mreg_cli/types.py
@@ -1,21 +1,23 @@
-from typing import Any
-from typing_extensions import Protocol
+from typing import TYPE_CHECKING
 
+if TYPE_CHECKING:
+    from typing import Any
+    from typing_extensions import Protocol
 
-class ResponseLike(Protocol):
-    """Interface for objects that resemble a requests.Response object."""
+    class ResponseLike(Protocol):
+        """Interface for objects that resemble a requests.Response object."""
 
-    @property
-    def ok(self) -> bool:
-        ...
+        @property
+        def ok(self) -> bool:
+            ...
 
-    @property
-    def status_code(self) -> int:
-        ...
+        @property
+        def status_code(self) -> int:
+            ...
 
-    @property
-    def reason(self) -> str:
-        ...
+        @property
+        def reason(self) -> str:
+            ...
 
-    def json(self, **kwargs: Any) -> Any:
-        ...
+        def json(self, **kwargs: Any) -> Any:
+            ...

--- a/mreg_cli/util.py
+++ b/mreg_cli/util.py
@@ -16,8 +16,13 @@ from typing import (
     Union,
     overload,
     cast,
+    TYPE_CHECKING,
 )
-from typing_extensions import Literal
+
+if TYPE_CHECKING:
+    from .types import ResponseLike
+    from typing_extensions import Literal
+
 import urllib.parse
 
 import requests
@@ -27,7 +32,7 @@ from prompt_toolkit import prompt
 from .exceptions import CliError, HostNotFoundWarning
 from .history import history
 from .log import cli_error, cli_warning
-from .types import ResponseLike
+
 from . import mocktraffic
 
 location_tags = []  # type: List[str]
@@ -294,7 +299,7 @@ def _update_token(username: str, password: str) -> None:
     set_file_permissions(mreg_auth_token_file, 0o600)
 
 
-def result_check(result: ResponseLike, type: str, url: str) -> None:
+def result_check(result: "ResponseLike", type: str, url: str) -> None:
     if not result.ok:
         message = f"{type} \"{url}\": {result.status_code}: {result.reason}"
         try:
@@ -314,7 +319,7 @@ def _request_wrapper(
     first: bool = True,
     use_json: bool = False,
     **data,
-) -> Optional[ResponseLike]:
+) -> Optional["ResponseLike"]:
     url = requests.compat.urljoin(mregurl, path)
     mh = mocktraffic.MockTraffic()
 
@@ -346,31 +351,31 @@ def _request_wrapper(
 
 @overload
 def get(
-    path: str, params: Dict[str, str], ok404: Literal[True]
-) -> Optional[ResponseLike]:
+    path: str, params: Dict[str, str], ok404: "Literal[True]"
+) -> Optional["ResponseLike"]:
     ...
 
 
 @overload
-def get(path: str, params: Dict[str, str], ok404: Literal[False]) -> ResponseLike:
+def get(path: str, params: Dict[str, str], ok404: "Literal[False]") -> "ResponseLike":
     ...
 
 
 @overload
 def get(
     path: str, params: Dict[str, str] = ..., *, ok404: bool
-) -> Optional[ResponseLike]:
+) -> Optional["ResponseLike"]:
     ...
 
 
 @overload
-def get(path: str, params: Dict[str, str] = ...) -> ResponseLike:
+def get(path: str, params: Dict[str, str] = ...) -> "ResponseLike":
     ...
 
 
 def get(
     path: str, params: Dict[str, str] = {}, ok404: bool = False
-) -> Optional[ResponseLike]:
+) -> Optional["ResponseLike"]:
     """Uses requests to make a get request."""
     return _request_wrapper("get", path, params=params, ok404=ok404)
 
@@ -393,19 +398,19 @@ def get_list(path: Optional[str], params: dict = {}, ok404: bool = False) -> Lis
     return ret
 
 
-def post(path: str, params: dict = {}, **kwargs: Any) -> Optional[ResponseLike]:
+def post(path: str, params: dict = {}, **kwargs: Any) -> Optional["ResponseLike"]:
     """Uses requests to make a post request. Assumes that all kwargs are data fields"""
     return _request_wrapper("post", path, params=params, **kwargs)
 
 
 def patch(
     path: str, params: dict = {}, use_json: bool = False, **kwargs: Any
-) -> Optional[ResponseLike]:
+) -> Optional["ResponseLike"]:
     """Uses requests to make a patch request. Assumes that all kwargs are data fields"""
     return _request_wrapper("patch", path, params=params, use_json=use_json, **kwargs)
 
 
-def delete(path: str, params: dict = {}) -> Optional[ResponseLike]:
+def delete(path: str, params: dict = {}) -> Optional["ResponseLike"]:
     """Uses requests to make a delete request."""
     return _request_wrapper("delete", path, params=params)
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ install_requirements = [
     'python-dateutil',
     'prompt_toolkit>=2',
     'requests',
-    'typing_extensions'
+    'typing_extensions; python_version > "3.6"',
 ]
 
 


### PR DESCRIPTION
This pull request removes all imports of `typing_extension` on runtime, and only imports it when [`typing.TYPE_CHECKING`](https://docs.python.org/3/library/typing.html#typing.TYPE_CHECKING) evaluates to True (when running mypy, etc.). This fixes an issue where mreg-cli could not be launched in environments where `typing_extensions` is not available (RHEL7). However, it is still listed as a dependency in setup.py for Python >=3.7.

To not break the existing annotations that make use of `typing_extensions` classes, these annotations are now specified as strings, which is a format mypy and pylance understands. i.e:

```py
# before
def foo(l: List[str]) -> List[str]:
    ...

# after
def foo(l: "List[str]") -> "List[str]":
    ...
```

When Python 3.6 support is dropped, we can instead use `from __future__ import annotations` to prevent type annotations from being evaluated on runtime: https://peps.python.org/pep-0563/

Also, to keep supporting Python 3.6 in the GitHub actions workflow, the workflow OS image has been set to `ubuntu-20.04` instead of `ubuntu-latest`, because the action `actions/setup-python@v2` has dropped support for Python 3.6 in Ubuntu 22.04.