### PR TITLE
Fix workflow annotations and more

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,8 @@ jobs:
           - '3.7'
           - '3.8'
           - '3.9'
+          - '3.10'
+          - '3.11'
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -39,12 +41,9 @@ jobs:
   integration:
     name: Integration
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        postgresql-version: [11, 12, 13]
     services:
       postgres:
-        image: postgres:${{ matrix.postgresql-version }}
+        image: postgres:latest
         env:
           POSTGRES_USER: mreg
           POSTGRES_DB: mreg
@@ -61,8 +60,8 @@ jobs:
         options: >-
           --name mreg
         env:
-          GUNICORN_CMD_ARGS: --bind=0.0.0.0
           MREG_DB_HOST: postgres
+          MREG_DB_USER: mreg
           MREG_DB_PASSWORD: postgres
         ports:
           - 8000:8000

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,9 +15,9 @@ jobs:
           - '3.9'
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Cache pip
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: v1-pip-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('requirements-*.txt') }}
@@ -26,7 +26,7 @@ jobs:
             v1-pip-${{ runner.os }}
             v1-pip-
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install
@@ -68,9 +68,9 @@ jobs:
           - 8000:8000
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Cache pip
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: v1-pip-${{ runner.os }}-${{ hashFiles('requirements-*.txt') }}

--- a/mreg_cli/host.py
+++ b/mreg_cli/host.py
@@ -186,6 +186,9 @@ def add(args):
     if cname_exists(name):
         cli_warning("the name is already in use by a cname")
 
+    if args.macaddress is not None and not is_valid_mac(args.macaddress):
+        cli_warning("invalid MAC address: {}".format(args.macaddress))
+
     if args.ip:
         ip = _get_ip_from_args(args.ip, args.force)
 

--- a/mreg_cli/policy.py
+++ b/mreg_cli/policy.py
@@ -522,7 +522,7 @@ def host_add(args):
         path = f'/api/v1/hostpolicy/roles/{args.role}/hosts/'
         history.record_post(path, "", data, undoable=False)
         post(path, **data)
-        cli_info(f"Added {name} to {args.role}", print_msg=True)
+        cli_info(f"Added host {name} to role {args.role}", print_msg=True)
 
 
 policy.add_command(
@@ -597,7 +597,7 @@ def host_remove(args):
         path = f'/api/v1/hostpolicy/roles/{args.role}/hosts/{name}'
         history.record_delete(path, dict())
         delete(path)
-        cli_info(f"Removed '{name}' from {args.role}", print_msg=True)
+        cli_info(f"Removed host {name} from role {args.role}", print_msg=True)
 
 
 policy.add_command(

--- a/mreg_cli/policy.py
+++ b/mreg_cli/policy.py
@@ -522,7 +522,7 @@ def host_add(args):
         path = f'/api/v1/hostpolicy/roles/{args.role}/hosts/'
         history.record_post(path, "", data, undoable=False)
         post(path, **data)
-        cli_info(f"Added host {name} to role {args.role}", print_msg=True)
+        cli_info(f"Added host '{name}' to role '{args.role}'", print_msg=True)
 
 
 policy.add_command(
@@ -597,7 +597,7 @@ def host_remove(args):
         path = f'/api/v1/hostpolicy/roles/{args.role}/hosts/{name}'
         history.record_delete(path, dict())
         delete(path)
-        cli_info(f"Removed host {name} from role {args.role}", print_msg=True)
+        cli_info(f"Removed host '{name}' from role '{args.role}'", print_msg=True)
 
 
 policy.add_command(

--- a/testsuite-result.json
+++ b/testsuite-result.json
@@ -459,7 +459,7 @@
 {"method": "GET", "url": "/api/v1/hostpolicy/roles/?name=fruit", "data": {}, "ok": true, "status": 200, "reason": "OK", "json_data": {"count": 1, "next": null, "previous": null, "results": [{"id": 18, "hosts": [], "atoms": [{"name": "tangerine"}], "updated_at": "2020-12-03T17:04:39.350461+01:00", "create_date": "2020-12-03", "description": "5 a day", "name": "fruit", "labels": []}]}}
 {"method": "GET", "url": "/api/v1/hosts/foo.example.org", "data": {}, "ok": true, "status": 200, "reason": "OK", "json_data": {"id": 171, "ipaddresses": [], "cnames": [], "mxs": [], "txts": [{"id": 181, "created_at": "2020-12-03T17:04:39.680469+01:00", "updated_at": "2020-12-03T17:04:39.680508+01:00", "txt": "v=spf1 -all", "host": 171}], "ptr_overrides": [], "hinfo": null, "loc": null, "created_at": "2020-12-03T17:04:39.669575+01:00", "updated_at": "2020-12-03T17:04:39.669607+01:00", "name": "foo.example.org", "contact": "", "ttl": null, "comment": "", "zone": 10}}
 {"method": "POST", "url": "/api/v1/hostpolicy/roles/fruit/hosts/", "data": {"name": "foo.example.org"}, "ok": true, "status": 201, "reason": "Created"}
-{"output": "OK: : Added foo.example.org to fruit"}
+{"output": "OK: : Added host foo.example.org to role fruit"}
 {"command": "policy list_hosts fruit\n"}
 {"method": "GET", "url": "/api/v1/hostpolicy/roles/?name=fruit", "data": {}, "ok": true, "status": 200, "reason": "OK", "json_data": {"count": 1, "next": null, "previous": null, "results": [{"id": 18, "hosts": [{"name": "foo.example.org"}], "atoms": [{"name": "tangerine"}], "updated_at": "2020-12-03T17:04:40.022449+01:00", "create_date": "2020-12-03", "description": "5 a day", "name": "fruit", "labels": []}]}}
 {"command": "policy host_list foo\n"}
@@ -469,7 +469,7 @@
 {"method": "GET", "url": "/api/v1/hostpolicy/roles/?name=fruit", "data": {}, "ok": true, "status": 200, "reason": "OK", "json_data": {"count": 1, "next": null, "previous": null, "results": [{"id": 18, "hosts": [{"name": "foo.example.org"}], "atoms": [{"name": "tangerine"}], "updated_at": "2020-12-03T17:04:40.022449+01:00", "create_date": "2020-12-03", "description": "5 a day", "name": "fruit", "labels": []}]}}
 {"method": "GET", "url": "/api/v1/hosts/foo.example.org", "data": {}, "ok": true, "status": 200, "reason": "OK", "json_data": {"id": 171, "ipaddresses": [], "cnames": [], "mxs": [], "txts": [{"id": 181, "created_at": "2020-12-03T17:04:39.680469+01:00", "updated_at": "2020-12-03T17:04:39.680508+01:00", "txt": "v=spf1 -all", "host": 171}], "ptr_overrides": [], "hinfo": null, "loc": null, "created_at": "2020-12-03T17:04:39.669575+01:00", "updated_at": "2020-12-03T17:04:39.669607+01:00", "name": "foo.example.org", "contact": "", "ttl": null, "comment": "", "zone": 10}}
 {"method": "DELETE", "url": "/api/v1/hostpolicy/roles/fruit/hosts/foo.example.org", "data": {}, "ok": true, "status": 204, "reason": "No Content"}
-{"output": "OK: : Removed 'foo.example.org' from fruit"}
+{"output": "OK: : Removed host foo.example.org from role fruit"}
 {"command": "policy remove_atom fruit banana"}
 {"method": "GET", "url": "/api/v1/hostpolicy/roles/?name=fruit", "data": {}, "ok": true, "status": 200, "reason": "OK", "json_data": {"count": 1, "next": null, "previous": null, "results": [{"id": 18, "hosts": [], "atoms": [{"name": "tangerine"}], "updated_at": "2020-12-03T17:04:40.542141+01:00", "create_date": "2020-12-03", "description": "5 a day", "name": "fruit", "labels": []}]}}
 {"output": "WARNING: : Atom 'banana' not a member of 'fruit'"}

--- a/testsuite-result.json
+++ b/testsuite-result.json
@@ -459,7 +459,7 @@
 {"method": "GET", "url": "/api/v1/hostpolicy/roles/?name=fruit", "data": {}, "ok": true, "status": 200, "reason": "OK", "json_data": {"count": 1, "next": null, "previous": null, "results": [{"id": 18, "hosts": [], "atoms": [{"name": "tangerine"}], "updated_at": "2020-12-03T17:04:39.350461+01:00", "create_date": "2020-12-03", "description": "5 a day", "name": "fruit", "labels": []}]}}
 {"method": "GET", "url": "/api/v1/hosts/foo.example.org", "data": {}, "ok": true, "status": 200, "reason": "OK", "json_data": {"id": 171, "ipaddresses": [], "cnames": [], "mxs": [], "txts": [{"id": 181, "created_at": "2020-12-03T17:04:39.680469+01:00", "updated_at": "2020-12-03T17:04:39.680508+01:00", "txt": "v=spf1 -all", "host": 171}], "ptr_overrides": [], "hinfo": null, "loc": null, "created_at": "2020-12-03T17:04:39.669575+01:00", "updated_at": "2020-12-03T17:04:39.669607+01:00", "name": "foo.example.org", "contact": "", "ttl": null, "comment": "", "zone": 10}}
 {"method": "POST", "url": "/api/v1/hostpolicy/roles/fruit/hosts/", "data": {"name": "foo.example.org"}, "ok": true, "status": 201, "reason": "Created"}
-{"output": "OK: : Added host foo.example.org to role fruit"}
+{"output": "OK: : Added host 'foo.example.org' to role 'fruit'"}
 {"command": "policy list_hosts fruit\n"}
 {"method": "GET", "url": "/api/v1/hostpolicy/roles/?name=fruit", "data": {}, "ok": true, "status": 200, "reason": "OK", "json_data": {"count": 1, "next": null, "previous": null, "results": [{"id": 18, "hosts": [{"name": "foo.example.org"}], "atoms": [{"name": "tangerine"}], "updated_at": "2020-12-03T17:04:40.022449+01:00", "create_date": "2020-12-03", "description": "5 a day", "name": "fruit", "labels": []}]}}
 {"command": "policy host_list foo\n"}
@@ -469,7 +469,7 @@
 {"method": "GET", "url": "/api/v1/hostpolicy/roles/?name=fruit", "data": {}, "ok": true, "status": 200, "reason": "OK", "json_data": {"count": 1, "next": null, "previous": null, "results": [{"id": 18, "hosts": [{"name": "foo.example.org"}], "atoms": [{"name": "tangerine"}], "updated_at": "2020-12-03T17:04:40.022449+01:00", "create_date": "2020-12-03", "description": "5 a day", "name": "fruit", "labels": []}]}}
 {"method": "GET", "url": "/api/v1/hosts/foo.example.org", "data": {}, "ok": true, "status": 200, "reason": "OK", "json_data": {"id": 171, "ipaddresses": [], "cnames": [], "mxs": [], "txts": [{"id": 181, "created_at": "2020-12-03T17:04:39.680469+01:00", "updated_at": "2020-12-03T17:04:39.680508+01:00", "txt": "v=spf1 -all", "host": 171}], "ptr_overrides": [], "hinfo": null, "loc": null, "created_at": "2020-12-03T17:04:39.669575+01:00", "updated_at": "2020-12-03T17:04:39.669607+01:00", "name": "foo.example.org", "contact": "", "ttl": null, "comment": "", "zone": 10}}
 {"method": "DELETE", "url": "/api/v1/hostpolicy/roles/fruit/hosts/foo.example.org", "data": {}, "ok": true, "status": 204, "reason": "No Content"}
-{"output": "OK: : Removed host foo.example.org from role fruit"}
+{"output": "OK: : Removed host 'foo.example.org' from role 'fruit'"}
 {"command": "policy remove_atom fruit banana"}
 {"method": "GET", "url": "/api/v1/hostpolicy/roles/?name=fruit", "data": {}, "ok": true, "status": 200, "reason": "OK", "json_data": {"count": 1, "next": null, "previous": null, "results": [{"id": 18, "hosts": [], "atoms": [{"name": "tangerine"}], "updated_at": "2020-12-03T17:04:40.542141+01:00", "create_date": "2020-12-03", "description": "5 a day", "name": "fruit", "labels": []}]}}
 {"output": "WARNING: : Atom 'banana' not a member of 'fruit'"}


### PR DESCRIPTION
This PR makes some changes to the test workflow:
- Use latest versions of actions
- Add Python 3.10 and 3.11 to the strategy matrix
- Remove unnecessary Postgres version matrix. Testing with different Postgres versions should be done in the server repo instead.
- Add environment vars for the mreg container service

Also, changes to the code:
- A new test for the "host add" command that the mac address is syntactically valid
- Clearer output from policy host_add/host_remove