### PR TITLE
Clarify help about wildcards, and in some cases automatically use them

### DIFF
--- a/ci/testsuite
+++ b/ci/testsuite
@@ -42,7 +42,6 @@ network remove 2001:db8::/64 -f
 #    - excluded ip ranges
 #    - network info
 #    - setting network category, location, vlan
-#TODO: network find
 network create -network 10.0.1.0/24 -desc "Frozzzen"        # frozen network
 network set_frozen 10.0.1.0/24
 host add somehost -ip 10.0.1.0/24 -contact support@example.org  # should require force, because net's frozen
@@ -56,6 +55,7 @@ network set_description 10.0.1.0/24 "Frozen but has one host"
 #network set_location 10.0.1.0/24 Oslo_Norway
 network set_vlan 10.0.1.0/24 1234
 network info 10.0.1.0/24
+network find -network 10.0.1.0/24 -description '*one host*' -vlan 1234 -frozen 1 -reserved 6 -dns_delegated 0 -category Yellow -location Somewhere
 host remove somehost
 network unset_frozen 10.0.1.0/24
 host add otherhost -ip 10.0.1.20 -contact support@example.org  # fails because reserved range
@@ -124,8 +124,10 @@ zone delegation_delete example.org wut.example.org
 policy atom_create apple "Here's the description"
 policy atom_create -created 2018-07-07 orange "Round and orange"
 policy list_atoms *
+policy list_atoms ppl
 policy role_create fruit "5 a day"
 policy list_roles *
+policy list_roles fru
 policy add_atom fruit apple
 policy add_atom fruit orange
 policy info orange

--- a/ci/testsuite-result.json
+++ b/ci/testsuite-result.json
@@ -5665,6 +5665,24 @@
     ]
   },
   {
+    "command": "network find -network 10.0.1.0/24 -description '*one host*' -vlan 1234 -frozen 1 -reserved 6 -dns_delegated 0 -category Yellow -location Somewhere\n"
+  },
+  {
+    "method": "GET",
+    "url": "/api/v1/networks/?network=10.0.1.0%2F24&description__regex=.%2Aone+host.%2A&vlan=1234&dns_delegated=0&category=Yellow&location=Somewhere&frozen=1&reserved=6",
+    "data": {},
+    "status": 200,
+    "response": {
+      "count": 0,
+      "next": null,
+      "previous": null,
+      "results": []
+    }
+  },
+  {
+    "output": "WARNING: : No networks matching the query were found."
+  },
+  {
     "command": "host remove somehost\n"
   },
   {
@@ -8133,6 +8151,27 @@
     }
   },
   {
+    "command": "policy list_atoms ppl\n"
+  },
+  {
+    "method": "GET",
+    "url": "/api/v1/hostpolicy/atoms/?name__regex=.%2Appl.%2A",
+    "data": {},
+    "status": 200,
+    "response": {
+      "count": 1,
+      "next": null,
+      "previous": null,
+      "results": [
+        {
+          "roles": [],
+          "description": "Here's the description",
+          "name": "apple"
+        }
+      ]
+    }
+  },
+  {
     "command": "policy role_create fruit \"5 a day\"\n"
   },
   {
@@ -8165,6 +8204,41 @@
   {
     "method": "GET",
     "url": "/api/v1/hostpolicy/roles/?name__regex=.",
+    "data": {},
+    "status": 200,
+    "response": {
+      "count": 1,
+      "next": null,
+      "previous": null,
+      "results": [
+        {
+          "hosts": [],
+          "atoms": [],
+          "description": "5 a day",
+          "name": "fruit",
+          "labels": []
+        }
+      ]
+    }
+  },
+  {
+    "method": "GET",
+    "url": "/api/v1/labels/",
+    "data": {},
+    "status": 200,
+    "response": {
+      "count": 0,
+      "next": null,
+      "previous": null,
+      "results": []
+    }
+  },
+  {
+    "command": "policy list_roles fru\n"
+  },
+  {
+    "method": "GET",
+    "url": "/api/v1/hostpolicy/roles/?name__regex=.%2Afru.%2A",
     "data": {},
     "status": 200,
     "response": {

--- a/mreg_cli/host.py
+++ b/mreg_cli/host.py
@@ -582,10 +582,7 @@ def find(args):
     """
 
     def _add_param(param, value):
-        if '*' not in value:
-            value = f'*{value}*'
-
-        param, value = convert_wildcard_to_regex(param, value)
+        param, value = convert_wildcard_to_regex(param, value, True)
         params[param] = value
 
     if not any([args.name, args.comment, args.contact]):

--- a/mreg_cli/network.py
+++ b/mreg_cli/network.py
@@ -307,7 +307,7 @@ network.add_command(
         ),
         Flag(
             "-description",
-            description="Description",
+            description="Description. Supports * as a wildcard",
             metavar="DESCRIPTION",
         ),
         Flag(

--- a/mreg_cli/policy.py
+++ b/mreg_cli/policy.py
@@ -385,7 +385,7 @@ def list_atoms(args):
         print("{1:<{0}} {2}".format(padding, key, value))
 
     params = {}
-    param, value = convert_wildcard_to_regex('name', args.name)
+    param, value = convert_wildcard_to_regex('name', args.name, True)
     params[param] = value
     info = get_list("/api/v1/hostpolicy/atoms/", params=params)
     if info:
@@ -402,7 +402,7 @@ policy.add_command(
     callback=list_atoms,
     flags=[
         Flag('name',
-             description='Atom name filter (regexp)',
+             description='Atom name, or part of name. You can use * as a wildcard.',
              metavar='FILTER'),
     ]
 )
@@ -414,7 +414,7 @@ def list_roles(args):
     """
 
     params = {}
-    param, value = convert_wildcard_to_regex('name', args.name)
+    param, value = convert_wildcard_to_regex('name', args.name, True)
     params[param] = value
     info = get_list("/api/v1/hostpolicy/roles/", params=params)
     if not info:
@@ -445,7 +445,7 @@ policy.add_command(
     callback=list_roles,
     flags=[
         Flag('name',
-             description='Role name filter (regexp)',
+             description='Role name, or part of name. You can use * as a wildcard.',
              metavar='FILTER'),
     ]
 )


### PR DESCRIPTION
- Improve the help texts that describe when you can use wildcards
- Automatically wrap the parameters in wildcards in some cases
- Add a few commands to the test suite to test the "find"-commands
- Partially takes care of #136.
- Unrelated: Avoid a crash if the token endpoint returns non-json
