### PR TITLE
Fix a crash bug when dhcp assoc a host without ips

### DIFF
--- a/ci/run_testsuite_and_record.sh
+++ b/ci/run_testsuite_and_record.sh
@@ -14,6 +14,8 @@ trap cleanup EXIT
 docker compose up -d
 
 # create a superuser
+# TODO: Replace this with python manage.py create_mreg_superuser --username test --password test,
+#       but only after we're sure that every branch we want to test has that feature merged in already.
 echo -ne '
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -26,6 +28,6 @@ group.user_set.add(user)
 ' | docker exec -i mreg python /app/manage.py shell
 
 # run the test suite
-echo "test" | mreg-cli -u test -d example.org --url http://127.0.0.1:8000 --source testsuite --record new_output.json
+echo "test" | mreg-cli -u test -d example.org --url http://127.0.0.1:8000 --source testsuite --record new_output.json >/dev/null
 diff testsuite-result.json new_output.json
 exit $?

--- a/ci/testsuite
+++ b/ci/testsuite
@@ -173,6 +173,8 @@ dhcp assoc meh 11:22:33:44:55:66  # host not found
 dhcp assoc foo aa:bb:cc:dd:ee:ff
 dhcp disassoc foo
 dhcp disassoc meh   # host not found
+host a_remove foo 10.0.0.5
+dhcp assoc foo aa:bb:cc:dd:ee:ff # doesn't work, because the host doesn't have any ip addresses
 host remove foo
 network remove 10.0.0.0/24 -f
 

--- a/ci/testsuite-result.json
+++ b/ci/testsuite-result.json
@@ -9768,7 +9768,7 @@
     "output": "WARNING: : host not found: 'meh.example.org'"
   },
   {
-    "command": "host remove foo\n"
+    "command": "host a_remove foo 10.0.0.5\n"
   },
   {
     "method": "GET",
@@ -9783,6 +9783,76 @@
           "host": 13
         }
       ],
+      "cnames": [],
+      "mxs": [],
+      "txts": [
+        {
+          "txt": "v=spf1 -all",
+          "host": 13
+        }
+      ],
+      "ptr_overrides": [],
+      "hinfo": null,
+      "loc": null,
+      "bacnetid": null,
+      "name": "foo.example.org",
+      "contact": "",
+      "ttl": null,
+      "comment": "",
+      "zone": 1
+    }
+  },
+  {
+    "method": "DELETE",
+    "url": "/api/v1/ipaddresses/6",
+    "data": {},
+    "status": 204
+  },
+  {
+    "output": "OK: : removed ip 10.0.0.5 from foo.example.org"
+  },
+  {
+    "command": "dhcp assoc foo aa:bb:cc:dd:ee:ff"
+  },
+  {
+    "method": "GET",
+    "url": "/api/v1/hosts/foo.example.org",
+    "data": {},
+    "status": 200,
+    "response": {
+      "ipaddresses": [],
+      "cnames": [],
+      "mxs": [],
+      "txts": [
+        {
+          "txt": "v=spf1 -all",
+          "host": 13
+        }
+      ],
+      "ptr_overrides": [],
+      "hinfo": null,
+      "loc": null,
+      "bacnetid": null,
+      "name": "foo.example.org",
+      "contact": "",
+      "ttl": null,
+      "comment": "",
+      "zone": 1
+    }
+  },
+  {
+    "output": "ERROR: : foo doesn't have any ip addresses."
+  },
+  {
+    "command": "host remove foo\n"
+  },
+  {
+    "method": "GET",
+    "url": "/api/v1/hosts/foo.example.org",
+    "data": {},
+    "status": 200,
+    "response": {
+      "ipaddresses": [],
       "cnames": [],
       "mxs": [],
       "txts": [

--- a/mreg_cli/dhcp.py
+++ b/mreg_cli/dhcp.py
@@ -1,6 +1,6 @@
 from .cli import Flag, cli
 from .history import history
-from .log import cli_info, cli_warning
+from .log import cli_error, cli_info, cli_warning
 from .util import format_mac, get_list, host_info_by_name, is_valid_ip, is_valid_mac, patch
 
 #################################
@@ -32,10 +32,12 @@ def _dhcp_get_ip_by_arg(arg):
         info = host_info_by_name(arg)
         if len(info["ipaddresses"]) > 1:
             cli_warning(
-                "{} got {} ip addresses, please enter an ip instead.".format(
+                "{} has {} ip addresses, please enter one of the addresses instead.".format(
                     info["name"],
                     len(info["ipaddresses"]),
                 ))
+        if len(info["ipaddresses"]) == 0:
+            cli_error("{} doesn't have any ip addresses.".format(arg))
         ip = info["ipaddresses"][0]
     return ip
 


### PR DESCRIPTION
This commit fixes a bug where the mreg-cli client would crash if the "dhcp assoc <hostname> <macaddress>" command is used and the given host does not have any ip addresses.