### PR TITLE
feat: Allow for filtering of output

### DIFF
--- a/mreg_cli/bacnet.py
+++ b/mreg_cli/bacnet.py
@@ -2,7 +2,7 @@ from .cli import Flag
 from .history import history
 from .host import host
 from .log import cli_error, cli_info
-from .util import delete, format_table, get, get_list, host_info_by_name, post
+from .util import add_formatted_table_for_output, delete, get, get_list, host_info_by_name, post
 
 
 def bacnetid_add(args) -> None:
@@ -74,7 +74,7 @@ def bacnetid_list(args) -> None:
         if maxval > 4194302:
             cli_error("The maximum ID value is 4194302.")
     r = get_list("/api/v1/bacnet/ids/", {"id__range": "{},{}".format(minval, maxval)})
-    format_table(("ID", "Hostname"), ("id", "hostname"), r)
+    add_formatted_table_for_output(("ID", "Hostname"), ("id", "hostname"), r)
 
 
 host.add_command(

--- a/mreg_cli/bacnet.py
+++ b/mreg_cli/bacnet.py
@@ -2,15 +2,13 @@ from .cli import Flag
 from .history import history
 from .host import host
 from .log import cli_error, cli_info
-from .util import delete, get, get_list, host_info_by_name, post, print_table
+from .util import delete, format_table, get, get_list, host_info_by_name, post
 
 
-def bacnetid_add(args):
+def bacnetid_add(args) -> None:
     info = host_info_by_name(args.name)
     if "bacnetid" in info and info["bacnetid"] is not None:
-        cli_error(
-            "{} already has BACnet ID {}.".format(info["name"], info["bacnetid"]["id"])
-        )
+        cli_error("{} already has BACnet ID {}.".format(info["name"], info["bacnetid"]["id"]))
     postdata = {"hostname": info["name"]}
     path = "/api/v1/bacnet/ids/"
     bacnetid = args.id
@@ -18,18 +16,14 @@ def bacnetid_add(args):
         response = get(path + bacnetid, ok404=True)
         if response:
             j = response.json()
-            cli_error(
-                "BACnet ID {} is already in use by {}".format(j["id"], j["hostname"])
-            )
+            cli_error("BACnet ID {} is already in use by {}".format(j["id"], j["hostname"]))
         postdata["id"] = bacnetid
     history.record_post(path, "", postdata)
     post(path, **postdata)
     info = host_info_by_name(args.name)
     if "bacnetid" in info and info["bacnetid"] is not None:
         b = info["bacnetid"]
-        cli_info(
-            "Assigned BACnet ID {} to {}".format(b["id"], info["name"]), print_msg=True
-        )
+        cli_info("Assigned BACnet ID {} to {}".format(b["id"], info["name"]), print_msg=True)
 
 
 host.add_command(
@@ -44,7 +38,7 @@ host.add_command(
 )
 
 
-def bacnetid_remove(args):
+def bacnetid_remove(args) -> None:
     info = host_info_by_name(args.name)
     if "bacnetid" not in info or info["bacnetid"] is None:
         cli_error("{} does not have a BACnet ID assigned.".format(info["name"]))
@@ -68,7 +62,7 @@ host.add_command(
 )
 
 
-def bacnetid_list(args):
+def bacnetid_list(args) -> None:
     minval = 0
     if args.min is not None:
         minval = args.min
@@ -80,7 +74,7 @@ def bacnetid_list(args):
         if maxval > 4194302:
             cli_error("The maximum ID value is 4194302.")
     r = get_list("/api/v1/bacnet/ids/", {"id__range": "{},{}".format(minval, maxval)})
-    print_table(("ID", "Hostname"), ("id", "hostname"), r)
+    format_table(("ID", "Hostname"), ("id", "hostname"), r)
 
 
 host.add_command(

--- a/mreg_cli/cli.py
+++ b/mreg_cli/cli.py
@@ -1,5 +1,7 @@
 import argparse
 import os
+import shlex
+from typing import Any, List, Optional
 
 from prompt_toolkit import HTML, print_formatted_text
 from prompt_toolkit.completion import Completer, Completion
@@ -90,9 +92,7 @@ class Command(Completer):
             flags = []
         if not self.sub:
             self.sub = _create_command_group(self.parser)
-        parser = self.sub.add_parser(
-            prog, description=description, epilog=epilog, help=short_desc
-        )
+        parser = self.sub.add_parser(prog, description=description, epilog=epilog, help=short_desc)
         for f in flags:
             # Need to create a dict with the parameters so only used
             # parameters are sent, or else exceptions are raised. Ex: if
@@ -122,7 +122,11 @@ class Command(Completer):
         self.children[prog] = new_cmd
         return new_cmd
 
-    def parse(self, args):
+    def parse(self, command: str) -> None:
+        """Parse and execute a command."""
+
+        args = shlex.split(command, comments=True)
+
         try:
             args = self.parser.parse_args(args)
             # If the command has a callback function, call it.
@@ -272,16 +276,10 @@ def source(files, ignore_errors, verbose):
                     if rec.is_recording() and not line.lstrip().startswith("source"):
                         rec.record_command(line)
 
-                    # With comments=True shlex will remove comments from the line
-                    # when splitting. Comment symbol is #
-                    s = shlex.split(line, comments=True)
-
                     # In verbose mode all commands are printed before execution.
-                    if verbose and s:
-                        print_formatted_text(
-                            HTML(f"<i>> {html.escape(line.strip())}</i>")
-                        )
-                    cli.parse(s)
+                    if verbose:
+                        print_formatted_text(HTML(f"<i>> {html.escape(line.strip())}</i>"))
+                    cli.parse(line)
                     if cli.last_errno != 0:
                         print_formatted_text(
                             HTML(
@@ -324,8 +322,7 @@ cli.add_command(
         Flag(
             "-ignore-errors",
             description=(
-                "Continue command execution on error. Default is to "
-                "stop execution on error."
+                "Continue command execution on error. Default is to stop execution on error."
             ),
             short_desc="Stop on error.",
             action="store_true",

--- a/mreg_cli/cli.py
+++ b/mreg_cli/cli.py
@@ -1,7 +1,6 @@
 import argparse
 import os
 import shlex
-from typing import Any, List, Optional
 
 from prompt_toolkit import HTML, print_formatted_text
 from prompt_toolkit.completion import Completer, Completion

--- a/mreg_cli/cli.py
+++ b/mreg_cli/cli.py
@@ -1,4 +1,5 @@
 import argparse
+import html
 import os
 import shlex
 
@@ -254,8 +255,6 @@ def source(files, ignore_errors, verbose):
     newlines.
     The files may contain comments. The comment symbol is #.
     """
-    import html
-    import shlex
 
     rec = recorder.Recorder()
 

--- a/mreg_cli/dhcp.py
+++ b/mreg_cli/dhcp.py
@@ -90,7 +90,7 @@ def assoc_mac_to_ip(mac, ip, force=False):
 #########################################
 
 
-def assoc(args):
+def assoc(args) -> None:
     # .name .mac .force
     """Associate MAC address with host. If host got multiple A/AAAA records an
     IP must be given instead of name.
@@ -107,8 +107,10 @@ def assoc(args):
 
 dhcp.add_command(
     prog="assoc",
-    description="Associate MAC address with host. If host got multiple A/AAAA "
-    "records an IP must be given instead of name.",
+    description=(
+        "Associate MAC address with host. If host got multiple A/AAAA "
+        "records an IP must be given instead of name."
+    ),
     short_desc="Add MAC address to host.",
     callback=assoc,
     flags=[
@@ -124,7 +126,7 @@ dhcp.add_command(
 ############################################
 
 
-def disassoc(args):
+def disassoc(args) -> None:
     """Disassociate MAC address with host/ip. If host got multiple A/AAAA
     records an IP must be given instead of name.
     """
@@ -148,8 +150,10 @@ def disassoc(args):
 
 dhcp.add_command(
     prog="disassoc",
-    description="Disassociate MAC address with host/ip. If host got multiple "
-    "A/AAAA records an IP must be given instead of name.",
+    description=(
+        "Disassociate MAC address with host/ip. If host got multiple "
+        "A/AAAA records an IP must be given instead of name."
+    ),
     short_desc="Disassociate MAC address.",
     callback=disassoc,
     flags=[

--- a/mreg_cli/group.py
+++ b/mreg_cli/group.py
@@ -86,8 +86,6 @@ def info(args) -> None:
             owners = ", ".join([i["name"] for i in info["owners"]])
             manager.add_formatted_line("Owners:", owners)
 
-    return manager
-
 
 group.add_command(
     prog="info",
@@ -214,8 +212,6 @@ def _history(args) -> None:
     items = get_history_items(args.name, "group", data_relation="groups")
     for line in format_history_items(args.name, items):
         manager.add_line(line)
-
-    return manager
 
 
 group.add_command(
@@ -375,8 +371,6 @@ def host_list(args) -> None:
     manager.add_line("Groups:")
     for group in group_list:
         manager.add_line("  ", group["name"])
-
-    return manager
 
 
 group.add_command(

--- a/mreg_cli/history_log.py
+++ b/mreg_cli/history_log.py
@@ -1,4 +1,5 @@
 import json
+from typing import List
 
 from dateutil.parser import parse
 
@@ -33,7 +34,11 @@ def get_history_items(name, resource, data_relation=None):
     return ret
 
 
-def print_history_items(ownname, items):
+def format_history_items(ownname, items) -> List[str]:
+    """Format history items for output."""
+
+    lines: str = []
+
     def _remove_unneded_keys(data):
         for key in (
             "id",
@@ -80,4 +85,6 @@ def print_history_items(ownname, items):
         else:
             cli_warning(f"Unhandled history entry: {i}")
 
-        print(f"{timestamp} [{i['user']}]: {model} {action}: {msg}")
+        lines.append(f"{timestamp} [{i['user']}]: {model} {action}: {msg}")
+
+    return lines

--- a/mreg_cli/host.py
+++ b/mreg_cli/host.py
@@ -5,8 +5,9 @@ from .cli import Flag, cli
 from .dhcp import assoc_mac_to_ip
 from .exceptions import HostNotFoundWarning
 from .history import history
-from .history_log import get_history_items, print_history_items
+from .history_log import format_history_items, get_history_items
 from .log import cli_error, cli_info, cli_warning
+from .outputmanager import OutputManager
 from .util import (
     clean_hostname,
     cname_exists,
@@ -46,11 +47,13 @@ host = cli.add_command(
 )
 
 
-def print_hinfo(hinfo: dict, padding: int = 14) -> None:
+def format_hinfo(hinfo: dict, padding: int = 14) -> None:
     """Pretty given hinfo id."""
     if hinfo is None:
         return
-    print("{1:<{0}}cpu={2} os={3}".format(padding, "Hinfo:", hinfo["cpu"], hinfo["os"]))
+    OutputManager().add_line(
+        "{1:<{0}}cpu={2} os={3}".format(padding, "Hinfo:", hinfo["cpu"], hinfo["os"])
+    )
 
 
 def zoneinfo_for_hostname(host: str) -> Optional[dict]:
@@ -222,8 +225,9 @@ def add(args):
 # Add 'add' as a sub command to the 'host' command
 host.add_command(
     prog="add",
-    description="Add a new host with the given name, ip or network and contact. "
-    "comment is optional.",
+    description=(
+        "Add a new host with the given name, ip or network and contact. comment is optional."
+    ),
     short_desc="Add a new host",
     callback=add,
     flags=[
@@ -235,8 +239,10 @@ host.add_command(
         Flag(
             "-ip",
             short_desc="An ip or net",
-            description="The hosts ip or a network. If it's a network the first free IP is "
-            "selected from the network",
+            description=(
+                "The hosts ip or a network. If it's a network the first free IP is "
+                "selected from the network"
+            ),
             metavar="IP/NET",
         ),
         Flag(
@@ -359,37 +365,39 @@ host.add_command(
 # first some print helpers
 
 
-def print_host_name(name: str, padding: int = 14) -> None:
+def format_host_name(name: str, padding: int = 14) -> None:
     """Pretty print given name."""
     if name is None:
         return
     assert isinstance(name, str)
-    print("{1:<{0}}{2}".format(padding, "Name:", name))
+    OutputManager().add_line("{1:<{0}}{2}".format(padding, "Name:", name))
 
 
-def print_contact(contact: str, padding: int = 14) -> None:
+def format_contact(contact: str, padding: int = 14) -> None:
     """Pretty print given contact."""
     if contact is None:
         return
     assert isinstance(contact, str)
-    print("{1:<{0}}{2}".format(padding, "Contact:", contact))
+    OutputManager().add_line("{1:<{0}}{2}".format(padding, "Contact:", contact))
 
 
-def print_comment(comment: str, padding: int = 14) -> None:
+def format_comment(comment: str, padding: int = 14) -> None:
     """Pretty print given comment."""
     if comment is None:
         return
     assert isinstance(comment, str)
-    print("{1:<{0}}{2}".format(padding, "Comment:", comment))
+    OutputManager().add_line("{1:<{0}}{2}".format(padding, "Comment:", comment))
 
 
-def print_ipaddresses(
+def format_ipaddresses(
     ipaddresses: Iterable[dict], names: bool = False, padding: int = 14
 ) -> None:
     """Pretty print given ip addresses."""
 
     def _find_padding(lst, attr):
         return max(padding, max([len(i[attr]) for i in lst]) + 1)
+
+    manager = OutputManager()
 
     if not ipaddresses:
         return
@@ -407,7 +415,9 @@ def print_ipaddresses(
         len_names = padding
     for records, text in ((a_records, "A_Records"), (aaaa_records, "AAAA_Records")):
         if records:
-            print("{1:<{0}}{2:<{3}}  {4}".format(len_names, text, "IP", len_ip, "MAC"))
+            manager.add_line(
+                "{1:<{0}}{2:<{3}}  {4}".format(len_names, text, "IP", len_ip, "MAC")
+            )
             for record in records:
                 ip = record["ipaddress"]
                 mac = record["macaddress"]
@@ -415,7 +425,7 @@ def print_ipaddresses(
                     name = record["name"]
                 else:
                     name = ""
-                print(
+                manager.add_line(
                     "{1:<{0}}{2:<{3}}  {4}".format(
                         len_names,
                         name,
@@ -426,23 +436,25 @@ def print_ipaddresses(
                 )
 
 
-def print_ttl(ttl: int, padding: int = 14) -> None:
+def format_ttl(ttl: int, padding: int = 14) -> None:
     """Pretty print given ttl."""
     assert isinstance(ttl, int) or ttl is None
-    print("{1:<{0}}{2}".format(padding, "TTL:", ttl or "(Default)"))
+    OutputManager().add_line("{1:<{0}}{2}".format(padding, "TTL:", ttl or "(Default)"))
 
 
-def print_loc(loc: dict, padding: int = 14) -> None:
+def format_loc(loc: dict, padding: int = 14) -> None:
     """Pretty print given loc."""
     if loc is None:
         return
     assert isinstance(loc, dict)
-    print("{1:<{0}}{2}".format(padding, "Loc:", loc["loc"]))
+    OutputManager().add_line("{1:<{0}}{2}".format(padding, "Loc:", loc["loc"]))
 
 
-def print_cname(cname: str, host: str, padding: int = 14) -> None:
+def format_cname(cname: str, host: str, padding: int = 14) -> None:
     """Pretty print given cname."""
-    print("{1:<{0}}{2} -> {3}".format(padding, "Cname:", cname, host))
+    OutputManager().add_line(
+        "{1:<{0}}{2} -> {3}".format(padding, "Cname:", cname, host)
+    )
 
 
 def print_mx(mxs: dict, padding: int = 14) -> None:
@@ -450,67 +462,72 @@ def print_mx(mxs: dict, padding: int = 14) -> None:
     if not mxs:
         return
     len_pri = len("Priority")
-    print("{1:<{0}}{2} {3}".format(padding, "MX:", "Priority", "Server"))
+    manager = OutputManager()
+    manager.add_line("{1:<{0}}{2} {3}".format(padding, "MX:", "Priority", "Server"))
     for mx in sorted(mxs, key=lambda i: i["priority"]):
-        print(
+        manager.add_line(
             "{1:<{0}}{2:>{3}} {4}".format(
                 padding, "", mx["priority"], len_pri, mx["mx"]
             )
         )
 
 
-def print_naptr(naptr: dict, host_name: str, padding: int = 14) -> None:
+def format_naptr(naptr: dict, host_name: str, padding: int = 14) -> None:
     """Pretty print given txt."""
     assert isinstance(naptr, dict)
     assert isinstance(host_name, str)
 
 
-def print_ptr(ip: str, host_name: str, padding: int = 14) -> None:
+def format_ptr(ip: str, host_name: str, padding: int = 14) -> None:
     """Pretty print given txt."""
     assert isinstance(ip, str)
     assert isinstance(host_name, str)
-    print("{1:<{0}}{2} -> {3}".format(padding, "PTR override:", ip, host_name))
+    OutputManager().add_line(
+        "{1:<{0}}{2} -> {3}".format(padding, "PTR override:", ip, host_name)
+    )
 
 
-def print_txt(txt: str, padding: int = 14) -> None:
+def format_txt(txt: str, padding: int = 14) -> None:
     """Pretty print given txt."""
     if txt is None:
         return
     assert isinstance(txt, str)
-    print("{1:<{0}}{2}".format(padding, "TXT:", txt))
+    OutputManager().add_line("{1:<{0}}{2}".format(padding, "TXT:", txt))
 
 
-def print_bacnetid(bacnetid: dict, padding: int = 14) -> None:
+def format_bacnetid(bacnetid: dict, padding: int = 14) -> None:
     """Pretty print given txt."""
     if bacnetid is None:
         return
     assert isinstance(bacnetid, dict)
-    print("{1:<{0}}{2}".format(padding, "BACnet ID:", bacnetid["id"]))
+    OutputManager().add_line(
+        "{1:<{0}}{2}".format(padding, "BACnet ID:", bacnetid["id"])
+    )
 
 
 def _print_host_info(info):
     # Pretty print all host info
-    print_host_name(info["name"])
-    print_contact(info["contact"])
+    format_host_name(info["name"])
+    format_contact(info["contact"])
     if info["comment"]:
-        print_comment(info["comment"])
-    print_ipaddresses(info["ipaddresses"])
+        format_comment(info["comment"])
+    format_ipaddresses(info["ipaddresses"])
     for ptr in info["ptr_overrides"]:
-        print_ptr(ptr["ipaddress"], info["name"])
-    print_ttl(info["ttl"])
+        format_ptr(ptr["ipaddress"], info["name"])
+    format_ttl(info["ttl"])
     print_mx(info["mxs"])
-    print_hinfo(info["hinfo"])
+    format_hinfo(info["hinfo"])
     if info["loc"]:
-        print_loc(info["loc"])
+        format_loc(info["loc"])
     for cname in info["cnames"]:
-        print_cname(cname["name"], info["name"])
+        format_cname(cname["name"], info["name"])
     for txt in info["txts"]:
-        print_txt(txt["txt"])
+        format_txt(txt["txt"])
     _srv_show(host_id=info["id"])
     _naptr_show(info)
     _sshfp_show(info)
     if "bacnetid" in info:
-        print_bacnetid(info.get("bacnetid"))
+        format_bacnetid(info.get("bacnetid"))
     cli_info("printed host info for {}".format(info["name"]))
 
 
@@ -535,7 +552,7 @@ def _print_ip_info(ip):
             if i["ipaddress"] == ip:
                 ptrhost = info["name"]
 
-    print_ipaddresses(ipaddresses, names=True)
+    format_ipaddresses(ipaddresses, names=True)
     if len(ipaddresses) > 1 and ptrhost is None:
         cli_warning(f"IP {ip} used by {len(ipaddresses)} hosts, but no PTR override")
     if ptrhost is None:
@@ -551,10 +568,10 @@ def _print_ip_info(ip):
             ptrhost = "default"
     if not ipaddresses and ptrhost is None:
         cli_warning(f"Found no hosts or ptr override matching IP {ip}")
-    print_ptr(ip, ptrhost)
+    format_ptr(ip, ptrhost)
 
 
-def info_(args):
+def info_(args) -> None:
     """Print information about host. If <name> is an alias the cname hosts info
     is shown.
     """
@@ -573,7 +590,7 @@ def info_(args):
             info = host_info_by_name(name_or_ip)
             name = clean_hostname(name_or_ip)
             if any(cname["name"] == name for cname in info["cnames"]):
-                print(f'{name} is a CNAME for {info["name"]}')
+                OutputManager().add_line(f'{name} is a CNAME for {info["name"]}')
             _print_host_info(info)
 
 
@@ -595,7 +612,7 @@ host.add_command(
 )
 
 
-def find(args):
+def find(args) -> None:
     """List hosts maching search criteria."""
 
     def _add_param(param, value):
@@ -633,7 +650,7 @@ def find(args):
         max_contact = max(max_contact, len(i["contact"]))
 
     def _print(name, contact, comment):
-        print(
+        OutputManager().add_line(
             "{0:<{1}} {2:<{3}} {4}".format(
                 name, max_name, contact, max_contact, comment
             )
@@ -677,7 +694,7 @@ host.add_command(
 ############################################
 
 
-def rename(args):
+def rename(args) -> None:
     """Rename host. If <old-name> is an alias then the alias is renamed."""
     # Find old host
     old_name = resolve_input_name(args.old_name)
@@ -716,8 +733,7 @@ def rename(args):
 # Add 'rename' as a sub command to the 'host' command
 host.add_command(
     prog="rename",
-    description="Rename host. If the old name is an alias then the alias is "
-    "renamed.",
+    description="Rename host. If the old name is an alias then the alias is renamed.",
     short_desc="Rename a host",
     callback=rename,
     flags=[
@@ -744,7 +760,7 @@ host.add_command(
 #################################################
 
 
-def set_comment(args):
+def set_comment(args) -> None:
     """Set comment for host. If <name> is an alias the cname host is updated."""
     # Get host info or raise exception
     info = host_info_by_name(args.name)
@@ -764,16 +780,16 @@ def set_comment(args):
 # Add 'set_comment' as a sub command to the 'host' command
 host.add_command(
     prog="set_comment",
-    description="Set comment for host. If NAME is an alias the cname host is "
-    "updated.",
+    description="Set comment for host. If NAME is an alias the cname host is updated.",
     short_desc="Set comment.",
     callback=set_comment,
     flags=[
         Flag("name", description="Name of the target host.", metavar="NAME"),
         Flag(
             "comment",
-            description="The new comment. If it contains spaces then it must "
-            "be enclosed in quotes.",
+            description=(
+                "The new comment. If it contains spaces then it must be enclosed in quotes."
+            ),
             metavar="COMMENT",
         ),
     ],
@@ -785,7 +801,7 @@ host.add_command(
 #################################################
 
 
-def set_contact(args):
+def set_contact(args) -> None:
     """Set contact for host. If <name> is an alias the cname host is updated."""
     # Contact sanity check
     if not is_valid_email(args.contact):
@@ -810,8 +826,7 @@ def set_contact(args):
 # Add 'set_contact' as a sub command to the 'host' command
 host.add_command(
     prog="set_contact",
-    description="Set contact for host. If NAME is an alias the cname host is "
-    "updated.",
+    description="Set contact for host. If NAME is an alias the cname host is updated.",
     short_desc="Set contact.",
     callback=set_contact,
     flags=[
@@ -890,7 +905,7 @@ def _ip_add(args, ipversion, macaddress=None):
 ###########################################
 
 
-def a_add(args):
+def a_add(args) -> None:
     """Add an A record to host. If <name> is an alias the cname host is used."""
     _ip_add(args, 4, macaddress=args.macaddress)
 
@@ -898,17 +913,18 @@ def a_add(args):
 # Add 'a_add' as a sub command to the 'host' command
 host.add_command(
     prog="a_add",
-    description="Add an A record to host. If NAME is an alias the cname host "
-    "is used.",
+    description="Add an A record to host. If NAME is an alias the cname host is used.",
     short_desc="Add A record.",
     callback=a_add,
     flags=[
         Flag("name", description="Name of the target host.", metavar="NAME"),
         Flag(
             "ip",
-            description="The IP of new A record. May also be a network, "
-            "in which case a random IP address from that network "
-            "is chosen.",
+            description=(
+                "The IP of new A record. May also be a network, "
+                "in which case a random IP address from that network "
+                "is chosen."
+            ),
             metavar="IP/network",
         ),
         Flag("-macaddress", description="Mac address", metavar="MACADDRESS"),
@@ -922,7 +938,7 @@ host.add_command(
 ##############################################
 
 
-def _ip_change(args, ipversion):
+def _ip_change(args, ipversion) -> None:
     if args.old == args.new:
         cli_warning("New and old IP are equal")
 
@@ -962,8 +978,9 @@ def a_change(args):
 # Add 'a_change' as a sub command to the 'host' command
 host.add_command(
     prog="a_change",
-    description="Change an A record for the target host. If NAME is an alias "
-    "the cname host is used.",
+    description=(
+        "Change an A record for the target host. If NAME is an alias the cname host is used."
+    ),
     short_desc="Change A record.",
     callback=a_change,
     flags=[
@@ -982,8 +999,10 @@ host.add_command(
         ),
         Flag(
             "-new",
-            description="The new IP address. May also be a network, in which "
-            "case a random IP from that network is chosen.",
+            description=(
+                "The new IP address. May also be a network, in which "
+                "case a random IP from that network is chosen."
+            ),
             short_desc="New IP.",
             required=True,
             metavar="IP/network",
@@ -997,7 +1016,7 @@ host.add_command(
 ############################################
 
 
-def _ip_move(args, ipversion):
+def _ip_move(args, ipversion) -> None:
     _check_ipversion(args.ip, ipversion)
     frominfo = host_info_by_name(args.fromhost)
     toinfo = host_info_by_name(args.tohost)
@@ -1025,7 +1044,7 @@ def _ip_move(args, ipversion):
     cli_info(msg, print_msg=True)
 
 
-def a_move(args):
+def a_move(args) -> None:
     """Move an IP from a host to another host. Will move also move the PTR, if any."""
     _ip_move(args, 4)
 
@@ -1059,7 +1078,7 @@ host.add_command(
 ##############################################
 
 
-def _ip_remove(args, ipversion):
+def _ip_remove(args, ipversion) -> None:
     ip_id = None
 
     _check_ipversion(args.ip, ipversion)
@@ -1085,9 +1104,12 @@ def _ip_remove(args, ipversion):
     cli_info("removed ip {} from {}".format(args.ip, info["name"]), print_msg=True)
 
 
-def a_remove(args):
+def a_remove(args) -> None:
     """Remove A record from host. If <name> is an alias the cname host is used."""
-    _ip_remove(args, 4)
+    _ip_remove(
+        args,
+        4,
+    )
 
 
 # Add 'a_remove' as a sub command to the 'host' command
@@ -1108,18 +1130,17 @@ host.add_command(
 ############################################
 
 
-def a_show(args):
+def a_show(args) -> None:
     """Show hosts ipaddresses. If <name> is an alias the cname host is used."""
     info = host_info_by_name(args.name)
-    print_ipaddresses(info["ipaddresses"])
+    format_ipaddresses(info["ipaddresses"])
     cli_info("showed ip addresses for {}".format(info["name"]))
 
 
 # Add 'a_show' as a sub command to the 'host' command
 host.add_command(
     prog="a_show",
-    description="Show hosts ipaddresses. If NAME is an alias the cname host "
-    "is used.",
+    description="Show hosts ipaddresses. If NAME is an alias the cname host is used.",
     short_desc="Show ipaddresses.",
     callback=a_show,
     flags=[
@@ -1140,7 +1161,7 @@ host.add_command(
 ##############################################
 
 
-def aaaa_add(args):
+def aaaa_add(args) -> None:
     """Add an AAAA record to host. If <name> is an alias the cname host is used."""
     _ip_add(args, 6, macaddress=args.macaddress)
 
@@ -1148,8 +1169,7 @@ def aaaa_add(args):
 # Add 'aaaa_add' as a sub command to the 'host' command
 host.add_command(
     prog="aaaa_add",
-    description=" Add an AAAA record to host. If NAME is an alias the cname "
-    "host is used.",
+    description=" Add an AAAA record to host. If NAME is an alias the cname host is used.",
     short_desc="Add AAAA record.",
     callback=aaaa_add,
     flags=[
@@ -1166,9 +1186,12 @@ host.add_command(
 #################################################
 
 
-def aaaa_change(args):
+def aaaa_change(args) -> None:
     """Change AAAA record. If <name> is an alias the cname host is used."""
-    _ip_change(args, 6)
+    _ip_change(
+        args,
+        6,
+    )
 
 
 # Add 'aaaa_change' as a sub command to the 'host' command
@@ -1207,9 +1230,12 @@ host.add_command(
 ###############################################
 
 
-def aaaa_move(args):
+def aaaa_move(args) -> None:
     """Move an IP from a host to another host. Will move also move the PTR, if any."""
-    _ip_move(args, 6)
+    _ip_move(
+        args,
+        6,
+    )
 
 
 # Add 'aaaa_move' as a sub command to the 'host' command
@@ -1241,7 +1267,7 @@ host.add_command(
 #################################################
 
 
-def aaaa_remove(args):
+def aaaa_remove(args) -> None:
     """Remove AAAA record from host. If <name> is an alias the cname host is
     used.
     """
@@ -1251,8 +1277,7 @@ def aaaa_remove(args):
 # Add 'aaaa_remove' as a sub command to the 'host' command
 host.add_command(
     prog="aaaa_remove",
-    description="Remove AAAA record from host. If NAME is an alias the cname "
-    "host is used.",
+    description="Remove AAAA record from host. If NAME is an alias the cname host is used.",
     short_desc="Remove AAAA record.",
     callback=aaaa_remove,
     flags=[
@@ -1267,18 +1292,17 @@ host.add_command(
 ###############################################
 
 
-def aaaa_show(args):
+def aaaa_show(args) -> None:
     """Show hosts ipaddresses. If <name> is an alias the cname host is used."""
     info = host_info_by_name(args.name)
-    print_ipaddresses(info["ipaddresses"])
+    format_ipaddresses(info["ipaddresses"])
     cli_info("showed aaaa records for {}".format(info["name"]))
 
 
 # Add 'aaaa_show' as a sub command to the 'host' command
 host.add_command(
     prog="aaaa_show",
-    description="Show hosts AAAA records. If NAME is an alias the cname host "
-    "is used.",
+    description="Show hosts AAAA records. If NAME is an alias the cname host is used.",
     short_desc="Show AAAA records.",
     callback=aaaa_show,
     flags=[
@@ -1299,7 +1323,7 @@ host.add_command(
 ###############################################
 
 
-def cname_add(args):
+def cname_add(args) -> None:
     """Add a CNAME record to host."""
     # Get host info or raise exception
     info = host_info_by_name(args.name)
@@ -1347,7 +1371,7 @@ host.add_command(
 ##################################################
 
 
-def cname_remove(args):
+def cname_remove(args) -> None:
     """Remove CNAME record."""
     info = host_info_by_name(args.name)
     hostname = info["name"]
@@ -1385,7 +1409,7 @@ host.add_command(
 ###################################################
 
 
-def cname_replace(args):
+def cname_replace(args) -> None:
     """Move a CNAME entry from one host to another."""
     cname = clean_hostname(args.cname)
     host = clean_hostname(args.host)
@@ -1423,14 +1447,14 @@ host.add_command(
 ################################################
 
 
-def cname_show(args):
+def cname_show(args) -> None:
     """Show CNAME records for host. If <name> is an alias the cname hosts
     aliases are shown.
     """
     try:
         info = host_info_by_name(args.name)
         for cname in info["cnames"]:
-            print_cname(cname["name"], info["name"])
+            format_cname(cname["name"], info["name"])
         cli_info("showed cname aliases for {}".format(info["name"]))
         return
     except HostNotFoundWarning:
@@ -1473,7 +1497,7 @@ def _hinfo_remove(host_) -> None:
 ###############################################
 
 
-def hinfo_add(args):
+def hinfo_add(args) -> None:
     """Add hinfo for host. If <name> is an alias the cname host is updated."""
     # Get host info or raise exception
     info = host_info_by_name(args.name)
@@ -1507,7 +1531,7 @@ host.add_command(
 ##################################################
 
 
-def hinfo_remove(args):
+def hinfo_remove(args) -> None:
     """hinfo_remove <name>
     Remove hinfo for host. If <name> is an alias the cname host is updated.
     """
@@ -1526,8 +1550,7 @@ def hinfo_remove(args):
 # Add 'hinfo_remove' as a sub command to the 'host' command
 host.add_command(
     prog="hinfo_remove",
-    description="Remove hinfo for host. If NAME is an alias the cname host is "
-    "updated.",
+    description="Remove hinfo for host. If NAME is an alias the cname host is updated.",
     short_desc="Remove HINFO.",
     callback=hinfo_remove,
     flags=[
@@ -1541,13 +1564,13 @@ host.add_command(
 ################################################
 
 
-def hinfo_show(args):
+def hinfo_show(args) -> None:
     """Show hinfo for host. If <name> is an alias the cname hosts hinfo is
     shown.
     """
     info = host_info_by_name(args.name)
     if info["hinfo"]:
-        print_hinfo(info["hinfo"])
+        format_hinfo(info["hinfo"])
     else:
         cli_info("No hinfo for {}".format(args.name), print_msg=True)
     cli_info("showed hinfo for {}".format(info["name"]))
@@ -1556,8 +1579,7 @@ def hinfo_show(args):
 # Add 'hinfo_show' as a sub command to the 'host' command
 host.add_command(
     prog="hinfo_show",
-    description="Show hinfo for host. If NAME is an alias the cname hosts "
-    "hinfo is shown.",
+    description="Show hinfo for host. If NAME is an alias the cname hosts hinfo is shown.",
     short_desc="Show HINFO.",
     callback=hinfo_show,
     flags=[
@@ -1566,11 +1588,11 @@ host.add_command(
 )
 
 
-def _history(args):
+def _history(args) -> None:
     """Show host history for name."""
     hostname = clean_hostname(args.name)
     items = get_history_items(hostname, "host", data_relation="hosts")
-    print_history_items(hostname, items)
+    format_history_items(hostname, items)
 
 
 host.add_command(
@@ -1596,7 +1618,7 @@ host.add_command(
 ################################################
 
 
-def loc_remove(args):
+def loc_remove(args) -> None:
     """Remove location from host. If <name> is an alias the cname host is
     updated.
     """
@@ -1615,8 +1637,7 @@ def loc_remove(args):
 # Add 'loc_remove' as a sub command to the 'host' command
 host.add_command(
     prog="loc_remove",
-    description="Remove location from host. If NAME is an alias the cname host "
-    "is updated.",
+    description="Remove location from host. If NAME is an alias the cname host is updated.",
     short_desc="Remove LOC record.",
     callback=loc_remove,
     flags=[
@@ -1630,7 +1651,7 @@ host.add_command(
 #############################################
 
 
-def loc_add(args):
+def loc_add(args) -> None:
     """Set location of host. If <name> is an alias the cname host is updated."""
     # Get host info or raise exception
     info = host_info_by_name(args.name)
@@ -1647,8 +1668,7 @@ def loc_add(args):
 
 host.add_command(
     prog="loc_add",
-    description="Set location of host. If NAME is an alias the cname host is "
-    "updated.",
+    description="Set location of host. If NAME is an alias the cname host is updated.",
     short_desc="Set LOC record.",
     callback=loc_add,
     flags=[
@@ -1663,13 +1683,13 @@ host.add_command(
 ##############################################
 
 
-def loc_show(args):
+def loc_show(args) -> None:
     """Show location of host. If <name> is an alias the cname hosts LOC is
     shown.
     """
     info = host_info_by_name(args.name)
     if info["loc"]:
-        print_loc(info["loc"])
+        format_loc(info["loc"])
     else:
         cli_info("No LOC for {}".format(args.name), print_msg=True)
     cli_info("showed LOC for {}".format(info["name"]))
@@ -1678,8 +1698,7 @@ def loc_show(args):
 # Add 'loc_show' as a sub command to the 'host' command
 host.add_command(
     prog="loc_show",
-    description="Show location of host. If NAME is an alias the cname hosts "
-    "LOC is shown.",
+    description="Show location of host. If NAME is an alias the cname hosts LOC is shown.",
     short_desc="Show LOC record.",
     callback=loc_show,
     flags=[
@@ -1707,7 +1726,7 @@ def _mx_in_mxs(mxs, priority, mx):
 #############################################
 
 
-def mx_add(args):
+def mx_add(args) -> None:
     """Add a mx record to host. <text> must be enclosed in double quotes if it
     contains more than one word.
     """
@@ -1743,7 +1762,7 @@ host.add_command(
 ################################################
 
 
-def mx_remove(args):
+def mx_remove(args) -> None:
     """Remove MX record for host."""
     # Get host info or raise exception
     info = host_info_by_name(args.name)
@@ -1780,7 +1799,7 @@ host.add_command(
 ##############################################
 
 
-def mx_show(args):
+def mx_show(args) -> None:
     """Show all MX records for host."""
     info = host_info_by_name(args.name)
     path = "/api/v1/mxs/"
@@ -1817,7 +1836,7 @@ host.add_command(
 ###############################################
 
 
-def naptr_add(args):
+def naptr_add(args) -> None:
     """Add a NAPTR record to host."""
     # Get host info or raise exception
     info = host_info_by_name(args.name)
@@ -1886,7 +1905,7 @@ host.add_command(
 ##################################################
 
 
-def naptr_remove(args):
+def naptr_remove(args) -> None:
     """naptr_remove <name> <replacement>
     Remove NAPTR record.
     """
@@ -1989,10 +2008,11 @@ def _naptr_show(info):
         "Replacement",
     )
     row_format = "{:<14}" * len(headers)
+    manager = OutputManager()
     if naptrs:
-        print(row_format.format(*headers))
+        manager.add_line(row_format.format(*headers))
         for naptr in naptrs:
-            print(
+            manager.add_line(
                 row_format.format(
                     "",
                     naptr["preference"],
@@ -2006,12 +2026,12 @@ def _naptr_show(info):
     return len(naptrs)
 
 
-def naptr_show(args):
+def naptr_show(args) -> None:
     """Show all NAPTR records for host."""
     info = host_info_by_name(args.name)
     num_naptrs = _naptr_show(info)
     if num_naptrs == 0:
-        print(f"No naptrs for {info['name']}")
+        OutputManager().add_line(f"No naptrs for {info['name']}")
     cli_info("showed {} NAPTR records for {}".format(num_naptrs, info["name"]))
 
 
@@ -2039,7 +2059,7 @@ host.add_command(
 ################################################
 
 
-def ptr_change(args):
+def ptr_change(args) -> None:
     """Move PTR record from <old-name> to <new-name>."""
     # Get host info or raise exception
     old_info = host_info_by_name(args.old)
@@ -2099,7 +2119,7 @@ host.add_command(
 ################################################
 
 
-def ptr_remove(args):
+def ptr_remove(args) -> None:
     """Remove PTR record from host."""
     # Get host info or raise exception
     info = host_info_by_name(args.name)
@@ -2138,7 +2158,7 @@ host.add_command(
 #############################################
 
 
-def ptr_add(args):
+def ptr_add(args) -> None:
     """Create a PTR record for host."""
     # Ip sanity check
     if not is_valid_ip(args.ip):
@@ -2199,7 +2219,7 @@ host.add_command(
 ##############################################
 
 
-def ptr_show(args):
+def ptr_show(args) -> None:
     """Show PTR record matching given ip."""
     if not is_valid_ip(args.ip):
         cli_warning(f"{args.ip} is not a valid IP")
@@ -2216,16 +2236,15 @@ def ptr_show(args):
         for ptr in host["ptr_overrides"]:
             if args.ip == ptr["ipaddress"]:
                 padding = len(args.ip)
-                print_ptr(args.ip, host["name"], padding)
+                format_ptr(args.ip, host["name"], padding)
     else:
-        print(f"No PTR found for IP '{args.ip}'")
+        OutputManager().add_line(f"No PTR found for IP '{args.ip}'")
 
 
 # Add 'ptr_show' as a sub command to the 'host' command
 host.add_command(
     prog="ptr_show",
-    description="Show PTR record matching given ip (empty input shows all "
-    "PTR records).",
+    description="Show PTR record matching given ip (empty input shows all PTR records).",
     short_desc="Show PTR record.",
     callback=ptr_show,
     flags=[
@@ -2246,7 +2265,7 @@ host.add_command(
 #############################################
 
 
-def srv_add(args):
+def srv_add(args) -> None:
     """Add SRV record."""
     sname = clean_hostname(args.name)
     check_zone_for_hostname(sname, False, require_zone=True)
@@ -2299,7 +2318,7 @@ host.add_command(
 ################################################
 
 
-def srv_remove(args):
+def srv_remove(args) -> None:
     """Remove SRV record."""
     info = host_info_by_name(args.host)
     sname = clean_hostname(args.name)
@@ -2382,7 +2401,7 @@ def _srv_show(srvs=None, host_id=None):
 
     def print_srv(srv: dict, hostname: str, padding: int = 14) -> None:
         """Pretty print given srv."""
-        print(
+        OutputManager().add_line(
             "SRV: {1:<{0}} {2:^6} {3:^6} {4:^6} {5}".format(
                 padding,
                 srv["name"],
@@ -2426,7 +2445,7 @@ def _srv_show(srvs=None, host_id=None):
         print_srv(srv, hostid2name[srv["host"]], padding)
 
 
-def srv_show(args):
+def srv_show(args) -> None:
     """Show SRV records for the service."""
     sname = clean_hostname(args.service)
 
@@ -2468,7 +2487,7 @@ host.add_command(
 #############################################
 
 
-def sshfp_add(args):
+def sshfp_add(args) -> None:
     """Add SSHFP record."""
     # Get host info or raise exception
     info = host_info_by_name(args.name)
@@ -2511,7 +2530,7 @@ host.add_command(
 ################################################
 
 
-def sshfp_remove(args):
+def sshfp_remove(args) -> None:
     """Remove SSHFP record with a given fingerprint from the host.
     A missing fingerprint removes all SSHFP records for the host.
     """
@@ -2590,10 +2609,11 @@ def _sshfp_show(info):
     sshfps = get_list(path, params=params)
     headers = ("SSHFPs:", "Algorithm", "Type", "Fingerprint")
     row_format = "{:<14}" * len(headers)
+    manager = OutputManager()
     if sshfps:
-        print(row_format.format(*headers))
+        manager.add_line(row_format.format(*headers))
         for sshfp in sshfps:
-            print(
+            manager.add_line(
                 row_format.format(
                     "",
                     sshfp["algorithm"],
@@ -2604,7 +2624,7 @@ def _sshfp_show(info):
     return len(sshfps)
 
 
-def sshfp_show(args):
+def sshfp_show(args) -> None:
     """Show SSHFP records for the host."""
     # Get host info or raise exception
     info = host_info_by_name(args.name)
@@ -2637,7 +2657,7 @@ host.add_command(
 ################################################
 
 
-def ttl_remove(args):
+def ttl_remove(args) -> None:
     """Remove explicit TTL for host. If <name> is an alias the alias host is
     updated.
     """
@@ -2656,8 +2676,7 @@ def ttl_remove(args):
 # Add 'ttl_remove' as a sub command to the 'host' command
 host.add_command(
     prog="ttl_remove",
-    description="Remove explicit TTL for host. If NAME is an alias the alias "
-    "host is updated.",
+    description="Remove explicit TTL for host. If NAME is an alias the alias host is updated.",
     short_desc="Remove TTL record.",
     callback=ttl_remove,
     flags=[
@@ -2671,7 +2690,7 @@ host.add_command(
 #############################################
 
 
-def ttl_set(args):
+def ttl_set(args) -> None:
     """Set ttl for name. Valid values are 300 <= TTL <= 68400 or "default". If
     <name> is an alias the alias host is updated.
     """
@@ -2712,11 +2731,11 @@ host.add_command(
 ##############################################
 
 
-def ttl_show(args):
+def ttl_show(args) -> None:
     """Show ttl for name. If <name> is an alias the alias hosts TTL is shown."""
     info = host_info_by_name(args.name)
     target_type, info = get_info_by_name(args.name)
-    print_ttl(info["ttl"])
+    format_ttl(info["ttl"])
     cli_info("showed TTL for {}".format(info["name"]))
 
 
@@ -2744,7 +2763,7 @@ host.add_command(
 #############################################
 
 
-def txt_add(args):
+def txt_add(args) -> None:
     """Add a txt record to host. <text> must be enclosed in double quotes if it
     contains more than one word.
     """
@@ -2784,7 +2803,7 @@ host.add_command(
 ################################################
 
 
-def txt_remove(args):
+def txt_remove(args) -> None:
     """Remove TXT record for host with <text>."""
     # Get host info or raise exception
     info = host_info_by_name(args.name)
@@ -2827,7 +2846,7 @@ host.add_command(
 ##############################################
 
 
-def txt_show(args):
+def txt_show(args) -> None:
     """Show all TXT records for host."""
     info = host_info_by_name(args.name)
     path = "/api/v1/txts/"
@@ -2837,7 +2856,7 @@ def txt_show(args):
     history.record_get(path)
     txts = get_list(path, params=params)
     for txt in txts:
-        print_txt(txt["txt"], padding=5)
+        format_txt(txt["txt"], padding=5)
     cli_info("showed TXT records for {}".format(info["name"]))
 
 

--- a/mreg_cli/host.py
+++ b/mreg_cli/host.py
@@ -195,9 +195,7 @@ def add(args):
     # Contact sanity check
     if args.contact and not is_valid_email(args.contact):
         cli_warning(
-            "invalid mail address ({}) when trying to add {}".format(
-                args.contact, args.name
-            )
+            "invalid mail address ({}) when trying to add {}".format(args.contact, args.name)
         )
 
     # Create the new host with an ip address
@@ -415,9 +413,7 @@ def format_ipaddresses(
         len_names = padding
     for records, text in ((a_records, "A_Records"), (aaaa_records, "AAAA_Records")):
         if records:
-            manager.add_line(
-                "{1:<{0}}{2:<{3}}  {4}".format(len_names, text, "IP", len_ip, "MAC")
-            )
+            manager.add_line("{1:<{0}}{2:<{3}}  {4}".format(len_names, text, "IP", len_ip, "MAC"))
             for record in records:
                 ip = record["ipaddress"]
                 mac = record["macaddress"]
@@ -452,9 +448,7 @@ def format_loc(loc: dict, padding: int = 14) -> None:
 
 def format_cname(cname: str, host: str, padding: int = 14) -> None:
     """Pretty print given cname."""
-    OutputManager().add_line(
-        "{1:<{0}}{2} -> {3}".format(padding, "Cname:", cname, host)
-    )
+    OutputManager().add_line("{1:<{0}}{2} -> {3}".format(padding, "Cname:", cname, host))
 
 
 def print_mx(mxs: dict, padding: int = 14) -> None:
@@ -466,9 +460,7 @@ def print_mx(mxs: dict, padding: int = 14) -> None:
     manager.add_line("{1:<{0}}{2} {3}".format(padding, "MX:", "Priority", "Server"))
     for mx in sorted(mxs, key=lambda i: i["priority"]):
         manager.add_line(
-            "{1:<{0}}{2:>{3}} {4}".format(
-                padding, "", mx["priority"], len_pri, mx["mx"]
-            )
+            "{1:<{0}}{2:>{3}} {4}".format(padding, "", mx["priority"], len_pri, mx["mx"])
         )
 
 
@@ -482,9 +474,7 @@ def format_ptr(ip: str, host_name: str, padding: int = 14) -> None:
     """Pretty print given txt."""
     assert isinstance(ip, str)
     assert isinstance(host_name, str)
-    OutputManager().add_line(
-        "{1:<{0}}{2} -> {3}".format(padding, "PTR override:", ip, host_name)
-    )
+    OutputManager().add_line("{1:<{0}}{2} -> {3}".format(padding, "PTR override:", ip, host_name))
 
 
 def format_txt(txt: str, padding: int = 14) -> None:
@@ -500,9 +490,7 @@ def format_bacnetid(bacnetid: dict, padding: int = 14) -> None:
     if bacnetid is None:
         return
     assert isinstance(bacnetid, dict)
-    OutputManager().add_line(
-        "{1:<{0}}{2}".format(padding, "BACnet ID:", bacnetid["id"])
-    )
+    OutputManager().add_line("{1:<{0}}{2}".format(padding, "BACnet ID:", bacnetid["id"]))
 
 
 def _print_host_info(info):
@@ -638,9 +626,7 @@ def find(args) -> None:
     if ret["count"] == 0:
         cli_warning("No hosts found.")
     elif ret["count"] > 500:
-        cli_warning(
-            f'Too many hits, {ret["count"]}, more than limit of 500. Refine search.'
-        )
+        cli_warning(f'Too many hits, {ret["count"]}, more than limit of 500. Refine search.')
 
     del params["page_size"]
     ret = get_list(path, params=params)
@@ -651,9 +637,7 @@ def find(args) -> None:
 
     def _print(name, contact, comment):
         OutputManager().add_line(
-            "{0:<{1}} {2:<{3}} {4}".format(
-                name, max_name, contact, max_contact, comment
-            )
+            "{0:<{1}} {2:<{3}} {4}".format(name, max_name, contact, max_contact, comment)
         )
 
     _print("Name", "Contact", "Comment")
@@ -805,9 +789,7 @@ def set_contact(args) -> None:
     """Set contact for host. If <name> is an alias the cname host is updated."""
     # Contact sanity check
     if not is_valid_email(args.contact):
-        cli_warning(
-            "invalid mail address {} (target host: {})".format(args.contact, args.name)
-        )
+        cli_warning("invalid mail address {} (target host: {})".format(args.contact, args.name))
 
     # Get host info or raise exception
     info = host_info_by_name(args.name)
@@ -818,9 +800,7 @@ def set_contact(args) -> None:
     path = f"/api/v1/hosts/{info['name']}"
     history.record_patch(path, new_data, old_data)
     patch(path, contact=args.contact)
-    cli_info(
-        "Updated contact of {} to {}".format(info["name"], args.contact), print_msg=True
-    )
+    cli_info("Updated contact of {} to {}".format(info["name"], args.contact), print_msg=True)
 
 
 # Add 'set_contact' as a sub command to the 'host' command
@@ -879,9 +859,7 @@ def _ip_add(args, ipversion, macaddress=None):
     else:
         # Require force if host has multiple A/AAAA records
         if len(info["ipaddresses"]) and not args.force:
-            cli_warning(
-                "{} already has A/AAAA record(s), must force".format(info["name"])
-            )
+            cli_warning("{} already has A/AAAA record(s), must force".format(info["name"]))
 
         if any(args.ip == i["ipaddress"] for i in info["ipaddresses"]):
             cli_warning(f"Host already has IP {args.ip}")
@@ -1106,10 +1084,7 @@ def _ip_remove(args, ipversion) -> None:
 
 def a_remove(args) -> None:
     """Remove A record from host. If <name> is an alias the cname host is used."""
-    _ip_remove(
-        args,
-        4,
-    )
+    _ip_remove(args, 4)
 
 
 # Add 'a_remove' as a sub command to the 'host' command
@@ -1188,10 +1163,7 @@ host.add_command(
 
 def aaaa_change(args) -> None:
     """Change AAAA record. If <name> is an alias the cname host is used."""
-    _ip_change(
-        args,
-        6,
-    )
+    _ip_change(args, 6)
 
 
 # Add 'aaaa_change' as a sub command to the 'host' command
@@ -1232,10 +1204,7 @@ host.add_command(
 
 def aaaa_move(args) -> None:
     """Move an IP from a host to another host. Will move also move the PTR, if any."""
-    _ip_move(
-        args,
-        6,
-    )
+    _ip_move(args, 6)
 
 
 # Add 'aaaa_move' as a sub command to the 'host' command
@@ -1425,9 +1394,7 @@ def cname_replace(args) -> None:
     path = f"/api/v1/cnames/{cname}"
     history.record_patch(path, "", data, undoable=False)
     patch(path, **data)
-    cli_info(
-        f"Moved CNAME alias {cname}: {cname_info['name']} -> {host}", print_msg=True
-    )
+    cli_info(f"Moved CNAME alias {cname}: {cname_info['name']} -> {host}", print_msg=True)
 
 
 host.add_command(
@@ -1886,9 +1853,7 @@ host.add_command(
             metavar="ORDER",
         ),
         Flag("-flag", description="NAPTR flag.", required=True, metavar="FLAG"),
-        Flag(
-            "-service", description="NAPTR service.", required=True, metavar="SERVICE"
-        ),
+        Flag("-service", description="NAPTR service.", required=True, metavar="SERVICE"),
         Flag("-regex", description="NAPTR regexp.", required=True, metavar="REGEXP"),
         Flag(
             "-replacement",
@@ -1972,9 +1937,7 @@ host.add_command(
             metavar="ORDER",
         ),
         Flag("-flag", description="NAPTR flag.", required=True, metavar="FLAG"),
-        Flag(
-            "-service", description="NAPTR service.", required=True, metavar="SERVICE"
-        ),
+        Flag("-service", description="NAPTR service.", required=True, metavar="SERVICE"),
         Flag("-regex", description="NAPTR regexp.", required=True, metavar="REGEXP"),
         Flag(
             "-replacement",
@@ -2135,9 +2098,7 @@ def ptr_remove(args) -> None:
     path = f"/api/v1/ptroverrides/{ptr_id}"
     history.record_delete(path, ptr_id)
     delete(path)
-    cli_info(
-        "deleted PTR record {} for {}".format(args.ip, info["name"]), print_msg=True
-    )
+    cli_info("deleted PTR record {} for {}".format(args.ip, info["name"]), print_msg=True)
 
 
 # Add 'ptr_remove' as a sub command to the 'host' command
@@ -2180,9 +2141,7 @@ def ptr_add(args) -> None:
         cli_warning("{} already exist in a PTR record".format(args.ip))
     # check if host is in mreg controlled zone, must force if not
     if info["zone"] is None and not args.force:
-        cli_warning(
-            "{} isn't in a zone controlled by MREG, must force".format(info["name"])
-        )
+        cli_warning("{} isn't in a zone controlled by MREG, must force".format(info["name"]))
 
     network = get_network_by_ip(args.ip)
     reserved_addresses = get_network_reserved_ips(network["network"])
@@ -2289,9 +2248,7 @@ def srv_add(args) -> None:
     path = "/api/v1/srvs/"
     history.record_post(path, "", data, undoable=False)
     post(path, **data)
-    cli_info(
-        "Added SRV record {} with target {}".format(sname, info["name"]), print_msg=True
-    )
+    cli_info("Added SRV record {} with target {}".format(sname, info["name"]), print_msg=True)
 
 
 # Add 'srv_add' as a sub command to the 'host' command
@@ -2301,9 +2258,7 @@ host.add_command(
     callback=srv_add,
     flags=[
         Flag("-name", description="SRV service.", required=True, metavar="SERVICE"),
-        Flag(
-            "-priority", description="SRV priority.", required=True, metavar="PRIORITY"
-        ),
+        Flag("-priority", description="SRV priority.", required=True, metavar="PRIORITY"),
         Flag("-weight", description="SRV weight.", required=True, metavar="WEIGHT"),
         Flag("-port", description="SRV port.", required=True, metavar="PORT"),
         Flag("-host", description="Host target name.", required=True, metavar="NAME"),
@@ -2518,9 +2473,7 @@ host.add_command(
         Flag("name", description="Host target name.", metavar="NAME"),
         Flag("algorithm", description="SSH algorithm.", metavar="ALGORITHM"),
         Flag("hash_type", description="Hash type.", metavar="HASH_TYPE"),
-        Flag(
-            "fingerprint", description="Hexadecimal fingerprint.", metavar="FINGERPRINT"
-        ),
+        Flag("fingerprint", description="Hexadecimal fingerprint.", metavar="FINGERPRINT"),
     ],
 )
 
@@ -2540,9 +2493,7 @@ def sshfp_remove(args) -> None:
         history.record_delete(path, sshfp, redoable=False)
         delete(path)
         cli_info(
-            "removed SSHFP record with fingerprint {} for {}".format(
-                sshfp["fingerprint"], hname
-            ),
+            "removed SSHFP record with fingerprint {} for {}".format(sshfp["fingerprint"], hname),
             print_msg=True,
         )
 
@@ -2698,9 +2649,7 @@ def ttl_set(args) -> None:
 
     # TTL sanity check
     if not is_valid_ttl(args.ttl):
-        cli_warning(
-            "invalid TTL value: {} (target host {})".format(args.ttl, info["name"])
-        )
+        cli_warning("invalid TTL value: {} (target host {})".format(args.ttl, info["name"]))
 
     old_data = {"ttl": info["ttl"] or ""}
     new_data = {"ttl": args.ttl if args.ttl != "default" else ""}

--- a/mreg_cli/label.py
+++ b/mreg_cli/label.py
@@ -2,7 +2,7 @@ from .cli import Flag, cli
 from .history import history
 from .log import cli_info, cli_warning
 from .outputmanager import OutputManager
-from .util import delete, format_table, get, get_list, patch, post
+from .util import add_formatted_table_for_output, delete, get, get_list, patch, post
 
 label = cli.add_command(
     prog="label",
@@ -38,7 +38,7 @@ def label_list(args) -> None:
     if not labels:
         cli_info("No labels", True)
         return
-    format_table(("Name", "Description"), ("name", "description"), labels)
+    add_formatted_table_for_output(("Name", "Description"), ("name", "description"), labels)
 
 
 label.add_command(prog="list", description="List labels", callback=label_list, flags=[])
@@ -83,7 +83,7 @@ def label_info(args) -> None:
     permlist = get_list("/api/v1/permissions/netgroupregex/", params={"labels__name": args.name})
     manager.add_line("Permissions with this label:")
     if permlist:
-        format_table(
+        add_formatted_table_for_output(
             ("IP range", "Group", "Reg.exp."),
             ("range", "group", "regex"),
             permlist,

--- a/mreg_cli/label.py
+++ b/mreg_cli/label.py
@@ -1,7 +1,8 @@
 from .cli import Flag, cli
 from .history import history
 from .log import cli_info, cli_warning
-from .util import delete, get, get_list, patch, post, print_table
+from .outputmanager import OutputManager
+from .util import delete, format_table, get, get_list, patch, post
 
 label = cli.add_command(
     prog="label",
@@ -9,9 +10,9 @@ label = cli.add_command(
 )
 
 
-def label_add(args):
+def label_add(args) -> None:
     if " " in args.name:
-        print("The label name can't contain spaces.")
+        OutputManager().add_line("The label name can't contain spaces.")
         return
     data = {"name": args.name, "description": args.description}
     path = "/api/v1/labels/"
@@ -32,18 +33,18 @@ label.add_command(
 )
 
 
-def label_list(args):
+def label_list(args) -> None:
     labels = get_list("/api/v1/labels/", params={"ordering": "name"})
     if not labels:
         cli_info("No labels", True)
         return
-    print_table(("Name", "Description"), ("name", "description"), labels)
+    format_table(("Name", "Description"), ("name", "description"), labels)
 
 
 label.add_command(prog="list", description="List labels", callback=label_list, flags=[])
 
 
-def label_delete(args):
+def label_delete(args) -> None:
     path = f"/api/v1/labels/name/{args.name}"
     history.record_delete(path, dict(), undoable=False)
     delete(path)
@@ -64,33 +65,32 @@ label.add_command(
 )
 
 
-def label_info(args):
+def label_info(args) -> None:
     path = f"/api/v1/labels/name/{args.name}"
     label = get(path).json()
-    print("Name:                  ", label["name"])
-    print("Description:           ", label["description"])
+    manager = OutputManager()
+    manager.add_line(f"Name:                  {label['name']}")
+    manager.add_line(f"Description:           {label['description']}")
 
     rolelist = get_list("/api/v1/hostpolicy/roles/", params={"labels__name": args.name})
-    print("Roles with this label: ")
+    manager.add_line("Roles with this label: ")
     if rolelist:
         for r in rolelist:
-            print("    " + r["name"])
+            manager.add_line("    " + r["name"])
     else:
-        print("    None")
+        manager.add_line("    None")
 
-    permlist = get_list(
-        "/api/v1/permissions/netgroupregex/", params={"labels__name": args.name}
-    )
-    print("Permissions with this label:")
+    permlist = get_list("/api/v1/permissions/netgroupregex/", params={"labels__name": args.name})
+    manager.add_line("Permissions with this label:")
     if permlist:
-        print_table(
+        format_table(
             ("IP range", "Group", "Reg.exp."),
             ("range", "group", "regex"),
             permlist,
             indent=4,
         )
     else:
-        print("    None")
+        manager.add_line("    None")
 
 
 label.add_command(
@@ -101,7 +101,7 @@ label.add_command(
 )
 
 
-def label_rename(args):
+def label_rename(args) -> None:
     path = f"/api/v1/labels/name/{args.oldname}"
     res = get(path, ok404=True)
     if not res:

--- a/mreg_cli/main.py
+++ b/mreg_cli/main.py
@@ -2,13 +2,13 @@ import argparse
 import configparser
 import getpass
 import logging
-import shlex
 
 from prompt_toolkit import HTML
 from prompt_toolkit.shortcuts import CompleteStyle, PromptSession
 
 from . import config, log, recorder, util
 from .cli import cli, source
+from .outputmanager import OutputManager
 
 logger = logging.getLogger(__name__)
 
@@ -176,8 +176,17 @@ def main():
                 # Don't record the "source" command itself.
                 if rec.is_recording() and not line.lstrip().startswith("source"):
                     rec.record_command(line)
+                # OutputManager is a singleton class so we
+                # need to clear it before each command.
+                output = OutputManager()
+                output.clear()
+                # Set the command that generated the output
+                # Also remove filters and other noise.
+                cmd = output.from_command(line)
                 # Run the command
-                cli.parse(shlex.split(line))
+                cli.parse(cmd)
+                # Render the output
+                output.render()
         except ValueError as e:
             print(e)
 

--- a/mreg_cli/outputmanager.py
+++ b/mreg_cli/outputmanager.py
@@ -1,0 +1,128 @@
+"""This module contains the output management for the mreg_cli package.
+
+This is a singleton class that manages the output for the CLI. It stores the
+output lines and formats them for display. It also manages the filter for the
+command.
+"""
+
+import re
+from typing import Any, List, Tuple
+
+
+class OutputManager:
+    """Manages and formats output for display.
+
+    This is a singleton class to retain context between calls. It is initiated
+    and cleared in the main function of the CLI, all other calls should only
+    add lines to the output via add_line(), add_formatted_line(), or
+    add_formatted_line_with_source(),
+    """
+
+    _instance = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super(OutputManager, cls).__new__(cls)
+            cls._instance._lines = []
+        return cls._instance
+
+    def clear(self) -> None:
+        """Clears the object."""
+        self._lines = []
+        self._filter_re = None
+        self._negate = False
+        self._command = None
+
+    def has_output(self) -> bool:
+        """Returns True if there is output to display."""
+        return len(self._lines) > 0
+
+    def from_command(self, command: str) -> str:
+        """Adds the command that generated the output.
+
+        :param command: The command to add.
+
+        :return: The cleaned command, devoid of filters and other noise.
+        """
+        self.command = command
+        self._command, self._filter_re, self._negate = self.get_filter()
+        return self._command
+
+    def add_line(self, line: str) -> None:
+        """Adds a line to the output.
+
+        :param line: The line to add.
+        """
+        self._lines.append(line)
+
+    def add_formatted_line(self, key: str, value: str, padding: int = 14) -> None:
+        """Formats and adds a key-value pair as a line.
+
+        :param key: The key or label.
+        :param value: The value.
+        :param padding: The padding for the key.
+        """
+        formatted_line = "{1:<{0}} {2}".format(padding, key, value)
+        self.add_line(formatted_line)
+
+    def add_formatted_line_with_source(
+        self, key: str, value: str, source: str = "", padding: int = 14
+    ) -> None:
+        """Formats and adds a key-value pair as a line with a source.
+
+        :param key: The key or label.
+        :param value: The value.
+        :param source: The source of the value.
+        :param padding: The padding for the key.
+        """
+        formatted_line = "{1:<{0}} {2:<{0}} {3}".format(padding, key, value, source)
+        self.add_line(formatted_line)
+
+    # We want to use re.Pattern as the type here, but python 3.6 and older re-modules
+    # don't have that type. So we use Any instead.
+    def get_filter(self) -> Tuple[str, Any, bool]:
+        """Returns the filter for the output.
+
+        :return: The filter and whether it is a negated filter.
+        """
+        command = self.command
+        negate = False
+        filter_re = None
+
+        if command and "|" in command:
+            command, filter_str = command.split("|", 1)
+            filter_str = filter_str.strip()
+
+            if filter_str.startswith("!"):
+                negate = True
+                filter_str = filter_str[1:].strip()
+
+            filter_re = re.compile(filter_str)
+
+        return (command, filter_re, negate)
+
+    def lines(self) -> List[str]:
+        """Return the lines of output.
+
+        Note that if the command is set, and it has a filter, the lines will
+        be filtered by the command's filter.
+        """
+        lines = self._lines
+        filter_re = self._filter_re
+
+        if filter_re is None:
+            return lines
+
+        if self._negate:
+            return [line for line in lines if not filter_re.search(line)]
+
+        return [line for line in lines if filter_re.search(line)]
+
+    def render(self) -> None:
+        """Prints the output to stdout."""
+        for line in self.lines():
+            print(line)
+
+    def __str__(self) -> str:
+        """Returns the formatted output as a single string."""
+        return "\n".join(self._lines)

--- a/mreg_cli/outputmanager.py
+++ b/mreg_cli/outputmanager.py
@@ -22,8 +22,8 @@ class OutputManager:
 
     def __new__(cls):
         if cls._instance is None:
-            cls._instance = super(OutputManager, cls).__new__(cls)
-            cls._instance._lines = []
+            cls._instance = super().__new__(cls)
+            cls._instance.clear()
         return cls._instance
 
     def clear(self) -> None:
@@ -32,6 +32,7 @@ class OutputManager:
         self._filter_re = None
         self._negate = False
         self._command = None
+        self.command = None
 
     def has_output(self) -> bool:
         """Returns True if there is output to display."""
@@ -44,8 +45,7 @@ class OutputManager:
 
         :return: The cleaned command, devoid of filters and other noise.
         """
-        self.command = command
-        self._command, self._filter_re, self._negate = self.get_filter()
+        self._command, self._filter_re, self._negate = self.get_filter(command)
         return self._command
 
     def add_line(self, line: str) -> None:
@@ -80,12 +80,14 @@ class OutputManager:
 
     # We want to use re.Pattern as the type here, but python 3.6 and older re-modules
     # don't have that type. So we use Any instead.
-    def get_filter(self) -> Tuple[str, Any, bool]:
+    def get_filter(self, command: str) -> Tuple[str, Any, bool]:
         """Returns the filter for the output.
+
+        :param command: The command to parse for the filter.
 
         :return: The filter and whether it is a negated filter.
         """
-        command = self.command
+        self.command = command
         negate = False
         filter_re = None
 

--- a/mreg_cli/permission.py
+++ b/mreg_cli/permission.py
@@ -6,12 +6,12 @@ from .log import cli_info, cli_warning
 from .util import (
     convert_wildcard_to_regex,
     delete,
+    format_table,
     get,
     get_list,
     is_valid_network,
     patch,
     post,
-    print_table,
 )
 
 ###################################
@@ -30,14 +30,13 @@ permission = cli.add_command(
 ##########################################
 
 
-def network_list(args):
+def network_list(args) -> None:
     """Lists permissions for networks."""
 
     # Replace with a.supernet_of(b) when python 3.7 is required
     def _supernet_of(a, b):
         return (
-            a.network_address <= b.network_address
-            and a.broadcast_address >= b.broadcast_address
+            a.network_address <= b.network_address and a.broadcast_address >= b.broadcast_address
         )
 
     params = {
@@ -78,7 +77,7 @@ def network_list(args):
 
     headers = ("Range", "Group", "Regex", "Labels")
     keys = ("range", "group", "regex", "labels")
-    print_table(headers, keys, data)
+    format_table(headers, keys, data)
 
 
 permission.add_command(
@@ -101,7 +100,7 @@ permission.add_command(
 ##########################################
 
 
-def network_add(args):
+def network_add(args) -> None:
     """Add permission for network."""
     if not is_valid_network(args.range):
         cli_warning(f"Invalid range: {args.range}")
@@ -135,7 +134,7 @@ permission.add_command(
 ##########################################
 
 
-def network_remove(args):
+def network_remove(args) -> None:
     """Remove permission for networks."""
     params = {
         "group": args.group,
@@ -174,7 +173,7 @@ permission.add_command(
 #################################################################
 
 
-def add_label_to_permission(args):
+def add_label_to_permission(args) -> None:
     """Add a label to a permission triplet."""
     # find the permission
     query = {
@@ -224,7 +223,7 @@ permission.add_command(
 )
 
 
-def remove_label_from_permission(args):
+def remove_label_from_permission(args) -> None:
     """Remove a label from a permission."""
     # find the permission
     query = {

--- a/mreg_cli/permission.py
+++ b/mreg_cli/permission.py
@@ -4,9 +4,9 @@ from .cli import Flag, cli
 from .history import history
 from .log import cli_info, cli_warning
 from .util import (
+    add_formatted_table_for_output,
     convert_wildcard_to_regex,
     delete,
-    format_table,
     get,
     get_list,
     is_valid_network,
@@ -77,7 +77,7 @@ def network_list(args) -> None:
 
     headers = ("Range", "Group", "Regex", "Labels")
     keys = ("range", "group", "regex", "labels")
-    format_table(headers, keys, data)
+    add_formatted_table_for_output(headers, keys, data)
 
 
 permission.add_command(

--- a/mreg_cli/policy.py
+++ b/mreg_cli/policy.py
@@ -4,9 +4,9 @@ from .history_log import format_history_items, get_history_items
 from .log import cli_error, cli_info, cli_warning
 from .outputmanager import OutputManager
 from .util import (
+    add_formatted_table_for_output,
     convert_wildcard_to_regex,
     delete,
-    format_table,
     get,
     get_list,
     host_info_by_name,
@@ -393,7 +393,9 @@ def list_roles(args) -> None:
             labels.append(labelnames[j])
         i["labels"] = ", ".join(labels)
         rows.append(i)
-    format_table(("Role", "Description", "Labels"), ("name", "description", "labels"), rows)
+    add_formatted_table_for_output(
+        ("Role", "Description", "Labels"), ("name", "description", "labels"), rows
+    )
 
 
 policy.add_command(

--- a/mreg_cli/util.py
+++ b/mreg_cli/util.py
@@ -747,12 +747,13 @@ def convert_wildcard_to_regex(
 ################################################################################
 
 
-def print_table(
+def format_table(
     headers: Sequence[str],
     keys: Sequence[str],
     data: List[Dict[str, Any]],
     indent: int = 0,
-) -> None:
+) -> str:
+    output = ""
     raw_format = " " * indent
     for key, header in zip(keys, headers):
         longest = len(header)
@@ -760,6 +761,8 @@ def print_table(
             longest = max(longest, len(str(d[key])))
         raw_format += "{:<%d}   " % longest
 
-    print(raw_format.format(*headers))
+    output += raw_format.format(*headers)
     for d in data:
-        print(raw_format.format(*[d[key] for key in keys]))
+        output += raw_format.format(*[d[key] for key in keys])
+
+    return output


### PR DESCRIPTION
- Command output may be filtered by `|` followed by whitespace and a regular expression (or a simple string).
- The regular expression is applied to each line of output, and only lines that match are displayed.
- The expression may be negated by using `|!` instead of `|`.
- Substitution is not supported.

Examples:

- `network list_used_addresses 172.16.20.0 | bl23-.*mu2[17]` will output only lines matching the regular expression.
- `network list_used_addresses 172.16.20.0 |! mu2[17]` will output only lines *not* matching the regular expression.

This applies all commands that output to the console, but it does *not* apply to errors, warnings, or informational messages. This allows filters to be used without concern for missing important information.

This is a cleaner Singleton-based implementation of #171.