### PR TITLE
fix: Handle unquoted pipes.

### DIFF
--- a/mreg_cli/cli.py
+++ b/mreg_cli/cli.py
@@ -139,11 +139,8 @@ class Command(Completer):
             # after it prints a help msg.
             self.last_errno = e.code
 
-        except CliWarning as e:
-            print_formatted_text(HTML(f"<i>{e}</i>"))
-
-        except CliError as e:
-            print_formatted_text(HTML(f"<ansired>{e}</ansired>"))
+        except (CliWarning, CliError) as exc:
+            exc.print_self()
 
         except CliExit:
             from sys import exit

--- a/mreg_cli/exceptions.py
+++ b/mreg_cli/exceptions.py
@@ -1,13 +1,46 @@
+"""This module contains custom exceptions for the CLI."""
+
+import sys
+
+from prompt_toolkit import print_formatted_text
+from prompt_toolkit.formatted_text import HTML
+
+
 class CliException(Exception):
-    pass
+    """Base exception class for the CLI."""
+
+    def formatted_exception(self) -> str:
+        """Returns a formatted string representation of the exception.
+
+        :returns: Formatted string for the exception message.
+        """
+        raise NotImplementedError("This method should be implemented by subclasses")
+
+    def print_self(self):
+        """Prints the exception with appropriate formatting."""
+        print_formatted_text(HTML(self.formatted_exception()), file=sys.stdout)
 
 
 class CliError(CliException):
-    pass
+    """Exception class for CLI errors."""
+
+    def formatted_exception(self) -> str:
+        """Formatted string with ANSI red color for the error message.
+
+        :returns: Formatted error message.
+        """
+        return f"<ansired>{super().__str__()}</ansired>"
 
 
 class CliWarning(CliException):
-    pass
+    """Exception class for CLI warnings."""
+
+    def formatted_exception(self) -> str:
+        """Formatted string with HTML italic tag for the warning message.
+
+        :returns: Formatted warning message.
+        """
+        return f"<i>{super().__str__()}</i>"
 
 
 class HostNotFoundWarning(CliWarning):

--- a/mreg_cli/main.py
+++ b/mreg_cli/main.py
@@ -8,6 +8,7 @@ from prompt_toolkit.shortcuts import CompleteStyle, PromptSession
 
 from . import config, log, recorder, util
 from .cli import cli, source
+from .exceptions import CliError, CliWarning
 from .outputmanager import OutputManager
 
 logger = logging.getLogger(__name__)
@@ -187,8 +188,10 @@ def main():
                 cli.parse(cmd)
                 # Render the output
                 output.render()
-        except ValueError as e:
-            print(e)
+        except (CliWarning, CliError) as exc:
+            exc.print_self()
+        except ValueError as exc:
+            print(exc)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
  - Prevents the CLI from dying when confronted with commands like `permission network_add 123.123.123.0/27 some-group-name ^[a-z0-9\-]+(\.(aa|bbb|ccc|sikkerhet?\.uio\.no$`
  - To allow for reuse of exception formatting, moves the formatting to the exceptions themselves rather than leaving the issue for the user.