### PR TITLE
Prevent dynamic dates from being included in test suite.

### DIFF
--- a/ci/testsuite
+++ b/ci/testsuite
@@ -132,7 +132,7 @@ policy add_atom fruit apple
 policy add_atom fruit orange
 policy info orange |! Created # Created dates will differ
 policy info fruit |! Created # Created dates will differ
-policy list_members fruit
+policy list_members fruit |! Created # Created dates will differ
 policy atom_delete apple  # Should fail because 'apple' is used in role 'fruit'
 policy remove_atom fruit apple
 policy atom_delete apple

--- a/ci/testsuite
+++ b/ci/testsuite
@@ -130,8 +130,8 @@ policy list_roles *
 policy list_roles fru
 policy add_atom fruit apple
 policy add_atom fruit orange
-policy info orange
-policy info fruit
+policy info orange |! Created # Created dates will differ
+policy info fruit |! Created # Created dates will differ
 policy list_members fruit
 policy atom_delete apple  # Should fail because 'apple' is used in role 'fruit'
 policy remove_atom fruit apple

--- a/ci/testsuite
+++ b/ci/testsuite
@@ -285,7 +285,7 @@ label add postit 'A label again'
 policy role_create myrole 'This is the description'
 policy label_add postit myrole
 policy list_roles *
-policy info myrole
+policy info myrole |! Created # Created dates will differ
 label info postit
 policy label_remove postit myrole
 policy role_delete myrole

--- a/ci/testsuite-result.json
+++ b/ci/testsuite-result.json
@@ -8504,7 +8504,7 @@
     "output": "Name:          fruit\nDescription:   5 a day\nAtom members:\n               apple\n               orange\nLabels:\n               None"
   },
   {
-    "command": "policy list_members fruit\n"
+    "command": "policy list_members fruit |! Created"
   },
   {
     "method": "GET",

--- a/ci/testsuite-result.json
+++ b/ci/testsuite-result.json
@@ -98,7 +98,7 @@
     }
   },
   {
-    "output": "Zone:               example.org\n        Nameservers:        hostname            TTL\n                            ns1.example.org     <not set>\nPrimary ns:         ns1.example.org\nEmail:              hostmaster@example.org\nSerialnumber:       3231206000\nRefresh:            10800\nRetry:              3600\nExpire:             1814400\nSOA TTL:            43200\nDefault TTL:        43200"
+    "output": "Zone:               example.org\n        Nameservers:        hostname            TTL\n                            ns1.example.org     <not set>\nPrimary ns:         ns1.example.org\nEmail:              hostmaster@example.org\nSerialnumber:       3231208000\nRefresh:            10800\nRetry:              3600\nExpire:             1814400\nSOA TTL:            43200\nDefault TTL:        43200"
   },
   {
     "command": "zone list -forward\n"
@@ -8431,7 +8431,7 @@
     "output": "OK: : Added atom 'orange' to role 'fruit'"
   },
   {
-    "command": "policy info orange\n"
+    "command": "policy info orange |! Created"
   },
   {
     "method": "GET",
@@ -8456,10 +8456,10 @@
     }
   },
   {
-    "output": "Name:          orange\nCreated:       2018-07-07\nDescription:   Round and orange\nRoles where this atom is a member:\n               fruit"
+    "output": "Name:          orange\nDescription:   Round and orange\nRoles where this atom is a member:\n               fruit"
   },
   {
-    "command": "policy info fruit\n"
+    "command": "policy info fruit |! Created"
   },
   {
     "method": "GET",
@@ -8501,7 +8501,7 @@
     }
   },
   {
-    "output": "Name:          fruit\nCreated:       2023-12-06\nDescription:   5 a day\nAtom members:\n               apple\n               orange\nLabels:\n               None"
+    "output": "Name:          fruit\nDescription:   5 a day\nAtom members:\n               apple\n               orange\nLabels:\n               None"
   },
   {
     "command": "policy list_members fruit\n"
@@ -15290,7 +15290,7 @@
     }
   },
   {
-    "output": "Name:          myrole\nCreated:       2023-12-06\nDescription:   This is the description\nAtom members:\n               None\nLabels:\n               postit"
+    "output": "Name:          myrole\nCreated:       2023-12-08\nDescription:   This is the description\nAtom members:\n               None\nLabels:\n               postit"
   },
   {
     "command": "label info postit\n"

--- a/ci/testsuite-result.json
+++ b/ci/testsuite-result.json
@@ -15243,7 +15243,7 @@
     "output": "Role     Description               Labels   \nmyrole   This is the description   postit   "
   },
   {
-    "command": "policy info myrole\n"
+    "command": "policy info myrole |! Created"
   },
   {
     "method": "GET",
@@ -15290,7 +15290,7 @@
     }
   },
   {
-    "output": "Name:          myrole\nCreated:       2023-12-08\nDescription:   This is the description\nAtom members:\n               None\nLabels:\n               postit"
+    "output": "Name:          myrole\nDescription:   This is the description\nAtom members:\n               None\nLabels:\n               postit"
   },
   {
     "command": "label info postit\n"


### PR DESCRIPTION
  - Info for policy and roles returns created date.
  - The simple solution is to filter those results out of the suite.

This will again break the current tests...