### PR TITLE
Remove zone serialnumber from test output.

### DIFF
--- a/ci/testsuite
+++ b/ci/testsuite
@@ -5,7 +5,7 @@
 #   - set/update ns, soa, ttl
 zone create example.org hostmaster@example.org ns1.example.org  # should require force because ns1 is unknown
 zone create example.org hostmaster@example.org ns1.example.org -force
-zone info example.org
+zone info example.org |! Serialnumber # Serialnumber includes the date: https://github.com/unioslo/mreg/blob/master/mreg/utils.py#L78
 zone list -forward
 zone set_ns example.org ns2.example.org  #  requires force because ns2 is unknown
 zone set_ns example.org ns2.example.org -force

--- a/ci/testsuite-result.json
+++ b/ci/testsuite-result.json
@@ -72,7 +72,7 @@
     "output": "OK: : created zone example.org"
   },
   {
-    "command": "zone info example.org\n"
+    "command": "zone info example.org |! Serialnumber"
   },
   {
     "method": "GET",
@@ -98,7 +98,7 @@
     }
   },
   {
-    "output": "Zone:               example.org\n        Nameservers:        hostname            TTL\n                            ns1.example.org     <not set>\nPrimary ns:         ns1.example.org\nEmail:              hostmaster@example.org\nSerialnumber:       3231208000\nRefresh:            10800\nRetry:              3600\nExpire:             1814400\nSOA TTL:            43200\nDefault TTL:        43200"
+    "output": "Zone:               example.org\n        Nameservers:        hostname            TTL\n                            ns1.example.org     <not set>\nPrimary ns:         ns1.example.org\nEmail:              hostmaster@example.org\nRefresh:            10800\nRetry:              3600\nExpire:             1814400\nSOA TTL:            43200\nDefault TTL:        43200"
   },
   {
     "command": "zone list -forward\n"


### PR DESCRIPTION
- When the serial number for zones is created (https://github.com/unioslo/mreg/blob/master/mreg/utils.py#L78) it is created with as a "10-digit serialnumber in 3YYMMDDXXX format".
  - It's hard to mock this as it comes from the server and it's not like we're in a pytest environment with the ci runs here.
  - We would need to say something like "run this entire cli session as if the date and time was as follows", and outside of modifying the cli itself (it's an insane thing to offer as an option), we'd have to modify the runtime environment (ie, the container), but that would break SSL and its friends...
  - So, in short, we remove Serialnumber from the test output...