### PR TITLE
fix: Use OutputManager for history_log.

### DIFF
--- a/mreg_cli/history_log.py
+++ b/mreg_cli/history_log.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List
 from dateutil.parser import parse
 
 from .log import cli_warning
+from .outputmanager import OutputManager
 from .util import get_list
 
 
@@ -39,7 +40,6 @@ def get_history_items(name: str, resource: str, data_relation: str = None) -> Li
 
 def format_history_items(ownname: str, items: Dict[str, Any]) -> List[str]:
     """Format history items for output."""
-    lines: str = []
 
     def _remove_unneded_keys(data: Dict[str, Any]):
         """Remove unneeded keys from data.
@@ -91,6 +91,4 @@ def format_history_items(ownname: str, items: Dict[str, Any]) -> List[str]:
         else:
             cli_warning(f"Unhandled history entry: {i}")
 
-        lines.append(f"{timestamp} [{i['user']}]: {model} {action}: {msg}")
-
-    return lines
+        OutputManager().add_line(f"{timestamp} [{i['user']}]: {model} {action}: {msg}")


### PR DESCRIPTION
  - A bug was reported internally where `host history` no longer returned anything.
  - This was bisected to f11035156016859cda3b319b5f9f42bd02b3f5e9 (https://github.com/unioslo/mreg-cli/pull/174).
  - format_-commands used to return data, they now need to queue output to OutputManager.