### PR TITLE
bug: Excluded addresses not counted correctly.

### DIFF
--- a/ci/testsuite-result.json
+++ b/ci/testsuite-result.json
@@ -10076,7 +10076,7 @@
       "                         10.0.1.2",
       "                         10.0.1.3",
       "                         10.0.1.255 (broadcast)",
-      "Excluded ranges:         10 ipaddresses",
+      "Excluded ranges:         11 ipaddresses",
       "                         10.0.1.20 -> 10.0.1.30",
       "Used addresses:          1",
       "Unused addresses:        239 (excluding reserved adr.)"
@@ -11211,7 +11211,7 @@
       "                         2001:db8::1",
       "                         2001:db8::2",
       "                         2001:db8::3",
-      "Excluded ranges:         16 ipaddresses",
+      "Excluded ranges:         17 ipaddresses",
       "                         2001:db8::20 -> 2001:db8::30",
       "Used addresses:          1",
       "Unused addresses:        18446744073709551594 (excluding reserved adr.)"

--- a/mreg_cli/network.py
+++ b/mreg_cli/network.py
@@ -76,9 +76,7 @@ def format_network_excluded_ranges(info: Dict[str, Any], padding: int = 25) -> N
     for i in info:
         start_ip = ipaddress.ip_address(i["start_ip"])
         end_ip = ipaddress.ip_address(i["end_ip"])
-        count += int(end_ip) - int(start_ip)
-        if end_ip == start_ip:
-            count += 1
+        count += int(end_ip) - int(start_ip) + 1
     manager = OutputManager()
     manager.add_line("{1:<{0}}{2} ipaddresses".format(padding, "Excluded ranges:", count))
     for i in info:


### PR DESCRIPTION
- Always add one to the count of excluded IPs to include the last IP in the range

Fixes #196