### PR TITLE
Prevent group history from iterating over None.

### DIFF
--- a/mreg_cli/group.py
+++ b/mreg_cli/group.py
@@ -229,10 +229,8 @@ def _history(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name)
     """
-    manager = OutputManager()
     items = get_history_items(args.name, "group", data_relation="groups")
-    for line in format_history_items(args.name, items):
-        manager.add_line(line)
+    format_history_items(args.name, items)
 
 
 group.add_command(


### PR DESCRIPTION
- format_history_items now uses OutputManager internally, and returns nothing.