### PR TITLE
Allow assoc of a MAC with 1 IPv4 + 1 IPv6 on the same VLAN by supplying hostname

### DIFF
--- a/ci/testsuite
+++ b/ci/testsuite
@@ -173,7 +173,7 @@ permission network_remove 10.0.0.0/24 somegroup "[abc]+.uio.no"
 
 ##### Tests: DHCP
 #   - associate / disassociate ip with mac address
-network create -network 10.0.0.0/24 -desc foo
+network create -network 10.0.0.0/24 -desc foo -vlan 1234
 host add foo
 host a_add foo 10.0.0.5
 dhcp assoc 1.2.3.4 aa:bb:cc:dd:ee:ff  # doesn't work, because ip addr doesn't exist
@@ -186,8 +186,24 @@ dhcp disassoc foo
 dhcp disassoc meh   # host not found
 host a_remove foo 10.0.0.5
 dhcp assoc foo aa:bb:cc:dd:ee:ff # doesn't work, because the host doesn't have any ip addresses
-host remove foo
+
+# Test handling of multiple IPs on a host
+host a_add foo 10.0.0.5
+host a_add foo 10.0.0.6 -f
+dhcp assoc foo aa:bb:cc:dd:ee:ff # should fail, two IPs of same type
+host a_remove foo 10.0.0.6
+network create -network 2001:db8::/64 -desc "foo_ipv6" -vlan 1234
+network create -network 2001:db9::/64 -desc "notfoo_ipv6" -vlan 1235
+host aaaa_add foo 2001:db9::5 -f
+dhcp assoc foo aa:bb:cc:dd:ee:ff # should fail, the host has two IPs of different types on different VLANs.
+host aaaa_remove foo 2001:db9::5
+host aaaa_add foo 2001:db8::5 -f
+dhcp assoc foo aa:bb:cc:dd:ee:ff # should work, the host now has two IPs of different types on the same VLAN.
+
+host remove foo -f
 network remove 10.0.0.0/24 -f
+network remove 2001:db8::/64 -f
+network remove 2001:db9::/64 -f
 
 
 ##### Tests: host

--- a/ci/testsuite-result.json
+++ b/ci/testsuite-result.json
@@ -10423,10 +10423,10 @@
     "warning": [],
     "error": [],
     "output": [
-      "2024-01-19 07:52:52 [system-signals]: Txt create: txt = 'v=spf1 -all'",
-      "2024-01-19 07:52:52 [test]: Host create: name = 'somehost.example.org', contact = 'support@example.org'",
-      "2024-01-19 07:52:52 [test]: Ipaddress create: ipaddress = '10.0.1.4'",
-      "2024-01-19 07:52:52 [test]: Host update: contact: support@example.org -> new-support@example.org"
+      "2024-01-23 11:30:00 [system-signals]: Txt create: txt = 'v=spf1 -all'",
+      "2024-01-23 11:30:00 [test]: Host create: name = 'somehost.example.org', contact = 'support@example.org'",
+      "2024-01-23 11:30:00 [test]: Ipaddress create: ipaddress = '10.0.1.4'",
+      "2024-01-23 11:30:00 [test]: Host update: contact: support@example.org -> new-support@example.org"
     ],
     "api_requests": [
       {
@@ -10440,7 +10440,7 @@
           "previous": null,
           "results": [
             {
-              "timestamp": "2024-01-19T07:52:52.603073+01:00",
+              "timestamp": "2024-01-23T11:30:00.296065+01:00",
               "user": "system-signals",
               "resource": "host",
               "name": "somehost.example.org",
@@ -10452,7 +10452,7 @@
               }
             },
             {
-              "timestamp": "2024-01-19T07:52:52.607098+01:00",
+              "timestamp": "2024-01-23T11:30:00.300907+01:00",
               "user": "test",
               "resource": "host",
               "name": "somehost.example.org",
@@ -10462,7 +10462,7 @@
               "data": "{\"name\": \"somehost.example.org\", \"contact\": \"support@example.org\"}"
             },
             {
-              "timestamp": "2024-01-19T07:52:52.612085+01:00",
+              "timestamp": "2024-01-23T11:30:00.306110+01:00",
               "user": "test",
               "resource": "host",
               "name": "somehost.example.org",
@@ -10472,14 +10472,14 @@
               "data": "{\"ipaddress\": \"10.0.1.4\"}"
             },
             {
-              "timestamp": "2024-01-19T07:52:52.829508+01:00",
+              "timestamp": "2024-01-23T11:30:00.516985+01:00",
               "user": "test",
               "resource": "host",
               "name": "somehost.example.org",
               "model_id": 4,
               "model": "Host",
               "action": "update",
-              "data": "{\"current_data\": {\"id\": 4, \"ipaddresses\": [{\"id\": 3, \"macaddress\": \"\", \"created_at\": \"2024-01-19T07:52:52.611490+01:00\", \"updated_at\": \"2024-01-19T07:52:52.611499+01:00\", \"ipaddress\": \"10.0.1.4\", \"host\": 4}], \"cnames\": [], \"mxs\": [], \"txts\": [{\"id\": 4, \"created_at\": \"2024-01-19T07:52:52.602663+01:00\", \"updated_at\": \"2024-01-19T07:52:52.602671+01:00\", \"txt\": \"v=spf1 -all\", \"host\": 4}], \"ptr_overrides\": [], \"hinfo\": null, \"loc\": null, \"bacnetid\": null, \"created_at\": \"2024-01-19T07:52:52.601169+01:00\", \"updated_at\": \"2024-01-19T07:52:52.601177+01:00\", \"name\": \"somehost.example.org\", \"contact\": \"support@example.org\", \"ttl\": null, \"comment\": \"\", \"zone\": 1}, \"update\": {\"contact\": \"new-support@example.org\"}}"
+              "data": "{\"current_data\": {\"id\": 4, \"ipaddresses\": [{\"id\": 3, \"macaddress\": \"\", \"created_at\": \"2024-01-23T11:30:00.305587+01:00\", \"updated_at\": \"2024-01-23T11:30:00.305596+01:00\", \"ipaddress\": \"10.0.1.4\", \"host\": 4}], \"cnames\": [], \"mxs\": [], \"txts\": [{\"id\": 4, \"created_at\": \"2024-01-23T11:30:00.295418+01:00\", \"updated_at\": \"2024-01-23T11:30:00.295424+01:00\", \"txt\": \"v=spf1 -all\", \"host\": 4}], \"ptr_overrides\": [], \"hinfo\": null, \"loc\": null, \"bacnetid\": null, \"created_at\": \"2024-01-23T11:30:00.293959+01:00\", \"updated_at\": \"2024-01-23T11:30:00.293967+01:00\", \"name\": \"somehost.example.org\", \"contact\": \"support@example.org\", \"ttl\": null, \"comment\": \"\", \"zone\": 1}, \"update\": {\"contact\": \"new-support@example.org\"}}"
             }
           ]
         }
@@ -10495,7 +10495,7 @@
           "previous": null,
           "results": [
             {
-              "timestamp": "2024-01-19T07:52:52.603073+01:00",
+              "timestamp": "2024-01-23T11:30:00.296065+01:00",
               "user": "system-signals",
               "resource": "host",
               "name": "somehost.example.org",
@@ -10507,7 +10507,7 @@
               }
             },
             {
-              "timestamp": "2024-01-19T07:52:52.607098+01:00",
+              "timestamp": "2024-01-23T11:30:00.300907+01:00",
               "user": "test",
               "resource": "host",
               "name": "somehost.example.org",
@@ -10517,7 +10517,7 @@
               "data": "{\"name\": \"somehost.example.org\", \"contact\": \"support@example.org\"}"
             },
             {
-              "timestamp": "2024-01-19T07:52:52.612085+01:00",
+              "timestamp": "2024-01-23T11:30:00.306110+01:00",
               "user": "test",
               "resource": "host",
               "name": "somehost.example.org",
@@ -10527,14 +10527,14 @@
               "data": "{\"ipaddress\": \"10.0.1.4\"}"
             },
             {
-              "timestamp": "2024-01-19T07:52:52.829508+01:00",
+              "timestamp": "2024-01-23T11:30:00.516985+01:00",
               "user": "test",
               "resource": "host",
               "name": "somehost.example.org",
               "model_id": 4,
               "model": "Host",
               "action": "update",
-              "data": "{\"current_data\": {\"id\": 4, \"ipaddresses\": [{\"id\": 3, \"macaddress\": \"\", \"created_at\": \"2024-01-19T07:52:52.611490+01:00\", \"updated_at\": \"2024-01-19T07:52:52.611499+01:00\", \"ipaddress\": \"10.0.1.4\", \"host\": 4}], \"cnames\": [], \"mxs\": [], \"txts\": [{\"id\": 4, \"created_at\": \"2024-01-19T07:52:52.602663+01:00\", \"updated_at\": \"2024-01-19T07:52:52.602671+01:00\", \"txt\": \"v=spf1 -all\", \"host\": 4}], \"ptr_overrides\": [], \"hinfo\": null, \"loc\": null, \"bacnetid\": null, \"created_at\": \"2024-01-19T07:52:52.601169+01:00\", \"updated_at\": \"2024-01-19T07:52:52.601177+01:00\", \"name\": \"somehost.example.org\", \"contact\": \"support@example.org\", \"ttl\": null, \"comment\": \"\", \"zone\": 1}, \"update\": {\"contact\": \"new-support@example.org\"}}"
+              "data": "{\"current_data\": {\"id\": 4, \"ipaddresses\": [{\"id\": 3, \"macaddress\": \"\", \"created_at\": \"2024-01-23T11:30:00.305587+01:00\", \"updated_at\": \"2024-01-23T11:30:00.305596+01:00\", \"ipaddress\": \"10.0.1.4\", \"host\": 4}], \"cnames\": [], \"mxs\": [], \"txts\": [{\"id\": 4, \"created_at\": \"2024-01-23T11:30:00.295418+01:00\", \"updated_at\": \"2024-01-23T11:30:00.295424+01:00\", \"txt\": \"v=spf1 -all\", \"host\": 4}], \"ptr_overrides\": [], \"hinfo\": null, \"loc\": null, \"bacnetid\": null, \"created_at\": \"2024-01-23T11:30:00.293959+01:00\", \"updated_at\": \"2024-01-23T11:30:00.293967+01:00\", \"name\": \"somehost.example.org\", \"contact\": \"support@example.org\", \"ttl\": null, \"comment\": \"\", \"zone\": 1}, \"update\": {\"contact\": \"new-support@example.org\"}}"
             }
           ]
         }
@@ -12284,11 +12284,11 @@
     "warning": [],
     "error": [],
     "output": [
-      "2024-01-19 07:52:53 [test]: HostGroup create: name = 'mygroup', description = 'This describes the group'",
-      "2024-01-19 07:52:54 [test]: Host add: testhost1.example.org",
-      "2024-01-19 07:52:54 [test]: Host add: testhost2.example.org",
-      "2024-01-19 07:52:54 [test]: Group add: myself",
-      "2024-01-19 07:52:54 [test]: Host remove: testhost2.example.org"
+      "2024-01-23 11:30:01 [test]: HostGroup create: name = 'mygroup', description = 'This describes the group'",
+      "2024-01-23 11:30:01 [test]: Host add: testhost1.example.org",
+      "2024-01-23 11:30:01 [test]: Host add: testhost2.example.org",
+      "2024-01-23 11:30:01 [test]: Group add: myself",
+      "2024-01-23 11:30:01 [test]: Host remove: testhost2.example.org"
     ],
     "api_requests": [
       {
@@ -12302,7 +12302,7 @@
           "previous": null,
           "results": [
             {
-              "timestamp": "2024-01-19T07:52:53.961691+01:00",
+              "timestamp": "2024-01-23T11:30:01.624291+01:00",
               "user": "test",
               "resource": "group",
               "name": "mygroup",
@@ -12312,7 +12312,7 @@
               "data": "{\"name\": \"mygroup\", \"description\": \"This describes the group\"}"
             },
             {
-              "timestamp": "2024-01-19T07:52:54.141363+01:00",
+              "timestamp": "2024-01-23T11:30:01.804995+01:00",
               "user": "test",
               "resource": "group",
               "name": "mygroup",
@@ -12325,7 +12325,7 @@
               }
             },
             {
-              "timestamp": "2024-01-19T07:52:54.193994+01:00",
+              "timestamp": "2024-01-23T11:30:01.854552+01:00",
               "user": "test",
               "resource": "group",
               "name": "mygroup",
@@ -12338,7 +12338,7 @@
               }
             },
             {
-              "timestamp": "2024-01-19T07:52:54.226479+01:00",
+              "timestamp": "2024-01-23T11:30:01.891110+01:00",
               "user": "test",
               "resource": "group",
               "name": "mygroup",
@@ -12351,7 +12351,7 @@
               }
             },
             {
-              "timestamp": "2024-01-19T07:52:54.275794+01:00",
+              "timestamp": "2024-01-23T11:30:01.941636+01:00",
               "user": "test",
               "resource": "group",
               "name": "mygroup",
@@ -12377,7 +12377,7 @@
           "previous": null,
           "results": [
             {
-              "timestamp": "2024-01-19T07:52:53.961691+01:00",
+              "timestamp": "2024-01-23T11:30:01.624291+01:00",
               "user": "test",
               "resource": "group",
               "name": "mygroup",
@@ -12387,7 +12387,7 @@
               "data": "{\"name\": \"mygroup\", \"description\": \"This describes the group\"}"
             },
             {
-              "timestamp": "2024-01-19T07:52:54.141363+01:00",
+              "timestamp": "2024-01-23T11:30:01.804995+01:00",
               "user": "test",
               "resource": "group",
               "name": "mygroup",
@@ -12400,7 +12400,7 @@
               }
             },
             {
-              "timestamp": "2024-01-19T07:52:54.193994+01:00",
+              "timestamp": "2024-01-23T11:30:01.854552+01:00",
               "user": "test",
               "resource": "group",
               "name": "mygroup",
@@ -12413,7 +12413,7 @@
               }
             },
             {
-              "timestamp": "2024-01-19T07:52:54.226479+01:00",
+              "timestamp": "2024-01-23T11:30:01.891110+01:00",
               "user": "test",
               "resource": "group",
               "name": "mygroup",
@@ -12426,7 +12426,7 @@
               }
             },
             {
-              "timestamp": "2024-01-19T07:52:54.275794+01:00",
+              "timestamp": "2024-01-23T11:30:01.941636+01:00",
               "user": "test",
               "resource": "group",
               "name": "mygroup",
@@ -12784,15 +12784,15 @@
     "warning": [],
     "error": [],
     "output": [
-      "2024-01-19 07:52:53 [test]: HostGroup create: name = 'mygroup', description = 'This describes the group'",
-      "2024-01-19 07:52:54 [test]: Host add: testhost1.example.org",
-      "2024-01-19 07:52:54 [test]: Host add: testhost2.example.org",
-      "2024-01-19 07:52:54 [test]: Group add: myself",
-      "2024-01-19 07:52:54 [test]: Host remove: testhost2.example.org",
-      "2024-01-19 07:52:54 [test]: HostGroup add: yourgroup",
-      "2024-01-19 07:52:54 [test]: HostGroup remove: yourgroup",
-      "2024-01-19 07:52:54 [test]: Group add: anotherowner",
-      "2024-01-19 07:52:54 [test]: Group remove: myself"
+      "2024-01-23 11:30:01 [test]: HostGroup create: name = 'mygroup', description = 'This describes the group'",
+      "2024-01-23 11:30:01 [test]: Host add: testhost1.example.org",
+      "2024-01-23 11:30:01 [test]: Host add: testhost2.example.org",
+      "2024-01-23 11:30:01 [test]: Group add: myself",
+      "2024-01-23 11:30:01 [test]: Host remove: testhost2.example.org",
+      "2024-01-23 11:30:02 [test]: HostGroup add: yourgroup",
+      "2024-01-23 11:30:02 [test]: HostGroup remove: yourgroup",
+      "2024-01-23 11:30:02 [test]: Group add: anotherowner",
+      "2024-01-23 11:30:02 [test]: Group remove: myself"
     ],
     "api_requests": [
       {
@@ -12806,7 +12806,7 @@
           "previous": null,
           "results": [
             {
-              "timestamp": "2024-01-19T07:52:53.961691+01:00",
+              "timestamp": "2024-01-23T11:30:01.624291+01:00",
               "user": "test",
               "resource": "group",
               "name": "mygroup",
@@ -12816,7 +12816,7 @@
               "data": "{\"name\": \"mygroup\", \"description\": \"This describes the group\"}"
             },
             {
-              "timestamp": "2024-01-19T07:52:54.141363+01:00",
+              "timestamp": "2024-01-23T11:30:01.804995+01:00",
               "user": "test",
               "resource": "group",
               "name": "mygroup",
@@ -12829,7 +12829,7 @@
               }
             },
             {
-              "timestamp": "2024-01-19T07:52:54.193994+01:00",
+              "timestamp": "2024-01-23T11:30:01.854552+01:00",
               "user": "test",
               "resource": "group",
               "name": "mygroup",
@@ -12842,7 +12842,7 @@
               }
             },
             {
-              "timestamp": "2024-01-19T07:52:54.226479+01:00",
+              "timestamp": "2024-01-23T11:30:01.891110+01:00",
               "user": "test",
               "resource": "group",
               "name": "mygroup",
@@ -12855,7 +12855,7 @@
               }
             },
             {
-              "timestamp": "2024-01-19T07:52:54.275794+01:00",
+              "timestamp": "2024-01-23T11:30:01.941636+01:00",
               "user": "test",
               "resource": "group",
               "name": "mygroup",
@@ -12868,7 +12868,7 @@
               }
             },
             {
-              "timestamp": "2024-01-19T07:52:54.409832+01:00",
+              "timestamp": "2024-01-23T11:30:02.110333+01:00",
               "user": "test",
               "resource": "group",
               "name": "mygroup",
@@ -12881,7 +12881,7 @@
               }
             },
             {
-              "timestamp": "2024-01-19T07:52:54.459050+01:00",
+              "timestamp": "2024-01-23T11:30:02.160208+01:00",
               "user": "test",
               "resource": "group",
               "name": "mygroup",
@@ -12894,7 +12894,7 @@
               }
             },
             {
-              "timestamp": "2024-01-19T07:52:54.492491+01:00",
+              "timestamp": "2024-01-23T11:30:02.194806+01:00",
               "user": "test",
               "resource": "group",
               "name": "mygroup",
@@ -12907,7 +12907,7 @@
               }
             },
             {
-              "timestamp": "2024-01-19T07:52:54.525855+01:00",
+              "timestamp": "2024-01-23T11:30:02.226563+01:00",
               "user": "test",
               "resource": "group",
               "name": "mygroup",
@@ -12933,7 +12933,7 @@
           "previous": null,
           "results": [
             {
-              "timestamp": "2024-01-19T07:52:53.961691+01:00",
+              "timestamp": "2024-01-23T11:30:01.624291+01:00",
               "user": "test",
               "resource": "group",
               "name": "mygroup",
@@ -12943,7 +12943,7 @@
               "data": "{\"name\": \"mygroup\", \"description\": \"This describes the group\"}"
             },
             {
-              "timestamp": "2024-01-19T07:52:54.141363+01:00",
+              "timestamp": "2024-01-23T11:30:01.804995+01:00",
               "user": "test",
               "resource": "group",
               "name": "mygroup",
@@ -12956,7 +12956,7 @@
               }
             },
             {
-              "timestamp": "2024-01-19T07:52:54.193994+01:00",
+              "timestamp": "2024-01-23T11:30:01.854552+01:00",
               "user": "test",
               "resource": "group",
               "name": "mygroup",
@@ -12969,7 +12969,7 @@
               }
             },
             {
-              "timestamp": "2024-01-19T07:52:54.226479+01:00",
+              "timestamp": "2024-01-23T11:30:01.891110+01:00",
               "user": "test",
               "resource": "group",
               "name": "mygroup",
@@ -12982,7 +12982,7 @@
               }
             },
             {
-              "timestamp": "2024-01-19T07:52:54.275794+01:00",
+              "timestamp": "2024-01-23T11:30:01.941636+01:00",
               "user": "test",
               "resource": "group",
               "name": "mygroup",
@@ -12995,7 +12995,7 @@
               }
             },
             {
-              "timestamp": "2024-01-19T07:52:54.409832+01:00",
+              "timestamp": "2024-01-23T11:30:02.110333+01:00",
               "user": "test",
               "resource": "group",
               "name": "mygroup",
@@ -13008,7 +13008,7 @@
               }
             },
             {
-              "timestamp": "2024-01-19T07:52:54.459050+01:00",
+              "timestamp": "2024-01-23T11:30:02.160208+01:00",
               "user": "test",
               "resource": "group",
               "name": "mygroup",
@@ -13021,7 +13021,7 @@
               }
             },
             {
-              "timestamp": "2024-01-19T07:52:54.492491+01:00",
+              "timestamp": "2024-01-23T11:30:02.194806+01:00",
               "user": "test",
               "resource": "group",
               "name": "mygroup",
@@ -13034,7 +13034,7 @@
               }
             },
             {
-              "timestamp": "2024-01-19T07:52:54.525855+01:00",
+              "timestamp": "2024-01-23T11:30:02.226563+01:00",
               "user": "test",
               "resource": "group",
               "name": "mygroup",
@@ -14288,7 +14288,7 @@
     "error": [],
     "output": [
       "Name:          fruit",
-      "Created:       2024-01-19",
+      "Created:       2024-01-23",
       "Description:   5 a day",
       "Atom members:",
       "               apple",
@@ -14392,8 +14392,8 @@
     "warning": [],
     "error": [],
     "output": [
-      "2024-01-19 07:52:55 [test]: HostPolicyAtom create: description = 'Here's the description', name = 'apple'",
-      "2024-01-19 07:52:55 [test]: HostPolicyAtom add to: hostpolicy_role fruit"
+      "2024-01-23 11:30:02 [test]: HostPolicyAtom create: description = 'Here's the description', name = 'apple'",
+      "2024-01-23 11:30:03 [test]: HostPolicyAtom add to: hostpolicy_role fruit"
     ],
     "api_requests": [
       {
@@ -14407,7 +14407,7 @@
           "previous": null,
           "results": [
             {
-              "timestamp": "2024-01-19T07:52:55.216591+01:00",
+              "timestamp": "2024-01-23T11:30:02.976539+01:00",
               "user": "test",
               "resource": "hostpolicy_atom",
               "name": "apple",
@@ -14430,7 +14430,7 @@
           "previous": null,
           "results": [
             {
-              "timestamp": "2024-01-19T07:52:55.216591+01:00",
+              "timestamp": "2024-01-23T11:30:02.976539+01:00",
               "user": "test",
               "resource": "hostpolicy_atom",
               "name": "apple",
@@ -14453,7 +14453,7 @@
           "previous": null,
           "results": [
             {
-              "timestamp": "2024-01-19T07:52:55.407520+01:00",
+              "timestamp": "2024-01-23T11:30:03.192643+01:00",
               "user": "test",
               "resource": "hostpolicy_role",
               "name": "fruit",
@@ -14592,9 +14592,9 @@
     "warning": [],
     "error": [],
     "output": [
-      "2024-01-19 07:52:55 [test]: HostPolicyAtom create: description = 'Here's the description', name = 'apple'",
-      "2024-01-19 07:52:55 [test]: HostPolicyAtom add to: hostpolicy_role fruit",
-      "2024-01-19 07:52:55 [test]: HostPolicyAtom remove from: hostpolicy_role fruit"
+      "2024-01-23 11:30:02 [test]: HostPolicyAtom create: description = 'Here's the description', name = 'apple'",
+      "2024-01-23 11:30:03 [test]: HostPolicyAtom add to: hostpolicy_role fruit",
+      "2024-01-23 11:30:03 [test]: HostPolicyAtom remove from: hostpolicy_role fruit"
     ],
     "api_requests": [
       {
@@ -14608,7 +14608,7 @@
           "previous": null,
           "results": [
             {
-              "timestamp": "2024-01-19T07:52:55.216591+01:00",
+              "timestamp": "2024-01-23T11:30:02.976539+01:00",
               "user": "test",
               "resource": "hostpolicy_atom",
               "name": "apple",
@@ -14631,7 +14631,7 @@
           "previous": null,
           "results": [
             {
-              "timestamp": "2024-01-19T07:52:55.216591+01:00",
+              "timestamp": "2024-01-23T11:30:02.976539+01:00",
               "user": "test",
               "resource": "hostpolicy_atom",
               "name": "apple",
@@ -14654,7 +14654,7 @@
           "previous": null,
           "results": [
             {
-              "timestamp": "2024-01-19T07:52:55.407520+01:00",
+              "timestamp": "2024-01-23T11:30:03.192643+01:00",
               "user": "test",
               "resource": "hostpolicy_role",
               "name": "fruit",
@@ -14667,7 +14667,7 @@
               }
             },
             {
-              "timestamp": "2024-01-19T07:52:55.618731+01:00",
+              "timestamp": "2024-01-23T11:30:03.402442+01:00",
               "user": "test",
               "resource": "hostpolicy_role",
               "name": "fruit",
@@ -15516,13 +15516,13 @@
     "warning": [],
     "error": [],
     "output": [
-      "2024-01-19 07:52:55 [test]: HostPolicyRole create: description = '5 a day', name = 'fruit', labels = '[]'",
-      "2024-01-19 07:52:55 [test]: HostPolicyAtom add: apple",
-      "2024-01-19 07:52:55 [test]: HostPolicyAtom add: orange",
-      "2024-01-19 07:52:55 [test]: HostPolicyAtom remove: apple",
-      "2024-01-19 07:52:55 [test]: Host add: foo.example.org",
-      "2024-01-19 07:52:56 [test]: Host remove: foo.example.org",
-      "2024-01-19 07:52:56 [test]: HostPolicyAtom remove: tangerine"
+      "2024-01-23 11:30:03 [test]: HostPolicyRole create: description = '5 a day', name = 'fruit', labels = '[]'",
+      "2024-01-23 11:30:03 [test]: HostPolicyAtom add: apple",
+      "2024-01-23 11:30:03 [test]: HostPolicyAtom add: orange",
+      "2024-01-23 11:30:03 [test]: HostPolicyAtom remove: apple",
+      "2024-01-23 11:30:03 [test]: Host add: foo.example.org",
+      "2024-01-23 11:30:03 [test]: Host remove: foo.example.org",
+      "2024-01-23 11:30:03 [test]: HostPolicyAtom remove: tangerine"
     ],
     "api_requests": [
       {
@@ -15536,7 +15536,7 @@
           "previous": null,
           "results": [
             {
-              "timestamp": "2024-01-19T07:52:55.304769+01:00",
+              "timestamp": "2024-01-23T11:30:03.077421+01:00",
               "user": "test",
               "resource": "hostpolicy_role",
               "name": "fruit",
@@ -15546,7 +15546,7 @@
               "data": "{\"description\": \"5 a day\", \"name\": \"fruit\", \"labels\": []}"
             },
             {
-              "timestamp": "2024-01-19T07:52:55.407520+01:00",
+              "timestamp": "2024-01-23T11:30:03.192643+01:00",
               "user": "test",
               "resource": "hostpolicy_role",
               "name": "fruit",
@@ -15559,7 +15559,7 @@
               }
             },
             {
-              "timestamp": "2024-01-19T07:52:55.457739+01:00",
+              "timestamp": "2024-01-23T11:30:03.242962+01:00",
               "user": "test",
               "resource": "hostpolicy_role",
               "name": "fruit",
@@ -15572,7 +15572,7 @@
               }
             },
             {
-              "timestamp": "2024-01-19T07:52:55.618731+01:00",
+              "timestamp": "2024-01-23T11:30:03.402442+01:00",
               "user": "test",
               "resource": "hostpolicy_role",
               "name": "fruit",
@@ -15585,7 +15585,7 @@
               }
             },
             {
-              "timestamp": "2024-01-19T07:52:55.982189+01:00",
+              "timestamp": "2024-01-23T11:30:03.685499+01:00",
               "user": "test",
               "resource": "hostpolicy_role",
               "name": "fruit",
@@ -15598,7 +15598,7 @@
               }
             },
             {
-              "timestamp": "2024-01-19T07:52:56.158039+01:00",
+              "timestamp": "2024-01-23T11:30:03.783484+01:00",
               "user": "test",
               "resource": "hostpolicy_role",
               "name": "fruit",
@@ -15611,7 +15611,7 @@
               }
             },
             {
-              "timestamp": "2024-01-19T07:52:56.206994+01:00",
+              "timestamp": "2024-01-23T11:30:03.834689+01:00",
               "user": "test",
               "resource": "hostpolicy_role",
               "name": "fruit",
@@ -15637,7 +15637,7 @@
           "previous": null,
           "results": [
             {
-              "timestamp": "2024-01-19T07:52:55.304769+01:00",
+              "timestamp": "2024-01-23T11:30:03.077421+01:00",
               "user": "test",
               "resource": "hostpolicy_role",
               "name": "fruit",
@@ -15647,7 +15647,7 @@
               "data": "{\"description\": \"5 a day\", \"name\": \"fruit\", \"labels\": []}"
             },
             {
-              "timestamp": "2024-01-19T07:52:55.407520+01:00",
+              "timestamp": "2024-01-23T11:30:03.192643+01:00",
               "user": "test",
               "resource": "hostpolicy_role",
               "name": "fruit",
@@ -15660,7 +15660,7 @@
               }
             },
             {
-              "timestamp": "2024-01-19T07:52:55.457739+01:00",
+              "timestamp": "2024-01-23T11:30:03.242962+01:00",
               "user": "test",
               "resource": "hostpolicy_role",
               "name": "fruit",
@@ -15673,7 +15673,7 @@
               }
             },
             {
-              "timestamp": "2024-01-19T07:52:55.618731+01:00",
+              "timestamp": "2024-01-23T11:30:03.402442+01:00",
               "user": "test",
               "resource": "hostpolicy_role",
               "name": "fruit",
@@ -15686,7 +15686,7 @@
               }
             },
             {
-              "timestamp": "2024-01-19T07:52:55.982189+01:00",
+              "timestamp": "2024-01-23T11:30:03.685499+01:00",
               "user": "test",
               "resource": "hostpolicy_role",
               "name": "fruit",
@@ -15699,7 +15699,7 @@
               }
             },
             {
-              "timestamp": "2024-01-19T07:52:56.158039+01:00",
+              "timestamp": "2024-01-23T11:30:03.783484+01:00",
               "user": "test",
               "resource": "hostpolicy_role",
               "name": "fruit",
@@ -15712,7 +15712,7 @@
               }
             },
             {
-              "timestamp": "2024-01-19T07:52:56.206994+01:00",
+              "timestamp": "2024-01-23T11:30:03.834689+01:00",
               "user": "test",
               "resource": "hostpolicy_role",
               "name": "fruit",
@@ -16051,10 +16051,10 @@
     "time": null
   },
   {
-    "command": "network create -network 10.0.0.0/24 -desc foo",
+    "command": "network create -network 10.0.0.0/24 -desc foo -vlan 1234",
     "command_filter": null,
     "command_filter_negate": false,
-    "command_issued": "network create -network 10.0.0.0/24 -desc foo",
+    "command_issued": "network create -network 10.0.0.0/24 -desc foo -vlan 1234",
     "ok": [
       "OK: : created network 10.0.0.0/24"
     ],
@@ -16080,7 +16080,7 @@
         "data": {
           "network": "10.0.0.0/24",
           "description": "foo",
-          "vlan": null,
+          "vlan": "1234",
           "category": null,
           "location": null,
           "frozen": false
@@ -16199,7 +16199,7 @@
           "excluded_ranges": [],
           "network": "10.0.0.0/24",
           "description": "foo",
-          "vlan": null,
+          "vlan": 1234,
           "dns_delegated": false,
           "category": "",
           "location": "",
@@ -16700,10 +16700,889 @@
     "time": null
   },
   {
-    "command": "host remove foo",
+    "command": "host a_add foo 10.0.0.5",
     "command_filter": null,
     "command_filter_negate": false,
-    "command_issued": "host remove foo",
+    "command_issued": "host a_add foo 10.0.0.5",
+    "ok": [
+      "OK: : added ip 10.0.0.5 to foo.example.org"
+    ],
+    "warning": [],
+    "error": [],
+    "output": [],
+    "api_requests": [
+      {
+        "method": "GET",
+        "url": "/api/v1/hosts/?ipaddresses__ipaddress=10.0.0.5",
+        "data": {},
+        "status": 200,
+        "response": {
+          "count": 0,
+          "next": null,
+          "previous": null,
+          "results": []
+        }
+      },
+      {
+        "method": "GET",
+        "url": "/api/v1/networks/ip/10.0.0.5",
+        "data": {},
+        "status": 200,
+        "response": {
+          "excluded_ranges": [],
+          "network": "10.0.0.0/24",
+          "description": "foo",
+          "vlan": 1234,
+          "dns_delegated": false,
+          "category": "",
+          "location": "",
+          "frozen": false,
+          "reserved": 3
+        }
+      },
+      {
+        "method": "GET",
+        "url": "/api/v1/networks/10.0.0.0/24/reserved_list",
+        "data": {},
+        "status": 200,
+        "response": [
+          "10.0.0.0",
+          "10.0.0.1",
+          "10.0.0.2",
+          "10.0.0.3",
+          "10.0.0.255"
+        ]
+      },
+      {
+        "method": "GET",
+        "url": "/api/v1/hosts/foo.example.org",
+        "data": {},
+        "status": 200,
+        "response": {
+          "ipaddresses": [],
+          "cnames": [],
+          "mxs": [],
+          "txts": [
+            {
+              "txt": "v=spf1 -all",
+              "host": 13
+            }
+          ],
+          "ptr_overrides": [],
+          "hinfo": null,
+          "loc": null,
+          "bacnetid": null,
+          "name": "foo.example.org",
+          "contact": "",
+          "ttl": null,
+          "comment": "",
+          "zone": 1
+        }
+      },
+      {
+        "method": "POST",
+        "url": "/api/v1/ipaddresses/",
+        "data": {
+          "host": 13,
+          "ipaddress": "10.0.0.5"
+        },
+        "status": 201,
+        "response": {
+          "macaddress": "",
+          "ipaddress": "10.0.0.5",
+          "host": 13
+        }
+      }
+    ],
+    "time": null
+  },
+  {
+    "command": "host a_add foo 10.0.0.6 -f",
+    "command_filter": null,
+    "command_filter_negate": false,
+    "command_issued": "host a_add foo 10.0.0.6 -f",
+    "ok": [
+      "OK: : added ip 10.0.0.6 to foo.example.org"
+    ],
+    "warning": [],
+    "error": [],
+    "output": [],
+    "api_requests": [
+      {
+        "method": "GET",
+        "url": "/api/v1/hosts/?ipaddresses__ipaddress=10.0.0.6",
+        "data": {},
+        "status": 200,
+        "response": {
+          "count": 0,
+          "next": null,
+          "previous": null,
+          "results": []
+        }
+      },
+      {
+        "method": "GET",
+        "url": "/api/v1/networks/ip/10.0.0.6",
+        "data": {},
+        "status": 200,
+        "response": {
+          "excluded_ranges": [],
+          "network": "10.0.0.0/24",
+          "description": "foo",
+          "vlan": 1234,
+          "dns_delegated": false,
+          "category": "",
+          "location": "",
+          "frozen": false,
+          "reserved": 3
+        }
+      },
+      {
+        "method": "GET",
+        "url": "/api/v1/networks/10.0.0.0/24/reserved_list",
+        "data": {},
+        "status": 200,
+        "response": [
+          "10.0.0.0",
+          "10.0.0.1",
+          "10.0.0.2",
+          "10.0.0.3",
+          "10.0.0.255"
+        ]
+      },
+      {
+        "method": "GET",
+        "url": "/api/v1/hosts/foo.example.org",
+        "data": {},
+        "status": 200,
+        "response": {
+          "ipaddresses": [
+            {
+              "macaddress": "",
+              "ipaddress": "10.0.0.5",
+              "host": 13
+            }
+          ],
+          "cnames": [],
+          "mxs": [],
+          "txts": [
+            {
+              "txt": "v=spf1 -all",
+              "host": 13
+            }
+          ],
+          "ptr_overrides": [],
+          "hinfo": null,
+          "loc": null,
+          "bacnetid": null,
+          "name": "foo.example.org",
+          "contact": "",
+          "ttl": null,
+          "comment": "",
+          "zone": 1
+        }
+      },
+      {
+        "method": "POST",
+        "url": "/api/v1/ipaddresses/",
+        "data": {
+          "host": 13,
+          "ipaddress": "10.0.0.6"
+        },
+        "status": 201,
+        "response": {
+          "macaddress": "",
+          "ipaddress": "10.0.0.6",
+          "host": 13
+        }
+      }
+    ],
+    "time": null
+  },
+  {
+    "command": "dhcp assoc foo aa:bb:cc:dd:ee:ff",
+    "command_filter": null,
+    "command_filter_negate": false,
+    "command_issued": "dhcp assoc foo aa:bb:cc:dd:ee:ff # should fail, two IPs of same type",
+    "ok": [],
+    "warning": [
+      "WARNING: : foo has multiple addresses in the same address family. Please specify a specific address to use instead."
+    ],
+    "error": [],
+    "output": [],
+    "api_requests": [
+      {
+        "method": "GET",
+        "url": "/api/v1/hosts/foo.example.org",
+        "data": {},
+        "status": 200,
+        "response": {
+          "ipaddresses": [
+            {
+              "macaddress": "",
+              "ipaddress": "10.0.0.5",
+              "host": 13
+            },
+            {
+              "macaddress": "",
+              "ipaddress": "10.0.0.6",
+              "host": 13
+            }
+          ],
+          "cnames": [],
+          "mxs": [],
+          "txts": [
+            {
+              "txt": "v=spf1 -all",
+              "host": 13
+            }
+          ],
+          "ptr_overrides": [],
+          "hinfo": null,
+          "loc": null,
+          "bacnetid": null,
+          "name": "foo.example.org",
+          "contact": "",
+          "ttl": null,
+          "comment": "",
+          "zone": 1
+        }
+      }
+    ],
+    "time": null
+  },
+  {
+    "command": "host a_remove foo 10.0.0.6",
+    "command_filter": null,
+    "command_filter_negate": false,
+    "command_issued": "host a_remove foo 10.0.0.6",
+    "ok": [
+      "OK: : removed ip 10.0.0.6 from foo.example.org"
+    ],
+    "warning": [],
+    "error": [],
+    "output": [],
+    "api_requests": [
+      {
+        "method": "GET",
+        "url": "/api/v1/hosts/foo.example.org",
+        "data": {},
+        "status": 200,
+        "response": {
+          "ipaddresses": [
+            {
+              "macaddress": "",
+              "ipaddress": "10.0.0.5",
+              "host": 13
+            },
+            {
+              "macaddress": "",
+              "ipaddress": "10.0.0.6",
+              "host": 13
+            }
+          ],
+          "cnames": [],
+          "mxs": [],
+          "txts": [
+            {
+              "txt": "v=spf1 -all",
+              "host": 13
+            }
+          ],
+          "ptr_overrides": [],
+          "hinfo": null,
+          "loc": null,
+          "bacnetid": null,
+          "name": "foo.example.org",
+          "contact": "",
+          "ttl": null,
+          "comment": "",
+          "zone": 1
+        }
+      },
+      {
+        "method": "DELETE",
+        "url": "/api/v1/ipaddresses/8",
+        "data": {},
+        "status": 204
+      }
+    ],
+    "time": null
+  },
+  {
+    "command": "network create -network 2001:db8::/64 -desc \"foo_ipv6\" -vlan 1234",
+    "command_filter": null,
+    "command_filter_negate": false,
+    "command_issued": "network create -network 2001:db8::/64 -desc \"foo_ipv6\" -vlan 1234",
+    "ok": [
+      "OK: : created network 2001:db8::/64"
+    ],
+    "warning": [],
+    "error": [],
+    "output": [],
+    "api_requests": [
+      {
+        "method": "GET",
+        "url": "/api/v1/networks/",
+        "data": {},
+        "status": 200,
+        "response": {
+          "count": 1,
+          "next": null,
+          "previous": null,
+          "results": [
+            {
+              "excluded_ranges": [],
+              "network": "10.0.0.0/24",
+              "description": "foo",
+              "vlan": 1234,
+              "dns_delegated": false,
+              "category": "",
+              "location": "",
+              "frozen": false,
+              "reserved": 3
+            }
+          ]
+        }
+      },
+      {
+        "method": "POST",
+        "url": "/api/v1/networks/",
+        "data": {
+          "network": "2001:db8::/64",
+          "description": "foo_ipv6",
+          "vlan": "1234",
+          "category": null,
+          "location": null,
+          "frozen": false
+        },
+        "status": 201
+      }
+    ],
+    "time": null
+  },
+  {
+    "command": "network create -network 2001:db9::/64 -desc \"notfoo_ipv6\" -vlan 1235",
+    "command_filter": null,
+    "command_filter_negate": false,
+    "command_issued": "network create -network 2001:db9::/64 -desc \"notfoo_ipv6\" -vlan 1235",
+    "ok": [
+      "OK: : created network 2001:db9::/64"
+    ],
+    "warning": [],
+    "error": [],
+    "output": [],
+    "api_requests": [
+      {
+        "method": "GET",
+        "url": "/api/v1/networks/",
+        "data": {},
+        "status": 200,
+        "response": {
+          "count": 2,
+          "next": null,
+          "previous": null,
+          "results": [
+            {
+              "excluded_ranges": [],
+              "network": "10.0.0.0/24",
+              "description": "foo",
+              "vlan": 1234,
+              "dns_delegated": false,
+              "category": "",
+              "location": "",
+              "frozen": false,
+              "reserved": 3
+            },
+            {
+              "excluded_ranges": [],
+              "network": "2001:db8::/64",
+              "description": "foo_ipv6",
+              "vlan": 1234,
+              "dns_delegated": false,
+              "category": "",
+              "location": "",
+              "frozen": false,
+              "reserved": 3
+            }
+          ]
+        }
+      },
+      {
+        "method": "POST",
+        "url": "/api/v1/networks/",
+        "data": {
+          "network": "2001:db9::/64",
+          "description": "notfoo_ipv6",
+          "vlan": "1235",
+          "category": null,
+          "location": null,
+          "frozen": false
+        },
+        "status": 201
+      }
+    ],
+    "time": null
+  },
+  {
+    "command": "host aaaa_add foo 2001:db9::5 -f",
+    "command_filter": null,
+    "command_filter_negate": false,
+    "command_issued": "host aaaa_add foo 2001:db9::5 -f",
+    "ok": [
+      "OK: : added ip 2001:db9::5 to foo.example.org"
+    ],
+    "warning": [],
+    "error": [],
+    "output": [],
+    "api_requests": [
+      {
+        "method": "GET",
+        "url": "/api/v1/hosts/?ipaddresses__ipaddress=2001%3Adb9%3A%3A5",
+        "data": {},
+        "status": 200,
+        "response": {
+          "count": 0,
+          "next": null,
+          "previous": null,
+          "results": []
+        }
+      },
+      {
+        "method": "GET",
+        "url": "/api/v1/networks/ip/2001%3Adb9%3A%3A5",
+        "data": {},
+        "status": 200,
+        "response": {
+          "excluded_ranges": [],
+          "network": "2001:db9::/64",
+          "description": "notfoo_ipv6",
+          "vlan": 1235,
+          "dns_delegated": false,
+          "category": "",
+          "location": "",
+          "frozen": false,
+          "reserved": 3
+        }
+      },
+      {
+        "method": "GET",
+        "url": "/api/v1/networks/2001%3Adb9%3A%3A/64/reserved_list",
+        "data": {},
+        "status": 200,
+        "response": [
+          "2001:db9::",
+          "2001:db9::1",
+          "2001:db9::2",
+          "2001:db9::3"
+        ]
+      },
+      {
+        "method": "GET",
+        "url": "/api/v1/hosts/foo.example.org",
+        "data": {},
+        "status": 200,
+        "response": {
+          "ipaddresses": [
+            {
+              "macaddress": "",
+              "ipaddress": "10.0.0.5",
+              "host": 13
+            }
+          ],
+          "cnames": [],
+          "mxs": [],
+          "txts": [
+            {
+              "txt": "v=spf1 -all",
+              "host": 13
+            }
+          ],
+          "ptr_overrides": [],
+          "hinfo": null,
+          "loc": null,
+          "bacnetid": null,
+          "name": "foo.example.org",
+          "contact": "",
+          "ttl": null,
+          "comment": "",
+          "zone": 1
+        }
+      },
+      {
+        "method": "POST",
+        "url": "/api/v1/ipaddresses/",
+        "data": {
+          "host": 13,
+          "ipaddress": "2001:db9::5"
+        },
+        "status": 201,
+        "response": {
+          "macaddress": "",
+          "ipaddress": "2001:db9::5",
+          "host": 13
+        }
+      }
+    ],
+    "time": null
+  },
+  {
+    "command": "dhcp assoc foo aa:bb:cc:dd:ee:ff",
+    "command_filter": null,
+    "command_filter_negate": false,
+    "command_issued": "dhcp assoc foo aa:bb:cc:dd:ee:ff # should fail, the host has two IPs of different types on different VLANs.",
+    "ok": [],
+    "warning": [
+      "WARNING: : foo.example.org has one IPv4 and one IPv6 address, but they are on different VLANs. Please specify a specific address to use instead."
+    ],
+    "error": [],
+    "output": [],
+    "api_requests": [
+      {
+        "method": "GET",
+        "url": "/api/v1/hosts/foo.example.org",
+        "data": {},
+        "status": 200,
+        "response": {
+          "ipaddresses": [
+            {
+              "macaddress": "",
+              "ipaddress": "10.0.0.5",
+              "host": 13
+            },
+            {
+              "macaddress": "",
+              "ipaddress": "2001:db9::5",
+              "host": 13
+            }
+          ],
+          "cnames": [],
+          "mxs": [],
+          "txts": [
+            {
+              "txt": "v=spf1 -all",
+              "host": 13
+            }
+          ],
+          "ptr_overrides": [],
+          "hinfo": null,
+          "loc": null,
+          "bacnetid": null,
+          "name": "foo.example.org",
+          "contact": "",
+          "ttl": null,
+          "comment": "",
+          "zone": 1
+        }
+      },
+      {
+        "method": "GET",
+        "url": "/api/v1/networks/ip/10.0.0.5",
+        "data": {},
+        "status": 200,
+        "response": {
+          "excluded_ranges": [],
+          "network": "10.0.0.0/24",
+          "description": "foo",
+          "vlan": 1234,
+          "dns_delegated": false,
+          "category": "",
+          "location": "",
+          "frozen": false,
+          "reserved": 3
+        }
+      },
+      {
+        "method": "GET",
+        "url": "/api/v1/networks/ip/2001%3Adb9%3A%3A5",
+        "data": {},
+        "status": 200,
+        "response": {
+          "excluded_ranges": [],
+          "network": "2001:db9::/64",
+          "description": "notfoo_ipv6",
+          "vlan": 1235,
+          "dns_delegated": false,
+          "category": "",
+          "location": "",
+          "frozen": false,
+          "reserved": 3
+        }
+      }
+    ],
+    "time": null
+  },
+  {
+    "command": "host aaaa_remove foo 2001:db9::5",
+    "command_filter": null,
+    "command_filter_negate": false,
+    "command_issued": "host aaaa_remove foo 2001:db9::5",
+    "ok": [
+      "OK: : removed ip 2001:db9::5 from foo.example.org"
+    ],
+    "warning": [],
+    "error": [],
+    "output": [],
+    "api_requests": [
+      {
+        "method": "GET",
+        "url": "/api/v1/hosts/foo.example.org",
+        "data": {},
+        "status": 200,
+        "response": {
+          "ipaddresses": [
+            {
+              "macaddress": "",
+              "ipaddress": "10.0.0.5",
+              "host": 13
+            },
+            {
+              "macaddress": "",
+              "ipaddress": "2001:db9::5",
+              "host": 13
+            }
+          ],
+          "cnames": [],
+          "mxs": [],
+          "txts": [
+            {
+              "txt": "v=spf1 -all",
+              "host": 13
+            }
+          ],
+          "ptr_overrides": [],
+          "hinfo": null,
+          "loc": null,
+          "bacnetid": null,
+          "name": "foo.example.org",
+          "contact": "",
+          "ttl": null,
+          "comment": "",
+          "zone": 1
+        }
+      },
+      {
+        "method": "DELETE",
+        "url": "/api/v1/ipaddresses/9",
+        "data": {},
+        "status": 204
+      }
+    ],
+    "time": null
+  },
+  {
+    "command": "host aaaa_add foo 2001:db8::5 -f",
+    "command_filter": null,
+    "command_filter_negate": false,
+    "command_issued": "host aaaa_add foo 2001:db8::5 -f",
+    "ok": [
+      "OK: : added ip 2001:db8::5 to foo.example.org"
+    ],
+    "warning": [],
+    "error": [],
+    "output": [],
+    "api_requests": [
+      {
+        "method": "GET",
+        "url": "/api/v1/hosts/?ipaddresses__ipaddress=2001%3Adb8%3A%3A5",
+        "data": {},
+        "status": 200,
+        "response": {
+          "count": 0,
+          "next": null,
+          "previous": null,
+          "results": []
+        }
+      },
+      {
+        "method": "GET",
+        "url": "/api/v1/networks/ip/2001%3Adb8%3A%3A5",
+        "data": {},
+        "status": 200,
+        "response": {
+          "excluded_ranges": [],
+          "network": "2001:db8::/64",
+          "description": "foo_ipv6",
+          "vlan": 1234,
+          "dns_delegated": false,
+          "category": "",
+          "location": "",
+          "frozen": false,
+          "reserved": 3
+        }
+      },
+      {
+        "method": "GET",
+        "url": "/api/v1/networks/2001%3Adb8%3A%3A/64/reserved_list",
+        "data": {},
+        "status": 200,
+        "response": [
+          "2001:db8::",
+          "2001:db8::1",
+          "2001:db8::2",
+          "2001:db8::3"
+        ]
+      },
+      {
+        "method": "GET",
+        "url": "/api/v1/hosts/foo.example.org",
+        "data": {},
+        "status": 200,
+        "response": {
+          "ipaddresses": [
+            {
+              "macaddress": "",
+              "ipaddress": "10.0.0.5",
+              "host": 13
+            }
+          ],
+          "cnames": [],
+          "mxs": [],
+          "txts": [
+            {
+              "txt": "v=spf1 -all",
+              "host": 13
+            }
+          ],
+          "ptr_overrides": [],
+          "hinfo": null,
+          "loc": null,
+          "bacnetid": null,
+          "name": "foo.example.org",
+          "contact": "",
+          "ttl": null,
+          "comment": "",
+          "zone": 1
+        }
+      },
+      {
+        "method": "POST",
+        "url": "/api/v1/ipaddresses/",
+        "data": {
+          "host": 13,
+          "ipaddress": "2001:db8::5"
+        },
+        "status": 201,
+        "response": {
+          "macaddress": "",
+          "ipaddress": "2001:db8::5",
+          "host": 13
+        }
+      }
+    ],
+    "time": null
+  },
+  {
+    "command": "dhcp assoc foo aa:bb:cc:dd:ee:ff",
+    "command_filter": null,
+    "command_filter_negate": false,
+    "command_issued": "dhcp assoc foo aa:bb:cc:dd:ee:ff # should work, the host now has two IPs of different types on the same VLAN.",
+    "ok": [
+      "OK: : associated mac address aa:bb:cc:dd:ee:ff with ip 10.0.0.5"
+    ],
+    "warning": [],
+    "error": [],
+    "output": [],
+    "api_requests": [
+      {
+        "method": "GET",
+        "url": "/api/v1/hosts/foo.example.org",
+        "data": {},
+        "status": 200,
+        "response": {
+          "ipaddresses": [
+            {
+              "macaddress": "",
+              "ipaddress": "10.0.0.5",
+              "host": 13
+            },
+            {
+              "macaddress": "",
+              "ipaddress": "2001:db8::5",
+              "host": 13
+            }
+          ],
+          "cnames": [],
+          "mxs": [],
+          "txts": [
+            {
+              "txt": "v=spf1 -all",
+              "host": 13
+            }
+          ],
+          "ptr_overrides": [],
+          "hinfo": null,
+          "loc": null,
+          "bacnetid": null,
+          "name": "foo.example.org",
+          "contact": "",
+          "ttl": null,
+          "comment": "",
+          "zone": 1
+        }
+      },
+      {
+        "method": "GET",
+        "url": "/api/v1/networks/ip/10.0.0.5",
+        "data": {},
+        "status": 200,
+        "response": {
+          "excluded_ranges": [],
+          "network": "10.0.0.0/24",
+          "description": "foo",
+          "vlan": 1234,
+          "dns_delegated": false,
+          "category": "",
+          "location": "",
+          "frozen": false,
+          "reserved": 3
+        }
+      },
+      {
+        "method": "GET",
+        "url": "/api/v1/networks/ip/2001%3Adb8%3A%3A5",
+        "data": {},
+        "status": 200,
+        "response": {
+          "excluded_ranges": [],
+          "network": "2001:db8::/64",
+          "description": "foo_ipv6",
+          "vlan": 1234,
+          "dns_delegated": false,
+          "category": "",
+          "location": "",
+          "frozen": false,
+          "reserved": 3
+        }
+      },
+      {
+        "method": "GET",
+        "url": "/api/v1/ipaddresses/?macaddress=aa%3Abb%3Acc%3Add%3Aee%3Aff&ordering=ipaddress",
+        "data": {},
+        "status": 200,
+        "response": {
+          "count": 0,
+          "next": null,
+          "previous": null,
+          "results": []
+        }
+      },
+      {
+        "method": "PATCH",
+        "url": "/api/v1/ipaddresses/7",
+        "data": {
+          "macaddress": "aa:bb:cc:dd:ee:ff"
+        },
+        "status": 204
+      }
+    ],
+    "time": null
+  },
+  {
+    "command": "host remove foo -f",
+    "command_filter": null,
+    "command_filter_negate": false,
+    "command_issued": "host remove foo -f",
     "ok": [
       "OK: : removed foo.example.org"
     ],
@@ -16717,7 +17596,18 @@
         "data": {},
         "status": 200,
         "response": {
-          "ipaddresses": [],
+          "ipaddresses": [
+            {
+              "macaddress": "aa:bb:cc:dd:ee:ff",
+              "ipaddress": "10.0.0.5",
+              "host": 13
+            },
+            {
+              "macaddress": "",
+              "ipaddress": "2001:db8::5",
+              "host": 13
+            }
+          ],
           "cnames": [],
           "mxs": [],
           "txts": [
@@ -16792,6 +17682,62 @@
       {
         "method": "DELETE",
         "url": "/api/v1/networks/10.0.0.0/24",
+        "data": {},
+        "status": 204
+      }
+    ],
+    "time": null
+  },
+  {
+    "command": "network remove 2001:db8::/64 -f",
+    "command_filter": null,
+    "command_filter_negate": false,
+    "command_issued": "network remove 2001:db8::/64 -f",
+    "ok": [
+      "OK: : removed network 2001:db8::/64"
+    ],
+    "warning": [],
+    "error": [],
+    "output": [],
+    "api_requests": [
+      {
+        "method": "GET",
+        "url": "/api/v1/networks/2001%3Adb8%3A%3A/64/used_list",
+        "data": {},
+        "status": 200,
+        "response": []
+      },
+      {
+        "method": "DELETE",
+        "url": "/api/v1/networks/2001%3Adb8%3A%3A/64",
+        "data": {},
+        "status": 204
+      }
+    ],
+    "time": null
+  },
+  {
+    "command": "network remove 2001:db9::/64 -f",
+    "command_filter": null,
+    "command_filter_negate": false,
+    "command_issued": "network remove 2001:db9::/64 -f",
+    "ok": [
+      "OK: : removed network 2001:db9::/64"
+    ],
+    "warning": [],
+    "error": [],
+    "output": [],
+    "api_requests": [
+      {
+        "method": "GET",
+        "url": "/api/v1/networks/2001%3Adb9%3A%3A/64/used_list",
+        "data": {},
+        "status": 200,
+        "response": []
+      },
+      {
+        "method": "DELETE",
+        "url": "/api/v1/networks/2001%3Adb9%3A%3A/64",
         "data": {},
         "status": 204
       }
@@ -17052,7 +17998,7 @@
       },
       {
         "method": "PATCH",
-        "url": "/api/v1/ipaddresses/7",
+        "url": "/api/v1/ipaddresses/11",
         "data": {
           "macaddress": "11:22:33:aa:bb:cc"
         },
@@ -18176,7 +19122,7 @@
       },
       {
         "method": "PATCH",
-        "url": "/api/v1/ipaddresses/8",
+        "url": "/api/v1/ipaddresses/12",
         "data": {
           "ipaddress": "10.0.0.14"
         },
@@ -18283,7 +19229,7 @@
       },
       {
         "method": "PATCH",
-        "url": "/api/v1/ipaddresses/9",
+        "url": "/api/v1/ipaddresses/13",
         "data": {
           "ipaddress": "10.0.0.15"
         },
@@ -18507,7 +19453,7 @@
       },
       {
         "method": "PATCH",
-        "url": "/api/v1/ipaddresses/7",
+        "url": "/api/v1/ipaddresses/11",
         "data": {
           "host": 15
         },
@@ -19045,7 +19991,7 @@
       },
       {
         "method": "PATCH",
-        "url": "/api/v1/ipaddresses/10",
+        "url": "/api/v1/ipaddresses/14",
         "data": {
           "ipaddress": "2001:db8::13"
         },
@@ -19156,7 +20102,7 @@
       },
       {
         "method": "PATCH",
-        "url": "/api/v1/ipaddresses/11",
+        "url": "/api/v1/ipaddresses/15",
         "data": {
           "ipaddress": "2001:db8::14"
         },
@@ -19226,7 +20172,7 @@
       },
       {
         "method": "DELETE",
-        "url": "/api/v1/ipaddresses/10",
+        "url": "/api/v1/ipaddresses/14",
         "data": {},
         "status": 204
       }
@@ -19321,7 +20267,7 @@
       },
       {
         "method": "PATCH",
-        "url": "/api/v1/ipaddresses/11",
+        "url": "/api/v1/ipaddresses/15",
         "data": {
           "host": 15
         },
@@ -22851,7 +23797,7 @@
     "error": [],
     "output": [
       "Name:          myrole",
-      "Created:       2024-01-19",
+      "Created:       2024-01-23",
       "Description:   This is the description",
       "Atom members:",
       "               None",

--- a/mreg_cli/utilities/host.py
+++ b/mreg_cli/utilities/host.py
@@ -102,7 +102,7 @@ def get_unique_ip_by_name_or_ip(arg: str) -> Dict[str, Any]:
 
         net1 = get_network_by_ip(ip1)
         net2 = get_network_by_ip(ip2)
-        if net1["vlan"] == net2["vlan"]:
+        if net1["vlan"] and net2["vlan"] and net1["vlan"] == net2["vlan"]:
             # In the case of the host having IPv4 and IPv6 on the same VLAN, we return the IPv4
             # address. This works "okay" for now as its the only DUID type they can share.
             if is_valid_ipv4(ip1):

--- a/mreg_cli/utilities/host.py
+++ b/mreg_cli/utilities/host.py
@@ -62,12 +62,16 @@ def get_unique_ip_by_name_or_ip(arg: str) -> Dict[str, Any]:
     """Get A/AAAA record by either ip address or host name.
 
     This will fail if:
-        - The host has multiple A/AAAA records.
+        - The host has multiple A/AAAA records and they are on different VLANs.
         - The host has no A/AAAA records.
         - The IP is used by multiple hosts.
         - The IP or host doesn't exist.
 
+    If the host has one A and AAAA record on the same VLAN, the IPv4 address is returned.
+
     :param arg: ip address or host name (as a string)
+
+    :return: A dict with the ip address information.
     """
     if is_valid_ip(arg):
         path = "/api/v1/ipaddresses/"
@@ -79,23 +83,53 @@ def get_unique_ip_by_name_or_ip(arg: str) -> Dict[str, Any]:
             cli_warning(f"ip {arg} doesn't exist.")
         elif len(ips) > 1:
             cli_warning("ip {} is in use by {} hosts".format(arg, len(ips)))
-        ip = ips[0]
-    else:
-        info = host_info_by_name(arg)
-        if len(info["ipaddresses"]) > 1:
+        return ips[0]
+
+    # We were not given an IP, so resolve as a host.
+    info = host_info_by_name(arg)
+    if len(info["ipaddresses"]) == 2:
+        # one of these may be is_valid_ip4 and the other is_valid_ip6.
+        ip1 = info["ipaddresses"][0]["ipaddress"]
+        ip2 = info["ipaddresses"][1]["ipaddress"]
+
+        if not (is_valid_ipv4(ip1) and is_valid_ipv6(ip2)) or (
+            is_valid_ipv6(ip1) and is_valid_ipv4(ip2)
+        ):
             cli_warning(
-                "{} has {} ip addresses, please enter one of the addresses instead.".format(
-                    info["name"],
-                    len(info["ipaddresses"]),
+                "{} has multiple addresses in the same address family.".format(arg)
+                + " Please specify a specific address to use instead."
+            )
+
+        net1 = get_network_by_ip(ip1)
+        net2 = get_network_by_ip(ip2)
+        if net1["vlan"] == net2["vlan"]:
+            # In the case of the host having IPv4 and IPv6 on the same VLAN, we return the IPv4
+            # address. This works "okay" for now as its the only DUID type they can share.
+            if is_valid_ipv4(ip1):
+                return info["ipaddresses"][0]
+            return info["ipaddresses"][1]
+        else:
+            cli_warning(
+                "{} has one IPv4 and one IPv6 address, but they are on different VLANs.".format(
+                    info["name"]
                 )
+                + " Please specify a specific address to use instead."
             )
-        if len(info["ipaddresses"]) == 0:
-            cli_warning(
-                "{} doesn't have any ip addresses.".format(arg),
-                raise_exception=True,
-                exception=CliWarning,
+
+    elif len(info["ipaddresses"]) > 1:
+        cli_warning(
+            "{} has {} ip addresses, please enter one of the addresses instead.".format(
+                info["name"],
+                len(info["ipaddresses"]),
             )
-        ip = info["ipaddresses"][0]
+        )
+    if len(info["ipaddresses"]) == 0:
+        cli_warning(
+            "{} doesn't have any ip addresses.".format(arg),
+            raise_exception=True,
+            exception=CliWarning,
+        )
+    ip = info["ipaddresses"][0]
     return ip
 
 


### PR DESCRIPTION
  - This assumes that the VLAN IDs map between IPv4 and IPv6 networks correctly.
  - We return the IPv4 address when asking for a unique IP for a host with both IPv4 and IPv6 adresses on the same VLAN.
  - We assign the MAC to the IPv4 address when being asked to assoc against a host with both IPv4 and IPv6 on the same VLAN.
  - From a DUID perspective, this is probably the sanest thing until mreg supports DHCPv6 in a more flexible way.

Fixes #141