### PR TITLE
Use corrolation_id for logging across commands.

### DIFF
--- a/mreg_cli/cli.py
+++ b/mreg_cli/cli.py
@@ -28,6 +28,7 @@ from mreg_cli.exceptions import CliError, CliWarning
 from mreg_cli.help_formatter import CustomHelpFormatter
 from mreg_cli.outputmanager import OutputManager
 from mreg_cli.types import CommandFunc, Flag
+from mreg_cli.utilities.api import create_and_set_corrolation_id
 from mreg_cli.utilities.api import logout as _force_logout
 
 if TYPE_CHECKING:
@@ -246,6 +247,10 @@ class Command(Completer):
         # Set the command that generated the output
         # Also remove filters and other noise.
         cmd = output.from_command(line)
+        # Create and set the corrolation id, using the cleaned command
+        # as the suffix. This is used to track the command in the logs
+        # on the server side.
+        create_and_set_corrolation_id(cmd)
         # Run the command
         cli.parse(cmd)
         # Render the output

--- a/mreg_cli/utilities/api.py
+++ b/mreg_cli/utilities/api.py
@@ -10,6 +10,7 @@ import os
 import sys
 from typing import TYPE_CHECKING, Any, Dict, List, NoReturn, Optional, Union, cast, overload
 from urllib.parse import urljoin
+from uuid import uuid4
 
 import requests
 
@@ -40,6 +41,27 @@ def error(msg: Union[str, Exception], code: int = os.EX_UNAVAILABLE) -> NoReturn
     """Print an error message and exits with the given code."""
     print(f"ERROR: {msg}", file=sys.stderr)
     sys.exit(code)
+
+
+def create_and_set_corrolation_id(suffix: str) -> str:
+    """Set currently active corrolation id.
+
+    This will take a suffix and append it to a generated UUIDv4 and set it as the corrolation id.
+
+    :param suffix: The suffix to use for the corrolation id.
+
+    :returns: The generated corrolation id.
+    """
+    suffix = suffix.replace(" ", "_")
+    corrolation_id = f"{uuid4()}-{suffix}"
+
+    session.headers.update({"X-Correlation-ID": corrolation_id})
+    return corrolation_id
+
+
+def set_headers(headers: Dict[str, str]) -> None:
+    """Set headers for the session."""
+    session.headers.update(headers)
 
 
 def set_file_permissions(f: str, mode: int) -> None:

--- a/mreg_cli/utilities/api.py
+++ b/mreg_cli/utilities/api.py
@@ -7,6 +7,7 @@ And this rule is promptly broken by importing from mreg_cli.outputmanager...
 import json
 import logging
 import os
+import re
 import sys
 from typing import TYPE_CHECKING, Any, Dict, List, NoReturn, Optional, Union, cast, overload
 from urllib.parse import urljoin
@@ -52,11 +53,11 @@ def create_and_set_corrolation_id(suffix: str) -> str:
 
     :returns: The generated corrolation id.
     """
-    suffix = suffix.replace(" ", "_")
-    corrolation_id = f"{uuid4()}-{suffix}"
+    suffix = re.sub(r"\s+", "_", suffix)
+    correlation_id = f"{uuid4()}-{suffix}"
 
-    session.headers.update({"X-Correlation-ID": corrolation_id})
-    return corrolation_id
+    session.headers.update({"X-Correlation-ID": correlation_id})
+    return correlation_id
 
 
 def set_file_permissions(f: str, mode: int) -> None:

--- a/mreg_cli/utilities/api.py
+++ b/mreg_cli/utilities/api.py
@@ -59,11 +59,6 @@ def create_and_set_corrolation_id(suffix: str) -> str:
     return corrolation_id
 
 
-def set_headers(headers: Dict[str, str]) -> None:
-    """Set headers for the session."""
-    session.headers.update(headers)
-
-
 def set_file_permissions(f: str, mode: int) -> None:
     """Set file permissions on a file."""
     try:


### PR DESCRIPTION
This PR sets the corrolation-id sent to the mreg server per command, and the mreg server then logs it like this (well, for console view, it's less pretty otherwise (see https://github.com/unioslo/mreg/pull/515) for more information.

In short, this ensures that multiple requests performed by the same command will have the same correlation-id set by reg-cli, and this id is an uuidv4 plus the command issued (where spaces are substituted for _).

````
2024-02-21T11:55:44.797346Z [info     ]  • request          request_id=eda...3cc method=GET remote_ip=127.0.0.1 proxy_ip= path=/api/v1/hosts/foo.bar.com request_size=0 content= correlation_id=515a1d8d-4511-4cd0-8eb8-b0f34a59e544-host_info_foo.bar.com lineno=111 filename=logging_http.py func_name=log_request
2024-02-21T11:55:44.925721Z [info     ]  • updated          request_id=eda...3cc model=ExpiringToken id=7d4...b0e _str=7d4...b0e correlation_id=515a1d8d-4511-4cd0-8eb8-b0f34a59e544-host_info_foo.bar.com lineno=448 filename=signals.py func_name=_log_object_event
2024-02-21T11:55:44.937297Z [warning  ]  • response         request_id=eda...3cc user=test method=GET status_code=404 status_label=Not Found path=/api/v1/hosts/foo.bar.com content={"detail":"Not found."} run_time_ms=140.77 correlation_id=515a1d8d-4511-4cd0-8eb8-b0f34a59e544-host_info_foo.bar.com lineno=156 filename=logging_http.py func_name=log_response
2024-02-21T11:55:44.945056Z [info     ]  • request          request_id=26f...45d method=GET remote_ip=127.0.0.1 proxy_ip= path=/api/v1/hosts/ request_size=0 content= correlation_id=515a1d8d-4511-4cd0-8eb8-b0f34a59e544-host_info_foo.bar.com lineno=111 filename=logging_http.py func_name=log_request
2024-02-21T11:55:45.025543Z [info     ]  • updated          request_id=26f...45d model=ExpiringToken id=7d4...b0e _str=7d4...b0e correlation_id=515a1d8d-4511-4cd0-8eb8-b0f34a59e544-host_info_foo.bar.com lineno=448 filename=signals.py func_name=_log_object_event
2024-02-21T11:55:45.037113Z [info     ]  • response         request_id=26f...45d user=test method=GET status_code=200 status_label=OK path=/api/v1/hosts/ content={"count":0,"next":null,"previous":null,"results":[]} run_time_ms=92.24 correlation_id=515a1d8d-4511-4cd0-8eb8-b0f34a59e544-host_info_foo.bar.com lineno=156 filename=logging_http.py func_name=log_response
````