### PR TITLE
Table model

### DIFF
--- a/mreg_cli/tables.py
+++ b/mreg_cli/tables.py
@@ -1,0 +1,37 @@
+from pydantic import BaseModel, ConfigDict
+
+
+class TableRow(BaseModel):
+    """Base class for table rows used by `OutputManager.print_formatted_table`.
+
+    The Header for each column is determined by the name of each field.
+    However, names can be overridden by specifying an attribute docstring
+    for the field _or_ using `Field(..., description="<header>")`.
+
+    Example:
+    -------
+    ```
+    class MyRow(TableRow):
+        foo: str # header: "Foo"
+        bar: str # header: "Bar Users"
+        \"\"\"Bar Users\"\"\"
+        baz: str = Field(..., description="Baz Users") # header: "Baz Users"
+    ```
+
+    """  # noqa: D301 # escaping double quotes
+
+    model_config = ConfigDict(use_attribute_docstrings=True)
+
+    # NOTE: ideally we guarantee identical order between `keys` and `headers` somehow
+    @classmethod
+    def keys(cls) -> list[str]:
+        """Return the keys of the model as a list."""
+        return list(cls.model_fields.keys())
+
+    @classmethod
+    def headers(cls) -> list[str]:
+        """Return the headers of the model as a list."""
+        headers: list[str] = []
+        for name, field in cls.model_fields.items():
+            headers.append(field.description or name.capitalize())
+        return headers


### PR DESCRIPTION
The idea is that we can guard a little more against human error when calling `OutputManager().add_formatted_table()`, as well as providing a minimum of type safety.

```py
from mreg_cli.tables import TableRow

class SomeTableRow(TableRow):
    hosts: str # header: Hosts
    stuff_to_add: str
    """Stuff to Add""" # Use attribute docstrings to specify custom headers
    other_thing: str = Field(..., description="Can also use field description to specify header")
    
rows = [
    SomeTableRow(
        hosts="foo.example.com",
        stuff_to_add="stuff",
        other_thing="thing",
    )
]

OutputManager.add_formatted_table(
    headers=SomeTableRow.headers(),
    keys=SomeTableRow.keys(),
    data=rows,
)
```
    