### PR TITLE
Use `Self` type annotation for `APIMixin`

### DIFF
--- a/mreg_cli/api/abstracts.py
+++ b/mreg_cli/api/abstracts.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from datetime import datetime
-from typing import Any, Generic, TypeVar, cast
+from typing import Any, Self, cast
 
 from pydantic import AliasChoices, BaseModel
 from pydantic.fields import FieldInfo
@@ -23,8 +23,6 @@ from mreg_cli.utilities.api import (
     patch,
     post,
 )
-
-BMT = TypeVar("BMT", bound="BaseModel")
 
 
 def get_field_aliases(field_info: FieldInfo) -> set[str]:
@@ -95,8 +93,16 @@ class FrozenModelWithTimestamps(FrozenModel):
         output_manager.add_line(f"{'Updated:':<{padding}}{self.updated_at:%c}")
 
 
-class APIMixin(Generic[BMT], ABC):
+class APIMixin(ABC):
     """A mixin for API-related methods."""
+
+    def __init_subclass__(cls) -> None:
+        """Ensure that the subclass inherits from BaseModel."""
+        super().__init_subclass__()
+        if BaseModel not in cls.__bases__:
+            raise TypeError(
+                f"{cls.__name__} must be applied on classes inheriting from BaseModel."
+            )
 
     def id_for_endpoint(self) -> int | str:
         """Return the appropriate id for the object for its endpoint.
@@ -122,7 +128,7 @@ class APIMixin(Generic[BMT], ABC):
         raise NotImplementedError("You must define an endpoint.")
 
     @classmethod
-    def get(cls, _id: int) -> BMT | None:
+    def get(cls, _id: int) -> Self | None:
         """Get an object.
 
         This function is at its base a wrapper around the get_by_id function,
@@ -134,7 +140,7 @@ class APIMixin(Generic[BMT], ABC):
         return cls.get_by_id(_id)
 
     @classmethod
-    def get_by_id(cls, _id: int) -> BMT | None:
+    def get_by_id(cls, _id: int) -> Self | None:
         """Get an object by its ID.
 
         Note that for Hosts, the ID is the name of the host.
@@ -157,10 +163,10 @@ class APIMixin(Generic[BMT], ABC):
         if not data:
             return None
 
-        return cast(BMT, cls(**data))
+        return cls(**data)
 
     @classmethod
-    def get_by_field(cls, field: str, value: str) -> BMT | None:
+    def get_by_field(cls, field: str, value: str) -> Self | None:
         """Get an object by a field.
 
         Note that some endpoints do not use the ID field for lookups. We do some
@@ -192,7 +198,7 @@ class APIMixin(Generic[BMT], ABC):
         if not data:
             return None
 
-        return cast(BMT, cls(**data))
+        return cls(**data)
 
     @classmethod
     def get_by_field_or_raise(
@@ -201,7 +207,7 @@ class APIMixin(Generic[BMT], ABC):
         value: str,
         exc_type: type[Exception] = CliError,
         exc_message: str | None = None,
-    ) -> BMT:
+    ) -> Self:
         """Get an object by a field and raise if not found.
 
         Used for cases where the object must exist for the operation to continue.
@@ -249,7 +255,7 @@ class APIMixin(Generic[BMT], ABC):
     @classmethod
     def get_list_by_field(
         cls, field: str, value: str | int, ordering: str | None = None
-    ) -> list[BMT]:
+    ) -> list[Self]:
         """Get a list of objects by a field.
 
         :param field: The field to search by.
@@ -263,10 +269,10 @@ class APIMixin(Generic[BMT], ABC):
             params["ordering"] = ordering
 
         data = get_list(cls.endpoint(), params=params)
-        return [cast(BMT, cls(**item)) for item in data]
+        return [cls(**item) for item in data]
 
     @classmethod
-    def get_by_query(cls, query: dict[str, str], ordering: str | None = None) -> list[BMT]:
+    def get_by_query(cls, query: dict[str, str], ordering: str | None = None) -> list[Self]:
         """Get a list of objects by a query.
 
         :param query: The query to search by.
@@ -277,10 +283,10 @@ class APIMixin(Generic[BMT], ABC):
             query["ordering"] = ordering
 
         data = get_list(cls.endpoint().with_query(query))
-        return [cast(BMT, cls(**item)) for item in data]
+        return [cls(**item) for item in data]
 
     @classmethod
-    def get_by_query_unique(cls, data: dict[str, str]) -> BMT:
+    def get_by_query_unique(cls, data: dict[str, str]) -> Self:
         """Get an object with the given data.
 
         :param data: The data to search for.
@@ -289,9 +295,9 @@ class APIMixin(Generic[BMT], ABC):
         obj_dict = get_list_unique(cls.endpoint(), params=data)
         if not obj_dict:
             cli_warning(f"{cls.__name__} record for {data} not found.")
-        return cast(BMT, cls(**obj_dict))
+        return cls(**obj_dict)
 
-    def refetch(self) -> BMT:
+    def refetch(self) -> Self:
         """Fetch an updated version of the object.
 
         Note that the caller (self) of this method will remain unchanged and can contain
@@ -322,7 +328,7 @@ class APIMixin(Generic[BMT], ABC):
 
         return obj
 
-    def patch(self, fields: dict[str, Any]) -> BMT:
+    def patch(self, fields: dict[str, Any]) -> Self:
         """Patch the object with the given values.
 
         Notes
@@ -338,7 +344,9 @@ class APIMixin(Generic[BMT], ABC):
 
         new_object = self.refetch()
 
-        aliases = get_model_aliases(new_object)
+        # __init_subclass__ guarantees we inherit from BaseModel
+        # but we can't signal this to the type checker, so we cast here.
+        aliases = get_model_aliases(cast(BaseModel, new_object))
         for key, value in fields.items():
             field_name = key
             if key in aliases:
@@ -368,7 +376,7 @@ class APIMixin(Generic[BMT], ABC):
         return False
 
     @classmethod
-    def create(cls, params: dict[str, str | None]) -> None | BMT:
+    def create(cls, params: dict[str, str | None]) -> Self | None:
         """Create the object.
 
         Note that several endpoints do not support location headers for created objects,

--- a/mreg_cli/api/abstracts.py
+++ b/mreg_cli/api/abstracts.py
@@ -99,9 +99,10 @@ class APIMixin(ABC):
     def __init_subclass__(cls) -> None:
         """Ensure that the subclass inherits from BaseModel."""
         super().__init_subclass__()
-        if BaseModel not in cls.__bases__:
+        if BaseModel not in cls.__mro__ and not cls.__name__.startswith("With"):
             raise TypeError(
-                f"{cls.__name__} must be applied on classes inheriting from BaseModel."
+                f"{cls.__name__} must be applied on classes inheriting from BaseModel "
+                "or on a `With*` mixin class."
             )
 
     def id_for_endpoint(self) -> int | str:

--- a/mreg_cli/api/models.py
+++ b/mreg_cli/api/models.py
@@ -256,7 +256,7 @@ class WithTTL(BaseModel):
         return ttl
 
 
-class WithName(APIMixin[Any]):
+class WithName(APIMixin):
     """Mixin type for an object that has a name element."""
 
     __name_field__: str = "name"
@@ -327,7 +327,7 @@ class Zone(FrozenModelWithTimestamps, WithTTL):
         return False
 
 
-class ForwardZone(Zone, APIMixin["ForwardZone"]):
+class ForwardZone(Zone, APIMixin):
     """A forward zone."""
 
     @classmethod
@@ -464,7 +464,7 @@ class HostPolicy(FrozenModel):
         output_manager.add_line(f"{'Description:':<{padding}}{self.description}")
 
 
-class Role(HostPolicy, WithName, APIMixin["Role"]):
+class Role(HostPolicy, WithName):
     """Model for a role."""
 
     id: int  # noqa: A003
@@ -524,7 +524,7 @@ class Role(HostPolicy, WithName, APIMixin["Role"]):
         return [Role(**item) for item in data]
 
 
-class Atom(HostPolicy, WithName, APIMixin["Atom"]):
+class Atom(HostPolicy, WithName):
     """Model for an atom."""
 
     id: int  # noqa: A003
@@ -547,7 +547,7 @@ class Atom(HostPolicy, WithName, APIMixin["Atom"]):
             output_manager.add_formatted_line("", role, padding)
 
 
-class Label(FrozenModelWithTimestamps, APIMixin["Label"]):
+class Label(FrozenModelWithTimestamps, APIMixin):
     """Model for a label."""
 
     id: int  # noqa: A003
@@ -586,7 +586,7 @@ class Label(FrozenModelWithTimestamps, APIMixin["Label"]):
         return label
 
 
-class Network(FrozenModelWithTimestamps, APIMixin["Network"]):
+class Network(FrozenModelWithTimestamps, APIMixin):
     """Model for a network."""
 
     id: int  # noqa: A003
@@ -680,7 +680,7 @@ class Network(FrozenModelWithTimestamps, APIMixin["Network"]):
         return hash((self.id, self.network))
 
 
-class IPAddress(FrozenModelWithTimestamps, WithHost, APIMixin["IPAddress"]):
+class IPAddress(FrozenModelWithTimestamps, WithHost, APIMixin):
     """Represents an IP address with associated details."""
 
     id: int  # noqa: A003
@@ -808,7 +808,7 @@ class IPAddress(FrozenModelWithTimestamps, WithHost, APIMixin["IPAddress"]):
         return hash((self.id, self.ipaddress.address, self.macaddress))
 
 
-class HInfo(FrozenModelWithTimestamps, WithHost, APIMixin["HInfo"]):
+class HInfo(FrozenModelWithTimestamps, WithHost, APIMixin):
     """Represents a HINFO record."""
 
     cpu: str
@@ -826,7 +826,7 @@ class HInfo(FrozenModelWithTimestamps, WithHost, APIMixin["HInfo"]):
         )
 
 
-class CNAME(FrozenModelWithTimestamps, WithHost, WithZone, WithTTL, APIMixin["CNAME"]):
+class CNAME(FrozenModelWithTimestamps, WithHost, WithZone, WithTTL, APIMixin):
     """Represents a CNAME record."""
 
     id: int  # noqa: A003
@@ -909,7 +909,7 @@ class CNAME(FrozenModelWithTimestamps, WithHost, WithZone, WithTTL, APIMixin["CN
             cname.output(padding=padding)
 
 
-class TXT(FrozenModelWithTimestamps, WithHost, APIMixin["TXT"]):
+class TXT(FrozenModelWithTimestamps, WithHost, APIMixin):
     """Represents a TXT record."""
 
     id: int  # noqa: A003
@@ -938,7 +938,7 @@ class TXT(FrozenModelWithTimestamps, WithHost, APIMixin["TXT"]):
             txt.output(padding=padding)
 
 
-class MX(FrozenModelWithTimestamps, WithHost, APIMixin["MX"]):
+class MX(FrozenModelWithTimestamps, WithHost, APIMixin):
     """Represents a MX record."""
 
     id: int  # noqa: A003
@@ -996,7 +996,7 @@ class MX(FrozenModelWithTimestamps, WithHost, APIMixin["MX"]):
             mx.output(padding=padding)
 
 
-class NAPTR(FrozenModelWithTimestamps, WithHost, APIMixin["NAPTR"]):
+class NAPTR(FrozenModelWithTimestamps, WithHost, APIMixin):
     """Represents a NAPTR record."""
 
     id: int  # noqa: A003
@@ -1055,7 +1055,7 @@ class NAPTR(FrozenModelWithTimestamps, WithHost, APIMixin["NAPTR"]):
                 naptr.output(padding=padding)
 
 
-class Srv(FrozenModelWithTimestamps, WithHost, WithZone, WithTTL, APIMixin["Srv"]):
+class Srv(FrozenModelWithTimestamps, WithHost, WithZone, WithTTL, APIMixin):
     """Represents a SRV record."""
 
     id: int  # noqa: A003
@@ -1137,7 +1137,7 @@ class Srv(FrozenModelWithTimestamps, WithHost, WithZone, WithTTL, APIMixin["Srv"
         return self.name
 
 
-class PTR_override(FrozenModelWithTimestamps, WithHost, APIMixin["PTR_override"]):
+class PTR_override(FrozenModelWithTimestamps, WithHost, APIMixin):
     """Represents a PTR override record."""
 
     id: int  # noqa: A003
@@ -1172,7 +1172,7 @@ class PTR_override(FrozenModelWithTimestamps, WithHost, APIMixin["PTR_override"]
         OutputManager().add_line(f"{'PTR override:':<{padding}}{self.ipaddress} -> {hostname}")
 
 
-class SSHFP(FrozenModelWithTimestamps, WithHost, WithTTL, APIMixin["SSHFP"]):
+class SSHFP(FrozenModelWithTimestamps, WithHost, WithTTL, APIMixin):
     """Represents a SSHFP record."""
 
     id: int  # noqa: A003
@@ -1217,7 +1217,7 @@ class SSHFP(FrozenModelWithTimestamps, WithHost, WithTTL, APIMixin["SSHFP"]):
         )
 
 
-class BacnetID(FrozenModel, WithHost, APIMixin["BacnetID"]):
+class BacnetID(FrozenModel, WithHost, APIMixin):
     """Represents a Bacnet ID record."""
 
     id: int  # noqa: A003
@@ -1257,7 +1257,7 @@ class BacnetID(FrozenModel, WithHost, APIMixin["BacnetID"]):
         OutputManager().add_formatted_table(("ID", "Hostname"), ("id", "hostname"), bacnetids)
 
 
-class Location(FrozenModelWithTimestamps, WithHost, APIMixin["Location"]):
+class Location(FrozenModelWithTimestamps, WithHost, APIMixin):
     """Represents a LOC record."""
 
     loc: str
@@ -1275,7 +1275,7 @@ class Location(FrozenModelWithTimestamps, WithHost, APIMixin["Location"]):
         OutputManager().add_line(f"{'LOC:':<{padding}}{self.loc}")
 
 
-class Host(FrozenModelWithTimestamps, WithTTL, APIMixin["Host"]):
+class Host(FrozenModelWithTimestamps, WithTTL, APIMixin):
     """Model for an individual host."""
 
     id: int  # noqa: A003
@@ -1907,7 +1907,7 @@ class HostList(FrozenModel):
             _format(str(i.name), i.contact, i.comment or "")
 
 
-class HostGroup(FrozenModelWithTimestamps, APIMixin["HostGroup"]):
+class HostGroup(FrozenModelWithTimestamps, APIMixin):
     """Model for a hostgroup."""
 
     id: int  # noqa: A003


### PR DESCRIPTION
This gets rid of needing to repeat the class name when inheriting from `APIMixin`, as well as most uses of `typing.cast()` inside the various methods.