### PR TITLE
dhcp commands and exception usage.

### DIFF
--- a/mreg_cli/api/abstracts.py
+++ b/mreg_cli/api/abstracts.py
@@ -12,8 +12,8 @@ from pydantic.fields import FieldInfo
 from mreg_cli.api.endpoints import Endpoint
 from mreg_cli.api.history import HistoryItem, HistoryResource
 from mreg_cli.exceptions import (
-    CliError,
     CreateFailure,
+    EntityAlreadyExists,
     EntityNotFound,
     GetFailure,
     InternalError,
@@ -211,7 +211,7 @@ class APIMixin(ABC):
         cls,
         field: str,
         value: str,
-        exc_type: type[Exception] = CliError,
+        exc_type: type[Exception] = EntityNotFound,
         exc_message: str | None = None,
     ) -> Self:
         """Get an object by a field and raise if not found.
@@ -237,7 +237,7 @@ class APIMixin(ABC):
         cls,
         field: str,
         value: str,
-        exc_type: type[Exception] = CliError,
+        exc_type: type[Exception] = EntityAlreadyExists,
         exc_message: str | None = None,
     ) -> None:
         """Get an object by a field and raise if found.

--- a/mreg_cli/api/fields.py
+++ b/mreg_cli/api/fields.py
@@ -4,10 +4,9 @@ from __future__ import annotations
 
 import ipaddress
 import re
-from datetime import datetime, date
 from typing import Annotated, Any
 
-from pydantic import AliasChoices, BeforeValidator, Field, field_validator
+from pydantic import BeforeValidator, field_validator
 
 from mreg_cli.api.abstracts import FrozenModel
 from mreg_cli.types import IP_AddressT

--- a/mreg_cli/api/history.py
+++ b/mreg_cli/api/history.py
@@ -10,7 +10,7 @@ from typing import Any
 from pydantic import BaseModel, Field, field_validator
 
 from mreg_cli.api.endpoints import Endpoint
-from mreg_cli.log import cli_warning
+from mreg_cli.exceptions import EntityNotFound, InternalError
 from mreg_cli.outputmanager import OutputManager
 from mreg_cli.utilities.api import get_list
 
@@ -93,7 +93,7 @@ class HistoryItem(BaseModel):
             else:
                 msg = ", ".join(f"{k} = '{v}'" for k, v in self.data.items())
         else:
-            cli_warning(f"Unhandled history entry: {action}")
+            raise InternalError(f"Unhandled history entry: {action}")
 
         return msg
 
@@ -119,7 +119,7 @@ class HistoryItem(BaseModel):
         ret = get_list(Endpoint.History, params=params)
 
         if len(ret) == 0:
-            cli_warning(f"No history found for {name}")
+            raise EntityNotFound(f"No history found for {name}")
 
         model_ids = ",".join({str(i["model_id"]) for i in ret})
 

--- a/mreg_cli/api/models.py
+++ b/mreg_cli/api/models.py
@@ -1580,7 +1580,7 @@ class Host(FrozenModelWithTimestamps, WithTTL, APIMixin):
         :returns: An IP address that can be associated with the host.
         """
         if len(self.ipaddresses) == 0:
-            raise EntityNotFound(f"Host {self.name.hostname} has no IP addresses.")
+            raise EntityNotFound(f"Host {self} has no IP addresses.")
 
         if len(self.ipaddresses) == 1:
             return self.ipaddresses[0]
@@ -2025,24 +2025,15 @@ class HostGroup(FrozenModelWithTimestamps, APIMixin):
     id: int  # noqa: A003
     name: str
     description: str | None = None
-    parent: list[str]
-    groups: list[str]
-    hosts: list[str]
-    owners: list[str]
+    parent: NameList
+    groups: NameList
+    hosts: NameList
+    owners: NameList
 
     @classmethod
     def endpoint(cls) -> Endpoint:
         """Return the endpoint for the class."""
         return Endpoint.HostGroups
-
-    @field_validator("parent", "groups", "hosts", "owners", mode="before")
-    @classmethod
-    def collapse_name(cls, v: list[dict[str, str]]) -> list[str]:
-        """Collapse the name field."""
-        if not v:
-            return []
-
-        return [i["name"] for i in v]
 
     @classmethod
     def output_multiple(cls, hostgroups: list[HostGroup], padding: int = 14) -> None:

--- a/mreg_cli/commands/dhcp.py
+++ b/mreg_cli/commands/dhcp.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 import argparse
 from typing import Any
 
+from mreg_cli.api.models import Host, IPAddress
 from mreg_cli.commands.base import BaseCommand
 from mreg_cli.commands.registry import CommandRegistry
+from mreg_cli.exceptions import InputFailure
 from mreg_cli.log import cli_info
 from mreg_cli.types import Flag
-from mreg_cli.utilities.api import patch
-from mreg_cli.utilities.host import assoc_mac_to_ip, get_unique_ip_by_name_or_ip
 
 command_registry = CommandRegistry()
 
@@ -43,14 +43,28 @@ def assoc(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name, mac, force)
     """
-    ip = get_unique_ip_by_name_or_ip(args.name)
-    new_mac = assoc_mac_to_ip(args.mac, ip, force=args.force)
+    ipaddress_to_use = None
 
-    if new_mac is not None:
-        cli_info(
-            "associated mac address {} with ip {}".format(new_mac, ip["ipaddress"]),
-            print_msg=True,
-        )
+    in_use = IPAddress.get_by_mac(args.mac)
+    if in_use:
+        raise InputFailure(f"MAC {args.mac} is already in use by {in_use.ip()}.")
+
+    ipobjs = IPAddress.get_by_ip(args.name)
+    if ipobjs:
+        if len(ipobjs) > 1:
+            raise InputFailure(f"IP {args.name} is in use by {len(ipobjs)} hosts.")
+
+        ipaddress_to_use = ipobjs[0]
+
+    if not ipaddress_to_use:
+        host = Host.get_by_any_means_or_raise(args.name)
+        ipaddress_to_use = host.get_associatable_ip()
+
+    ipaddress_to_use.associate_mac(args.mac, force=args.force)
+    cli_info(
+        f"Associated mac address {args.mac} with ip {ipaddress_to_use.ip()}",
+        print_msg=True,
+    )
 
 
 @command_registry.register_command(
@@ -71,18 +85,41 @@ def disassoc(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name)
     """
-    ip = get_unique_ip_by_name_or_ip(args.name)
+    ipaddress_to_use = None
+    ipobjs = IPAddress.get_by_ip(args.name)
+    if ipobjs:
+        if len(ipobjs) > 1:
+            raise InputFailure(f"IP {args.name} is in use by {len(ipobjs)} hosts.")
 
-    if ip.get("macaddress"):
-        # Update ipaddress
-        path = f"/api/v1/ipaddresses/{ip['id']}"
-        patch(path, macaddress="")
-        cli_info(
-            "disassociated mac address {} from ip {}".format(ip["macaddress"], ip["ipaddress"]),
-            print_msg=True,
-        )
-    else:
-        cli_info(
-            "ipaddress {} has no associated mac address".format(ip["ipaddress"]),
-            print_msg=True,
-        )
+        ipaddress_to_use = ipobjs[0]
+
+        if not ipaddress_to_use.macaddress:
+            raise InputFailure(f"IP {args.name} does not have a MAC address associated.")
+
+    if not ipaddress_to_use:
+        host = Host.get_by_any_means_or_raise(args.name)
+
+        try:
+            ipaddress_to_use = host.has_ip_with_mac(args.name)
+        except ValueError:
+            pass
+
+        if not ipaddress_to_use:
+            ips_with_mac = host.ips_with_macaddresses()
+
+            if not ips_with_mac:
+                raise InputFailure(
+                    f"Host {host} does not have any IP addresses with MAC addresses."
+                )
+
+            if len(ips_with_mac) > 1:
+                raise InputFailure(f"Host {host} has multiple IP addresses with MAC addresses.")
+
+            ipaddress_to_use = ips_with_mac[0]
+
+    mac = ipaddress_to_use.macaddress
+    ipaddress_to_use.disassociate_mac()
+    cli_info(
+        f"Disassociated mac address {mac} from ip {ipaddress_to_use.ip()}",
+        print_msg=True,
+    )

--- a/mreg_cli/commands/host_submodules/a_aaaa.py
+++ b/mreg_cli/commands/host_submodules/a_aaaa.py
@@ -49,11 +49,7 @@ def _ip_change(args: argparse.Namespace, ipversion: IP_Version) -> None:
     if args.old == args.new:
         raise EntityAlreadyExists("New and old IP are equal")
 
-    old_ip = NetworkOrIP(ip_or_network=args.old)
-    if old_ip.is_network():
-        raise InputFailure("From address cannot be a network")
-
-    old_ip = old_ip.as_ip()
+    old_ip = NetworkOrIP(ip_or_network=args.old).as_ip()
 
     new_ip = NetworkOrIP(ip_or_network=args.new)
     if new_ip.is_network():

--- a/mreg_cli/exceptions.py
+++ b/mreg_cli/exceptions.py
@@ -68,6 +68,36 @@ class DeleteFailure(CliError):
     pass
 
 
+class GetFailure(CliError):
+    """Error class for failed retrieval."""
+
+    pass
+
+
+class InternalError(CliError):
+    """Error class for internal errors."""
+
+    pass
+
+
+class APIError(CliError):
+    """Error class for API errors."""
+
+    pass
+
+
+class UnexpectedAPIData(APIError):
+    """Error class for unexpected API data."""
+
+    pass
+
+
+class ValidationFailure(CliWarning):
+    """Warning class for validation failures."""
+
+    pass
+
+
 class EntityNotFound(CliWarning):
     """Warning class for an entity that was not found."""
 
@@ -76,6 +106,12 @@ class EntityNotFound(CliWarning):
 
 class EntityAlreadyExists(CliWarning):
     """Warning class for an entity that already exists."""
+
+    pass
+
+
+class MultipleEntititesFound(CliWarning):
+    """Warning class for multiple entities found."""
 
     pass
 
@@ -94,6 +130,30 @@ class InputFailure(CliWarning):
 
 class ForceMissing(CliWarning):
     """Warning class for missing force flag."""
+
+    pass
+
+
+class IsNotAnIPAddress(CliWarning):
+    """Warning class for an entity that is not an IP address."""
+
+    pass
+
+
+class IsNotAnIPv4Address(CliWarning):
+    """Warning class for an entity that is not an IPv4 address."""
+
+    pass
+
+
+class IsNotAnIPv6Address(CliWarning):
+    """Warning class for an entity that is not an IPv6 address."""
+
+    pass
+
+
+class IsNotANetwork(CliWarning):
+    """Warning class for an entity that is not a network."""
 
     pass
 


### PR DESCRIPTION
  - Migrate more files to use exceptions and not `cli_*`-commands.
  - Migrate commands for `dhcp assoc` and `dhcp disassoc`.

There is a fair bit of refactoring to utilise all the flexibility now on offer, while retaining the safety previously desired.