### PR TITLE
Uniform exception names

### DIFF
--- a/mreg_cli/api/abstracts.py
+++ b/mreg_cli/api/abstracts.py
@@ -12,12 +12,12 @@ from pydantic.fields import FieldInfo
 from mreg_cli.api.endpoints import Endpoint
 from mreg_cli.api.history import HistoryItem, HistoryResource
 from mreg_cli.exceptions import (
-    CreateFailure,
+    CreateError,
     EntityAlreadyExists,
     EntityNotFound,
-    GetFailure,
+    GetError,
     InternalError,
-    PatchFailure,
+    PatchError,
 )
 from mreg_cli.outputmanager import OutputManager
 from mreg_cli.utilities.api import (
@@ -332,7 +332,7 @@ class APIMixin(ABC):
 
         obj = self.__class__.get_by_id(lookup)
         if not obj:
-            raise GetFailure(f"Could not refresh {self.__class__.__name__} with ID {identifier}.")
+            raise GetError(f"Could not refresh {self.__class__.__name__} with ID {identifier}.")
 
         return obj
 
@@ -362,11 +362,9 @@ class APIMixin(ABC):
             try:
                 nval = getattr(new_object, field_name)
             except AttributeError as e:
-                raise PatchFailure(
-                    f"Could not get value for {field_name} in patched object."
-                ) from e
+                raise PatchError(f"Could not get value for {field_name} in patched object.") from e
             if value and str(nval) != str(value):
-                raise PatchFailure(
+                raise PatchError(
                     # Should this reference `field_name` instead of `key`?
                     f"Patch failure! Tried to set {key} to {value}, but server returned {nval}."
                 )
@@ -411,7 +409,7 @@ class APIMixin(ABC):
                 if obj:
                     return obj
 
-                raise GetFailure(f"Could not fetch object from location {location}.")
+                raise GetError(f"Could not fetch object from location {location}.")
 
             # else:
             # Lots of endpoints don't give locations on creation,
@@ -420,7 +418,7 @@ class APIMixin(ABC):
             # cli_warning("No location header in response.")
 
         else:
-            raise CreateFailure(f"Failed to create {cls} with {params} @ {cls.endpoint()}.")
+            raise CreateError(f"Failed to create {cls} with {params} @ {cls.endpoint()}.")
 
         return None
 

--- a/mreg_cli/commands/host_submodules/a_aaaa.py
+++ b/mreg_cli/commands/host_submodules/a_aaaa.py
@@ -20,7 +20,7 @@ import argparse
 from mreg_cli.api.models import Host, HostList, IPAddress, MACAddressField, Network, NetworkOrIP
 from mreg_cli.commands.host import registry as command_registry
 from mreg_cli.exceptions import (
-    DeleteFailure,
+    DeleteError,
     EntityAlreadyExists,
     EntityNotFound,
     ForceMissing,
@@ -143,7 +143,7 @@ def _ip_remove(args: argparse.Namespace, ipversion: IP_Version) -> None:
     if host_ip.delete():
         cli_info(f"Removed ipaddress {args.ip} from {host}", print_msg=True)
     else:
-        raise DeleteFailure(f"Failed to remove ipaddress {args.ip} from {host}")
+        raise DeleteError(f"Failed to remove ipaddress {args.ip} from {host}")
 
 
 def _add_ip(

--- a/mreg_cli/commands/host_submodules/bacnet.py
+++ b/mreg_cli/commands/host_submodules/bacnet.py
@@ -14,8 +14,8 @@ import argparse
 from mreg_cli.api.models import BacnetID, Host
 from mreg_cli.commands.host import registry as command_registry
 from mreg_cli.exceptions import (
-    CreateFailure,
-    DeleteFailure,
+    CreateError,
+    DeleteError,
     EntityAlreadyExists,
     EntityNotFound,
     EntityOwnershipMismatch,
@@ -56,7 +56,7 @@ def bacnetid_add(args: argparse.Namespace) -> None:
     if validator and validator.hostname == host.name.hostname:
         cli_info(f"Assigned BACnet ID {validator.id} to {validator.hostname}.", print_msg=True)
     else:
-        raise CreateFailure(f"Failed to assign BACnet ID {args.id} to {host.name.hostname}.")
+        raise CreateError(f"Failed to assign BACnet ID {args.id} to {host.name.hostname}.")
 
 
 @command_registry.register_command(
@@ -80,7 +80,7 @@ def bacnetid_remove(args: argparse.Namespace) -> None:
     if host_bacnet.delete():
         cli_info(f"Unassigned BACnet ID {host_bacnet.id} from {host.name}.", print_msg=True)
     else:
-        raise DeleteFailure(f"Failed to unassign BACnet ID {host_bacnet.id} from {host.name}.")
+        raise DeleteError(f"Failed to unassign BACnet ID {host_bacnet.id} from {host.name}.")
 
 
 @command_registry.register_command(

--- a/mreg_cli/commands/host_submodules/cname.py
+++ b/mreg_cli/commands/host_submodules/cname.py
@@ -7,13 +7,13 @@ import argparse
 from mreg_cli.api.models import CNAME, ForwardZone, Host, HostT
 from mreg_cli.commands.host import registry as command_registry
 from mreg_cli.exceptions import (
-    CreateFailure,
-    DeleteFailure,
+    CreateError,
+    DeleteError,
     EntityAlreadyExists,
     EntityNotFound,
     EntityOwnershipMismatch,
     InputFailure,
-    PatchFailure,
+    PatchError,
 )
 from mreg_cli.log import cli_info
 from mreg_cli.types import Flag
@@ -66,7 +66,7 @@ def cname_add(args: argparse.Namespace) -> None:
     if cname:
         cli_info(f"Added CNAME {cname.name} for {host.name.hostname}.", print_msg=True)
     else:
-        raise CreateFailure(f"Failed to add CNAME {alias} for {host.name.hostname}.")
+        raise CreateError(f"Failed to add CNAME {alias} for {host.name.hostname}.")
 
 
 @command_registry.register_command(
@@ -108,7 +108,7 @@ def cname_remove(args: argparse.Namespace) -> None:
     if cname.delete():
         cli_info(f"Removed CNAME {cname.name} for {host.name}.", print_msg=True)
     else:
-        raise DeleteFailure(f"Failed to remove CNAME {cname.name} for {host.name}.")
+        raise DeleteError(f"Failed to remove CNAME {cname.name} for {host.name}.")
 
 
 @command_registry.register_command(
@@ -143,7 +143,7 @@ def cname_replace(args: argparse.Namespace) -> None:
             f"Moved CNAME alias {cname}: {old_host.name.hostname} -> {host.name}.", print_msg=True
         )
     else:
-        raise PatchFailure(f"Failed to move CNAME alias {cname}.")
+        raise PatchError(f"Failed to move CNAME alias {cname}.")
 
 
 @command_registry.register_command(

--- a/mreg_cli/commands/host_submodules/core.py
+++ b/mreg_cli/commands/host_submodules/core.py
@@ -19,14 +19,14 @@ from mreg_cli.api.history import HistoryResource
 from mreg_cli.api.models import ForwardZone, Host, HostList, HostT, MACAddressField, NetworkOrIP
 from mreg_cli.commands.host import registry as command_registry
 from mreg_cli.exceptions import (
-    CreateFailure,
-    DeleteFailure,
+    CreateError,
+    DeleteError,
     EntityAlreadyExists,
     EntityNotFound,
     EntityOwnershipMismatch,
     ForceMissing,
     InputFailure,
-    PatchFailure,
+    PatchError,
 )
 from mreg_cli.log import cli_info
 from mreg_cli.types import Flag
@@ -129,7 +129,7 @@ def add(args: argparse.Namespace) -> None:
 
     host = Host.create(data)
     if not host:
-        raise CreateFailure("Failed to add host.")
+        raise CreateError("Failed to add host.")
 
     if macaddress is not None:
         if ip:
@@ -291,7 +291,7 @@ def remove(args: argparse.Namespace) -> None:
     if host.delete():
         cli_info(f"removed {host.name}", print_msg=True)
     else:
-        raise DeleteFailure(f"failed to remove {host.name}")
+        raise DeleteError(f"failed to remove {host.name}")
 
 
 @command_registry.register_command(
@@ -451,7 +451,7 @@ def set_comment(args: argparse.Namespace) -> None:
     updated_host = host.set_comment(args.comment)
 
     if not updated_host:
-        raise PatchFailure(f"Failed to update comment of {host.name}")
+        raise PatchError(f"Failed to update comment of {host.name}")
 
     cli_info(
         f"Updated comment of {host} to {args.comment}",
@@ -477,7 +477,7 @@ def set_contact(args: argparse.Namespace) -> None:
     updated_host = host.set_contact(args.contact)
 
     if not updated_host:
-        raise PatchFailure(f"Failed to update contact of {host.name}")
+        raise PatchError(f"Failed to update contact of {host.name}")
 
     cli_info(f"Updated contact of {host} to {args.contact}", print_msg=True)
 

--- a/mreg_cli/commands/host_submodules/rr.py
+++ b/mreg_cli/commands/host_submodules/rr.py
@@ -58,13 +58,13 @@ from mreg_cli.api.models import (
 )
 from mreg_cli.commands.host import registry as command_registry
 from mreg_cli.exceptions import (
-    CreateFailure,
-    DeleteFailure,
+    CreateError,
+    DeleteError,
     EntityAlreadyExists,
     EntityNotFound,
     ForceMissing,
     InputFailure,
-    PatchFailure,
+    PatchError,
 )
 from mreg_cli.log import cli_info
 from mreg_cli.types import Flag
@@ -97,7 +97,7 @@ def hinfo_add(args: argparse.Namespace) -> None:
     if host.hinfo and host.hinfo.cpu == args.cpu and host.hinfo.os == args.os:
         cli_info(f"Added HINFO record for {host.name.hostname}.", print_msg=True)
     else:
-        raise CreateFailure(f"Failed to add correct HINFO for {host}")
+        raise CreateError(f"Failed to add correct HINFO for {host}")
 
 
 @command_registry.register_command(
@@ -123,7 +123,7 @@ def hinfo_remove(args: argparse.Namespace) -> None:
     if hinfo and hinfo.delete():
         cli_info(f"Removed HINFO record for {host.name.hostname}.", print_msg=True)
     else:
-        raise DeleteFailure(f"Failed to remove HINFO for {host}")
+        raise DeleteError(f"Failed to remove HINFO for {host}")
 
 
 @command_registry.register_command(
@@ -174,7 +174,7 @@ def loc_remove(args: argparse.Namespace) -> None:
     if host.loc.delete():
         cli_info(f"Removed LOC for {host.name.hostname}.", print_msg=True)
     else:
-        raise DeleteFailure(f"Failed to remove LOC for {host}")
+        raise DeleteError(f"Failed to remove LOC for {host}")
 
 
 @command_registry.register_command(
@@ -204,7 +204,7 @@ def loc_add(args: argparse.Namespace) -> None:
     if host.loc and host.loc.loc == args.loc:
         cli_info(f"Added LOC record for {host.name.hostname}.", print_msg=True)
     else:
-        CreateFailure(f"Failed to set LOC for {host}")
+        CreateError(f"Failed to set LOC for {host}")
 
 
 @command_registry.register_command(
@@ -279,7 +279,7 @@ def mx_remove(args: argparse.Namespace) -> None:
     if mx.delete():
         cli_info(f"deleted MX from {host.name.hostname}.", print_msg=True)
     else:
-        raise DeleteFailure(f"Failed to remove MX for {host}")
+        raise DeleteError(f"Failed to remove MX for {host}")
 
 
 @command_registry.register_command(
@@ -428,7 +428,7 @@ def naptr_remove(args: argparse.Namespace) -> None:
         if naptr.delete():
             cli_info(f"Deleted NAPTR record from {host.name.hostname}.", print_msg=True)
         else:
-            raise DeleteFailure(f"Failed to remove NAPTR for {host}")
+            raise DeleteError(f"Failed to remove NAPTR for {host}")
 
 
 @command_registry.register_command(
@@ -489,7 +489,7 @@ def ptr_change(args: argparse.Namespace) -> None:
 
     data = {"host": new_host.id}
     if not ptr_override.patch(data):
-        raise PatchFailure(f"Failed to move PTR record from {old_host} to {new_host}")
+        raise PatchError(f"Failed to move PTR record from {old_host} to {new_host}")
     else:
         cli_info(
             f"Moved PTR record {ip} from {old_host.name.hostname} to {new_host.name.hostname}.",
@@ -524,7 +524,7 @@ def ptr_remove(args: argparse.Namespace) -> None:
     if ptr_override.delete():
         cli_info(f"Removed PTR record {ip} from {host.name.hostname}.", print_msg=True)
     else:
-        raise DeleteFailure(f"Failed to remove PTR record from {host}")
+        raise DeleteError(f"Failed to remove PTR record from {host}")
 
 
 @command_registry.register_command(
@@ -696,7 +696,7 @@ def srv_remove(args: argparse.Namespace) -> None:
     if srv.delete():
         cli_info(f"Removed SRV record {sname} from {host.name.hostname}.", print_msg=True)
     else:
-        raise DeleteFailure(f"Failed to remove SRV for {sname}")
+        raise DeleteError(f"Failed to remove SRV for {sname}")
 
 
 @command_registry.register_command(
@@ -793,7 +793,7 @@ def sshfp_remove(args: argparse.Namespace) -> None:
     else:
         for sshfp in sshfps:
             if not sshfp.delete():
-                raise DeleteFailure(f"Failed to remove SSHFP for {host}")
+                raise DeleteError(f"Failed to remove SSHFP for {host}")
             else:
                 fp = sshfp.fingerprint
                 cli_info(
@@ -876,7 +876,7 @@ def ttl_set(args: argparse.Namespace) -> None:
     if result:
         cli_info(f"Set TTL for {target} to {args.ttl}.", print_msg=True)
     else:
-        raise PatchFailure(f"Failed to set TTL for {target}")
+        raise PatchError(f"Failed to set TTL for {target}")
 
 
 @command_registry.register_command(
@@ -956,7 +956,7 @@ def txt_remove(args: argparse.Namespace) -> None:
     if txt.delete():
         cli_info(f"Removed TXT record '{args.text}' from {host}.", print_msg=True)
     else:
-        raise DeleteFailure(f"Failed to remove TXT with '{args.text}' for {host}")
+        raise DeleteError(f"Failed to remove TXT with '{args.text}' for {host}")
 
 
 @command_registry.register_command(

--- a/mreg_cli/exceptions.py
+++ b/mreg_cli/exceptions.py
@@ -29,7 +29,11 @@ class CliException(Exception):
 
 
 class CliError(CliException):
-    """Exception class for CLI errors."""
+    """Exception class for CLI errors.
+
+    Errors are not recoverable and stem from internal failures that
+    the user cannot be expected to resolve.
+    """
 
     def formatted_exception(self) -> str:
         """Return a string formatted with HTML red tag for the error message.
@@ -40,7 +44,10 @@ class CliError(CliException):
 
 
 class CliWarning(CliException):
-    """Exception class for CLI warnings."""
+    """Exception class for CLI warnings.
+
+    Warnings should be recoverable by changing the user input.
+    """
 
     def formatted_exception(self) -> str:
         """Return a string formatted with HTML italic tag for the warning message.

--- a/mreg_cli/exceptions.py
+++ b/mreg_cli/exceptions.py
@@ -50,25 +50,25 @@ class CliWarning(CliException):
         return f"<i>{super().__str__()}</i>"
 
 
-class CreateFailure(CliError):
+class CreateError(CliError):
     """Error class for failed creation."""
 
     pass
 
 
-class PatchFailure(CliError):
+class PatchError(CliError):
     """Error class for failed patching."""
 
     pass
 
 
-class DeleteFailure(CliError):
+class DeleteError(CliError):
     """Error class for failed deletion."""
 
     pass
 
 
-class GetFailure(CliError):
+class GetError(CliError):
     """Error class for failed retrieval."""
 
     pass
@@ -86,14 +86,14 @@ class APIError(CliError):
     pass
 
 
-class UnexpectedAPIData(APIError):
+class UnexpectedDataError(APIError):
     """Error class for unexpected API data."""
 
     pass
 
 
-class ValidationFailure(CliWarning):
-    """Warning class for validation failures."""
+class ValidationError(CliError):
+    """Error class for validation failures."""
 
     pass
 
@@ -134,25 +134,25 @@ class ForceMissing(CliWarning):
     pass
 
 
-class IsNotAnIPAddress(CliWarning):
+class InvalidIPAddress(CliWarning):
     """Warning class for an entity that is not an IP address."""
 
     pass
 
 
-class IsNotAnIPv4Address(CliWarning):
+class InvalidIPv4Address(CliWarning):
     """Warning class for an entity that is not an IPv4 address."""
 
     pass
 
 
-class IsNotAnIPv6Address(CliWarning):
+class InvalidIPv6Address(CliWarning):
     """Warning class for an entity that is not an IPv6 address."""
 
     pass
 
 
-class IsNotANetwork(CliWarning):
+class InvalidNetwork(CliWarning):
     """Warning class for an entity that is not a network."""
 
     pass


### PR DESCRIPTION
  - Exceptions that inherit from `CliError` now consistently end with `Error`.
  - Exceptions that inherit from `CliWarning` have no consistent suffix and *should* be recoverable with appropriate user input.