### PR TITLE
Fix incorrect method used in `host sshfp_remove`

### DIFF
--- a/mreg_cli/commands/host_submodules/rr.py
+++ b/mreg_cli/commands/host_submodules/rr.py
@@ -783,7 +783,9 @@ def sshfp_remove(args: argparse.Namespace) -> None:
 
     if args.fingerprint:
         sshfps = [
-            SSHFP.get_by_query_unique({"fingerprint": args.fingerprint, "host": str(host.id)})
+            SSHFP.get_by_query_unique_or_raise(
+                {"fingerprint": args.fingerprint, "host": str(host.id)}
+            )
         ]
     else:
         sshfps = host.sshfps()


### PR DESCRIPTION
Raise if SSHFP is not found.