### PR TITLE
Use JSON encoding for all `PATCH` requests

### DIFF
--- a/mreg_cli/api/abstracts.py
+++ b/mreg_cli/api/abstracts.py
@@ -432,7 +432,7 @@ class APIMixin(ABC):
 
         return obj
 
-    def patch(self, fields: dict[str, Any], use_json: bool = False, validate: bool = True) -> Self:
+    def patch(self, fields: dict[str, Any], validate: bool = True) -> Self:
         """Patch the object with the given values.
 
         Notes
@@ -445,11 +445,7 @@ class APIMixin(ABC):
         :param validate: Whether to validate the patched object.
         :returns: The object refetched from the server.
         """
-        if use_json:
-            patch(self.endpoint().with_id(self.id_for_endpoint()), fields, use_json=True)
-        else:
-            patch(self.endpoint().with_id(self.id_for_endpoint()), use_json=False, **fields)
-
+        patch(self.endpoint().with_id(self.id_for_endpoint()), **fields)
         new_object = self.refetch()
 
         if validate:

--- a/mreg_cli/api/models.py
+++ b/mreg_cli/api/models.py
@@ -403,7 +403,7 @@ class Permission(FrozenModelWithTimestamps, APIMixin):
 
         label_ids = self.labels.copy()
         label_ids.remove(label.id)
-        return self.patch({"labels": label_ids}, use_json=True)
+        return self.patch({"labels": label_ids})
 
 
 def is_reverse_zone_name(name: str) -> bool:
@@ -1246,7 +1246,7 @@ class Role(HostPolicy):
 
         label_ids = self.labels.copy()
         label_ids.remove(label.id)
-        return self.patch({"labels": label_ids}, use_json=True)
+        return self.patch({"labels": label_ids})
 
     def add_host(self, name: str) -> bool:
         """Add a host to the role by name.

--- a/mreg_cli/utilities/api.py
+++ b/mreg_cli/utilities/api.py
@@ -203,7 +203,6 @@ def _request_wrapper(
     params: dict[str, Any] | None = None,
     ok404: bool = False,
     first: bool = True,
-    use_json: bool = False,
     **data: Any,
 ) -> ResponseLike | None:
     """Wrap request calls to MREG for logging and token management."""
@@ -211,12 +210,12 @@ def _request_wrapper(
         params = {}
     url = urljoin(MregCliConfig().get_url(), path)
 
-    if use_json:
-        result = getattr(session, operation_type)(url, json=params, timeout=HTTP_TIMEOUT)
-    else:
-        result = getattr(session, operation_type)(
-            url, params=params, data=data, timeout=HTTP_TIMEOUT
-        )
+    result = getattr(session, operation_type)(
+        url,
+        params=params,
+        json=data or None,
+        timeout=HTTP_TIMEOUT,
+    )
     result = cast(requests.Response, result)  # convince mypy that result is a Response
 
     OutputManager().recording_request(operation_type, url, params, data, result)
@@ -449,13 +448,11 @@ def post(path: str, params: dict[str, Any] | None = None, **kwargs: Any) -> Resp
     return _request_wrapper("post", path, params=params, **kwargs)
 
 
-def patch(
-    path: str, params: dict[str, Any] | None = None, use_json: bool = False, **kwargs: Any
-) -> ResponseLike | None:
+def patch(path: str, params: dict[str, Any] | None = None, **kwargs: Any) -> ResponseLike | None:
     """Use requests to make a patch request. Assumes that all kwargs are data fields."""
     if params is None:
         params = {}
-    return _request_wrapper("patch", path, params=params, use_json=use_json, **kwargs)
+    return _request_wrapper("patch", path, params=params, **kwargs)
 
 
 def delete(path: str, params: dict[str, Any] | None = None) -> ResponseLike | None:


### PR DESCRIPTION
This PR removes `use_json` from `utilities.api._request_wrapper`, and makes it so _all_ `PATCH` requests are sent with JSON encoded data. 