### PR TITLE
Validate GET responses with Pydantic

### DIFF
--- a/mreg_cli/api/abstracts.py
+++ b/mreg_cli/api/abstracts.py
@@ -83,7 +83,10 @@ def validate_patched_model(model: BaseModel, fields: dict[str, Any]) -> None:
             raise PatchError(f"Could not get value for {field_name} in patched object.") from e
 
         # Ensure patched value is the one we tried to set
-        validator = validators.get(type(nval), _validate_default)  # type: ignore # dict.get type checking is whatever
+        validator = validators.get(
+            type(nval),  # type: ignore # dict.get call with unknown type (Any) is fine
+            _validate_default,
+        )
         if not validator(nval, value):
             raise PatchError(
                 f"Patch failure! Tried to set {key} to {value}, but server returned {nval}."

--- a/mreg_cli/api/abstracts.py
+++ b/mreg_cli/api/abstracts.py
@@ -24,8 +24,8 @@ from mreg_cli.utilities.api import (
     delete,
     get,
     get_item_by_key_value,
-    get_list,
     get_list_unique,
+    get_typed,
     patch,
     post,
 )
@@ -321,8 +321,7 @@ class APIMixin(ABC):
         if ordering:
             params["ordering"] = ordering
 
-        data = get_list(cls.endpoint(), params=params, limit=limit)
-        return [cls(**item) for item in data]
+        return get_typed(cls.endpoint(), list[cls], params=params, limit=limit)
 
     @classmethod
     def get_by_query(
@@ -339,8 +338,7 @@ class APIMixin(ABC):
         if ordering:
             query["ordering"] = ordering
 
-        data = get_list(cls.endpoint().with_query(query), limit=limit)
-        return [cls(**item) for item in data]
+        return get_typed(cls.endpoint().with_query(query), list[cls], limit=limit)
 
     @classmethod
     def get_by_query_unique_or_raise(

--- a/mreg_cli/api/history.py
+++ b/mreg_cli/api/history.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel, Field, field_validator
 from mreg_cli.api.endpoints import Endpoint
 from mreg_cli.exceptions import EntityNotFound, InternalError
 from mreg_cli.outputmanager import OutputManager
-from mreg_cli.utilities.api import get_list
+from mreg_cli.utilities.api import get_list, get_typed
 
 
 class HistoryResource(str, Enum):
@@ -116,7 +116,7 @@ class HistoryItem(BaseModel):
 
         params: dict[str, str | int] = {"resource": resource_value, "name": name}
 
-        ret = get_list(Endpoint.History, params=params)
+        ret = get_typed(Endpoint.History, list[dict[str, Any]], params=params)
 
         if len(ret) == 0:
             raise EntityNotFound(f"No history found for {name}")
@@ -128,7 +128,7 @@ class HistoryItem(BaseModel):
             "model_id__in": model_ids,
         }
 
-        ret = get_list(Endpoint.History, params=params)
+        ret = get_typed(Endpoint.History, list[dict[str, Any]], params=params)
 
         data_relation = resource.relation()
 
@@ -136,6 +136,6 @@ class HistoryItem(BaseModel):
             "data__relation": data_relation,
             "data__id__in": model_ids,
         }
-        ret.extend(get_list(Endpoint.History, params=params))
+        ret.extend(get_typed(Endpoint.History, list[dict[str, Any]], params=params))
 
-        return [cls(**i) for i in ret]
+        return [cls.model_validate(i) for i in ret]

--- a/mreg_cli/tokenfile.py
+++ b/mreg_cli/tokenfile.py
@@ -35,7 +35,7 @@ class TokenFile:
 
     def __init__(self, tokens: Optional[list[dict[str, str]]] = None):
         """Initialize the TokenFile instance."""
-        self.tokens = [Token.model_validate(token) for token in tokens] if tokens else []
+        self.tokens = [Token(**token) for token in tokens] if tokens else []
 
     @classmethod
     def _load_tokens(cls) -> "TokenFile":

--- a/mreg_cli/tokenfile.py
+++ b/mreg_cli/tokenfile.py
@@ -35,7 +35,7 @@ class TokenFile:
 
     def __init__(self, tokens: Optional[list[dict[str, str]]] = None):
         """Initialize the TokenFile instance."""
-        self.tokens = [Token(**token) for token in tokens] if tokens else []
+        self.tokens = [Token.model_validate(token) for token in tokens] if tokens else []
 
     @classmethod
     def _load_tokens(cls) -> "TokenFile":

--- a/mreg_cli/types.py
+++ b/mreg_cli/types.py
@@ -62,6 +62,7 @@ NargsStr = Literal["?", "*", "+", "...", "A...", "==SUPPRESS=="]
 NargsType = int | NargsStr
 
 
+# Source: https://docs.pydantic.dev/2.7/concepts/types/#named-recursive-types
 def json_custom_error_validator(
     value: Any, handler: ValidatorFunctionWrapHandler, _info: ValidationInfo
 ) -> Any:

--- a/mreg_cli/types.py
+++ b/mreg_cli/types.py
@@ -11,7 +11,6 @@ from typing import (
     Literal,
     Mapping,
     NamedTuple,
-    Protocol,
     Sequence,
     TypeAlias,
     TypedDict,
@@ -21,7 +20,6 @@ from typing import (
 
 from pydantic import ValidationError, ValidationInfo, ValidatorFunctionWrapHandler, WrapValidator
 from pydantic_core import PydanticCustomError
-from requests.structures import CaseInsensitiveDict
 from typing_extensions import TypeAliasType
 
 CommandFunc = Callable[[argparse.Namespace], None]
@@ -129,36 +127,3 @@ class Command(NamedTuple):
 
 # Config
 DefaultType = TypeVar("DefaultType")
-
-
-class ResponseLike(Protocol):
-    """Interface for objects that resemble a requests.Response object."""
-
-    @property
-    def ok(self) -> bool:
-        """Return True if the response was successful."""
-        ...
-
-    @property
-    def status_code(self) -> int:
-        """Return the HTTP status code."""
-        ...
-
-    @property
-    def reason(self) -> str:
-        """Return the HTTP status reason."""
-        ...
-
-    @property
-    def headers(self) -> CaseInsensitiveDict[str]:
-        """Return the dictionary of response headers."""
-        ...
-
-    @property
-    def text(self) -> str:
-        """Return the response body as text."""
-        ...
-
-    def json(self, **kwargs: Any) -> Any:
-        """Return the response body as JSON."""
-        ...

--- a/mreg_cli/types.py
+++ b/mreg_cli/types.py
@@ -22,6 +22,7 @@ from typing import (
 from pydantic import ValidationError, ValidationInfo, ValidatorFunctionWrapHandler, WrapValidator
 from pydantic_core import PydanticCustomError
 from requests.structures import CaseInsensitiveDict
+from typing_extensions import TypeAliasType
 
 CommandFunc = Callable[[argparse.Namespace], None]
 
@@ -76,10 +77,13 @@ def json_custom_error_validator(
         ) from None
 
 
-type Json = Annotated[
-    Union[Mapping[str, "Json"], Sequence["Json"], str, int, float, bool, None],
-    WrapValidator(json_custom_error_validator),
-]
+Json = TypeAliasType(
+    "Json",
+    Annotated[
+        Union[Mapping[str, "Json"], Sequence["Json"], str, int, float, bool, None],
+        WrapValidator(json_custom_error_validator),
+    ],
+)
 JsonMapping = Mapping[str, Json]
 
 

--- a/mreg_cli/utilities/api.py
+++ b/mreg_cli/utilities/api.py
@@ -344,16 +344,14 @@ def get_list_unique(
     :returns: A single dictionary, or None if no result was found and ok404 is True.
     """
     ret = get_list_generic(path, params, ok404, expect_one_result=True)
-
-    if not isinstance(ret, dict):
-        raise CliError(f"Expected a single result, got {type(ret)}.")
-
     if not ret:
         return None
 
-    # HACK: convince type checker we have a dict[str, Json] here
-    # TODO: add validation
-    return cast(JsonMapping, ret)
+    try:
+        validator = TypeAdapter(JsonMapping)
+        return validator.validate_python(ret)
+    except ValidationError as e:
+        raise MregValidationError(f"Failed to validate response from {path}: {e}") from e
 
 
 class PaginatedResponse(BaseModel):

--- a/mreg_cli/utilities/api.py
+++ b/mreg_cli/utilities/api.py
@@ -350,7 +350,9 @@ def get_list_unique(
     if not ret:
         return None
 
-    return ret
+    # HACK: convince type checker we have a dict[str, Json] here
+    # TODO: add validation
+    return cast(JsonMapping, ret)
 
 
 class PaginatedResponse(BaseModel):

--- a/mreg_cli/utilities/api.py
+++ b/mreg_cli/utilities/api.py
@@ -35,6 +35,7 @@ from requests import Response
 
 from mreg_cli.config import MregCliConfig
 from mreg_cli.exceptions import CliError, LoginFailedError
+from mreg_cli.exceptions import ValidationError as MregValidationError
 from mreg_cli.log import cli_error, cli_warning
 from mreg_cli.outputmanager import OutputManager
 from mreg_cli.tokenfile import TokenFile
@@ -386,7 +387,7 @@ def validate_list_response(response: Response) -> list[Json]:
     try:
         return ListResponse.validate_json(response.text)
     except (ValidationError, ValueError) as e:
-        raise CliError(f"Failed to validate response: {e}") from e
+        raise MregValidationError(f"Failed to validate response: {e}") from e
 
 
 def validate_paginated_response(response: Response) -> PaginatedResponse:
@@ -394,7 +395,7 @@ def validate_paginated_response(response: Response) -> PaginatedResponse:
     try:
         return PaginatedResponse.from_response(response)
     except (ValidationError, ValueError) as e:
-        raise CliError(f"Failed to validate paginated response: {e}") from e
+        raise MregValidationError(f"Failed to validate paginated response: {e}") from e
 
 
 @overload


### PR DESCRIPTION
This PR builds on #240 by adding validation of responses with Pydantic for API functions that return responses as Python objects (`get_list` and friends). 

This is such a comprehensive set of changes that I am a bit apprehensive about it. We'll see how the CI tests go!