### PR TITLE
Fix broken command(s) in CI

### DIFF
--- a/ci/testsuite
+++ b/ci/testsuite
@@ -350,7 +350,8 @@ network remove 2001:db8::/64 -f
 label add postit 'This is a label'
 label list
 label info postit
-label rename postit mylabel -desc 'This is the new description'
+label rename postit mylabel
+label set_description mylabel 'This is the new description'
 label remove mylabel
 # Roles
 label add postit 'A label again'

--- a/mreg_cli/commands/host_submodules/rr.py
+++ b/mreg_cli/commands/host_submodules/rr.py
@@ -444,7 +444,7 @@ def naptr_show(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name)
     """
-    NAPTR.output_multiple(Host.get_by_any_means_or_raise(args.host).naptrs())
+    NAPTR.output_multiple(Host.get_by_any_means_or_raise(args.name).naptrs())
 
 
 @command_registry.register_command(


### PR DESCRIPTION
Aiming to just fix all commands that are broken in CI because of incorrect `argparse.Namespace` attribute access, and other similar surface-level issues (such as any new ones created by #240).