### PR TITLE
Add period to name when finding subzones

### DIFF
--- a/mreg_cli/api/models.py
+++ b/mreg_cli/api/models.py
@@ -672,7 +672,7 @@ class Zone(FrozenModelWithTimestamps, WithTTL, APIMixin):
 
         :returns: A list of subzones.
         """
-        zones = self.get_list_by_field("name__endswith", f"{self.name}")
+        zones = self.get_list_by_field("name__endswith", f".{self.name}")
         return [zone for zone in zones if zone.name != self.name]
 
     def ensure_deletable(self) -> None:


### PR DESCRIPTION
Matches old behavior: https://github.com/unioslo/mreg-cli/blob/e6eb660b99569d298420d3144d115061c53e4b08/mreg_cli/zone.py#L151