### PR TITLE
Strip None values when sending JSON

### DIFF
--- a/mreg_cli/utilities/api.py
+++ b/mreg_cli/utilities/api.py
@@ -191,6 +191,20 @@ def result_check(result: ResponseLike, operation_type: str, url: str) -> None:
         cli_warning(message)
 
 
+def _strip_none(data: dict[str, Any]) -> dict[str, Any]:
+    """Recursively strip None values from a dictionary."""
+    new: dict[str, Any] = {}
+    for key, value in data.items():
+        if value is not None:
+            if isinstance(value, dict):
+                v = _strip_none(value)  # pyright: ignore[reportUnknownArgumentType]
+                if v:
+                    new[key] = v
+            else:
+                new[key] = value
+    return new
+
+
 def _request_wrapper(
     operation_type: str,
     path: str,
@@ -206,7 +220,7 @@ def _request_wrapper(
 
     # Strip None values from data
     if data:
-        data = {k: v for k, v in data.items() if v is not None}
+        data = _strip_none(data)
 
     result = getattr(session, operation_type)(
         url,

--- a/mreg_cli/utilities/api.py
+++ b/mreg_cli/utilities/api.py
@@ -204,6 +204,10 @@ def _request_wrapper(
         params = {}
     url = urljoin(MregCliConfig().get_url(), path)
 
+    # Strip None values from data
+    if data:
+        data = {k: v for k, v in data.items() if v is not None}
+
     result = getattr(session, operation_type)(
         url,
         params=params,


### PR DESCRIPTION
The API is unable to handle `None` values in request data. Requests removes form data with `None` values, but the same doesn't happen automatically for JSON, so we have to do it ourselves.