### PR TITLE
Add `--version` option

### DIFF
--- a/mreg_cli/main.py
+++ b/mreg_cli/main.py
@@ -10,6 +10,7 @@ from prompt_toolkit import HTML
 from prompt_toolkit.shortcuts import CompleteStyle, PromptSession
 
 import mreg_cli.utilities.api as api
+from mreg_cli.__about__ import __version__
 from mreg_cli.cli import cli, source
 from mreg_cli.config import MregCliConfig
 from mreg_cli.exceptions import LoginFailedError
@@ -47,6 +48,12 @@ def main():
         default_url = config.get_url()
     except ValueError:
         pass
+
+    parser.add_argument(
+        "--version",
+        help="Show version and exit.",
+        action="store_true",
+    )
 
     connect_args = parser.add_argument_group("connection settings")
     connect_args.add_argument(
@@ -134,6 +141,11 @@ def main():
     )
 
     args = parser.parse_args()
+
+    if args.version:
+        print(f"mreg-cli version {__version__}")
+        raise SystemExit() from None
+
     setup_logging(args.verbosity)
     logger.debug(f"args: {args}")
     conf = {k: v for k, v in vars(args).items() if v}


### PR DESCRIPTION
```
$ mreg-cli --version
mreg-cli version 1.0.0
```

```
$ mreg-cli --help   
usage: mreg-cli [-h] [--version] [--url URL] [-u USER] [-d DOMAIN] [-p PROMPT] [-v] [-l LOGFILE] [--show-token] [--record RECFILE]
                [--record-without-timestamps] [--source SOURCE] [--token-only]
                [command ...]

The MREG cli

options:
  -h, --help            show this help message and exit
  --version             Show version and exit.

connection settings:
  --url URL             use mreg server at URL (default: http://127.0.0.1:8000)
  -u USER, --user USER  authenticate as USER (default: test)

mreg settings:
  -d DOMAIN, --domain DOMAIN
                        default DOMAIN (default: example.org)
  -p PROMPT, --prompt PROMPT
                        default PROMPT), defaults to the server name if not set.

output settings:
  -v, --verbosity       show debug messages on stderr
  -l LOGFILE, --logfile LOGFILE
                        write log to LOGFILE
  --show-token          show API token after login
  --record RECFILE      Record all server/client traffic to RECFILE
  --record-without-timestamps
                        Do not apply timestamps to the recording file
  --source SOURCE       Read commands from SOURCE
  --token-only          Only attempt token login, this will avoid interactive prompts.
  command               Oneshot command to issue to the cli.
  ```