### PR TITLE
Use specialized exceptions.

### DIFF
--- a/mreg_cli/api/abstracts.py
+++ b/mreg_cli/api/abstracts.py
@@ -501,7 +501,7 @@ class APIMixin(ABC):
             # Lots of endpoints don't give locations on creation,
             # so we can't fetch the object, but it's not an error...
             # Per se.
-            # raise CliWarning("No location header in response.")
+            # raise APIError("No location header in response.")
 
         else:
             raise CreateError(f"Failed to create {cls} with {params} @ {cls.endpoint()}.")

--- a/mreg_cli/api/models.py
+++ b/mreg_cli/api/models.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import ipaddress
 import re
 from datetime import date, datetime
-from mreg_cli.outputmanager import OutputManager
 from typing import Any, ClassVar, Literal, Self, cast
 
 from pydantic import (
@@ -25,12 +24,12 @@ from mreg_cli.api.fields import IPAddressField, MACAddressField, NameList
 from mreg_cli.api.history import HistoryItem, HistoryResource
 from mreg_cli.config import MregCliConfig
 from mreg_cli.exceptions import (
-    CliWarning,
     CreateError,
     DeleteError,
     EntityAlreadyExists,
     EntityNotFound,
     EntityOwnershipMismatch,
+    ForceMissing,
     InputFailure,
     InternalError,
     InvalidIPAddress,
@@ -614,7 +613,7 @@ class Zone(FrozenModelWithTimestamps, WithTTL, APIMixin):
                     if not host.ipaddresses and not force:
                         errors.append(f"{nameserver} has no A-record/glue, must force")
         if errors:
-            raise CliWarning("\n".join(errors))
+            raise ForceMissing("\n".join(errors))
 
     @classmethod
     def create_zone(

--- a/mreg_cli/cli.py
+++ b/mreg_cli/cli.py
@@ -28,7 +28,7 @@ from mreg_cli.commands.policy import PolicyCommands
 from mreg_cli.commands.zone import ZoneCommands
 
 # Import other mreg_cli modules
-from mreg_cli.exceptions import CliError, CliWarning
+from mreg_cli.exceptions import CliError, CliWarning, InputFailure
 from mreg_cli.help_formatter import CustomHelpFormatter
 from mreg_cli.outputmanager import OutputManager
 from mreg_cli.types import CommandFunc, Flag
@@ -250,7 +250,11 @@ class Command(Completer):
         output.clear()
         # Set the command that generated the output
         # Also remove filters and other noise.
-        cmd = output.from_command(line)
+        try:
+            cmd = output.from_command(line)
+        except (CliWarning, CliError) as exc:
+            exc.print_self()
+            return
         # Create and set the corrolation id, using the cleaned command
         # as the suffix. This is used to track the command in the logs
         # on the server side.
@@ -273,7 +277,7 @@ def _quit(_: argparse.Namespace) -> NoReturn:
 def _start_recording(args: argparse.Namespace) -> None:
     """Start recording commands and output to the given file."""
     if not args.filename:
-        raise CliError("No filename given.")
+        raise InputFailure("No filename given.")
 
     OutputManager().recording_start(args.filename)
 

--- a/mreg_cli/commands/host.py
+++ b/mreg_cli/commands/host.py
@@ -14,7 +14,7 @@ from typing import Any
 
 from mreg_cli.commands.base import BaseCommand
 from mreg_cli.commands.registry import CommandRegistry
-
+from mreg_cli.exceptions import InternalError
 
 registry = CommandRegistry()
 
@@ -45,7 +45,7 @@ class HostCommands(BaseCommand):
 
         # Get the directory path of the package
         if package.__file__ is None:
-            raise CliError(f"Unable to initalize host submodules from {package_name}")
+            raise InternalError(f"Unable to initalize host submodules from {package_name}")
 
         package_dir = os.path.dirname(package.__file__)
 

--- a/mreg_cli/commands/host_submodules/core.py
+++ b/mreg_cli/commands/host_submodules/core.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 
 import argparse
 
-from mreg_cli.api.history import HistoryResource
 from mreg_cli.api.models import ForwardZone, Host, HostList, HostT, MACAddressField, NetworkOrIP
 from mreg_cli.commands.host import registry as command_registry
 from mreg_cli.exceptions import (
@@ -451,9 +450,7 @@ def set_comment(args: argparse.Namespace) -> None:
     if not updated_host:
         raise PatchError(f"Failed to update comment of {host.name}")
 
-    OutputManager().add_ok(
-        f"Updated comment of {host} to {args.comment}"
-    )
+    OutputManager().add_ok(f"Updated comment of {host} to {args.comment}")
 
 
 @command_registry.register_command(

--- a/mreg_cli/commands/policy.py
+++ b/mreg_cli/commands/policy.py
@@ -5,11 +5,10 @@ from __future__ import annotations
 import argparse
 from typing import Any
 
-from mreg_cli.api.history import HistoryResource
 from mreg_cli.api.models import Atom, Host, HostPolicy, Role
 from mreg_cli.commands.base import BaseCommand
 from mreg_cli.commands.registry import CommandRegistry
-
+from mreg_cli.exceptions import CreateError, DeleteError, EntityAlreadyExists
 from mreg_cli.outputmanager import OutputManager
 from mreg_cli.types import Flag
 
@@ -75,7 +74,7 @@ def atom_delete(args: argparse.Namespace) -> None:
     if atom.delete():
         OutputManager().add_ok(f"Deleted atom {name}")
     else:
-        raise CliError(f"Failed to delete atom {name}")
+        raise DeleteError(f"Failed to delete atom {name}")
 
 
 @command_registry.register_command(
@@ -127,7 +126,7 @@ def role_delete(args: argparse.Namespace) -> None:
     if role.delete():
         OutputManager().add_ok(f"Deleted role {name!r}")
     else:
-        raise CliError(f"Failed to delete role {name!r}")
+        raise DeleteError(f"Failed to delete role {name!r}")
 
 
 @command_registry.register_command(
@@ -151,7 +150,7 @@ def add_atom(args: argparse.Namespace) -> None:
     if role.add_atom(atom_name):
         OutputManager().add_ok(f"Added atom {atom_name!r} to role {role_name!r}")
     else:
-        raise CliError(f"Failed to add atom {atom_name!r} to role {role_name!r}")
+        raise CreateError(f"Failed to add atom {atom_name!r} to role {role_name!r}")
 
 
 @command_registry.register_command(
@@ -175,7 +174,7 @@ def remove_atom(args: argparse.Namespace) -> None:
     if role.remove_atom(atom_name):
         OutputManager().add_ok(f"Removed atom {atom_name!r} from role {role_name!r}")
     else:
-        raise CliError(f"Failed to remove atom {atom_name!r} from role {role_name!r}")
+        raise DeleteError(f"Failed to remove atom {atom_name!r} from role {role_name!r}")
 
 
 @command_registry.register_command(
@@ -375,7 +374,7 @@ def rename(args: argparse.Namespace) -> None:
     newname: str = args.newname
 
     if oldname == newname:
-        raise CliWarning("Old and new names are the same")
+        raise EntityAlreadyExists("Old and new names are the same")
 
     # Check if role or atom with the new name already exists
     HostPolicy.get_role_or_atom_and_raise(newname)

--- a/mreg_cli/commands/zone.py
+++ b/mreg_cli/commands/zone.py
@@ -8,7 +8,7 @@ from typing import Any
 from mreg_cli.api.models import Zone
 from mreg_cli.commands.base import BaseCommand
 from mreg_cli.commands.registry import CommandRegistry
-from mreg_cli.exceptions import DeleteError
+from mreg_cli.exceptions import DeleteError, InputFailure
 from mreg_cli.outputmanager import OutputManager
 from mreg_cli.types import Flag
 
@@ -154,7 +154,7 @@ def zone_list(args: argparse.Namespace) -> None:
     :param args: argparse.Namespace (forward, reverse)
     """
     if not (args.forward or args.reverse):
-        raise CliWarning("Add either -forward or -reverse as argument")
+        raise InputFailure("Add either -forward or -reverse as argument")
     Zone.output_zones(args.forward, args.reverse)
 
 

--- a/mreg_cli/exceptions.py
+++ b/mreg_cli/exceptions.py
@@ -8,6 +8,7 @@ context of a CLI command.
 from __future__ import annotations
 
 import sys
+from typing import Any
 
 from prompt_toolkit import print_formatted_text
 from prompt_toolkit.formatted_text import HTML
@@ -35,9 +36,11 @@ class CliError(CliException):
     the user cannot be expected to resolve.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any):
+        """Initialize the error."""
         super().__init__(*args, **kwargs)
         from mreg_cli.outputmanager import OutputManager
+
         OutputManager().add_error(super().__str__())
 
     def formatted_exception(self) -> str:
@@ -45,7 +48,7 @@ class CliError(CliException):
 
         :returns: Formatted error message.
         """
-        return f"<ansired>{super().__str__()}</ansired>"
+        return f"<ansired>ERROR: {super().__str__()}</ansired>"
 
 
 class CliWarning(CliException):
@@ -54,9 +57,11 @@ class CliWarning(CliException):
     Warnings should be recoverable by changing the user input.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any):
+        """Initialize the warning."""
         super().__init__(*args, **kwargs)
         from mreg_cli.outputmanager import OutputManager
+
         OutputManager().add_warning(super().__str__())
 
     def formatted_exception(self) -> str:
@@ -111,6 +116,30 @@ class UnexpectedDataError(APIError):
 
 class ValidationError(CliError):
     """Error class for validation failures."""
+
+    pass
+
+
+class FileError(CliError):
+    """Error class for file errors."""
+
+    pass
+
+
+class APINotOk(CliWarning):
+    """Warning class for API not returning OK."""
+
+    pass
+
+
+class TooManyResults(CliWarning):
+    """Warning class for too many results."""
+
+    pass
+
+
+class NoHistoryFound(CliWarning):
+    """Warning class for no history found."""
 
     pass
 

--- a/mreg_cli/outputmanager.py
+++ b/mreg_cli/outputmanager.py
@@ -19,7 +19,7 @@ from urllib.parse import urlencode, urlparse
 import requests
 from pydantic import BaseModel
 
-from mreg_cli.exceptions import CliError
+from mreg_cli.exceptions import FileError, InputFailure
 from mreg_cli.types import RecordingEntry, TimeInfo
 
 
@@ -175,7 +175,7 @@ class OutputManager:
             with open(filename, "w") as _:
                 pass
         except OSError as exc:
-            raise CliError(f"Unable open file for writing: {filename}") from exc
+            raise FileError(f"Unable open recording file for writing: {filename}") from exc
 
         self._recording = True
         self._filename = filename
@@ -388,12 +388,12 @@ class OutputManager:
                     filter_re = re.compile(filter_str)
                 except re.error as exc:
                     if "|" in filter_str:
-                        raise CliError(
-                            "ERROR: Command parts that contain a pipe ('|') must be quoted.",
+                        raise InputFailure(
+                            "Command parts that contain a pipe ('|') must be quoted.",
                         ) from exc
                     else:
-                        raise CliError(
-                            "ERROR: Unable to compile regex '{}': {}", filter_str, exc
+                        raise InputFailure(
+                            f"Unable to compile regex '{filter_str}': {exc}"
                         ) from exc
 
         return (command, filter_re, negate)

--- a/mreg_cli/utilities/history.py
+++ b/mreg_cli/utilities/history.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from dateutil.parser import parse
 
-
+from mreg_cli.exceptions import InternalError, NoHistoryFound
 from mreg_cli.outputmanager import OutputManager
 from mreg_cli.utilities.api import get_list
 
@@ -24,7 +24,7 @@ def get_history_items(
     }
     ret = get_list(path, params=params)
     if len(ret) == 0:
-        raise CliWarning(f"No history found for {name}")
+        raise NoHistoryFound(f"No history found for {name}")
     # Get all model ids, a group gets a new one when deleted and created again
     model_ids = ",".join({str(i["model_id"]) for i in ret})
     params = {
@@ -92,6 +92,6 @@ def format_history_items(ownname: str, items: list[dict[str, Any]]) -> None:
             else:
                 msg = ", ".join(f"{k} = '{v}'" for k, v in data.items())
         else:
-            raise CliWarning(f"Unhandled history entry: {i}")
+            raise InternalError(f"Unhandled history entry: {i}")
 
         OutputManager().add_line(f"{timestamp} [{i['user']}]: {model} {action}: {msg}")

--- a/mreg_cli/utilities/network.py
+++ b/mreg_cli/utilities/network.py
@@ -12,7 +12,7 @@ from collections.abc import Iterable
 from typing import Any
 
 from mreg_cli.api.models import Network
-
+from mreg_cli.exceptions import EntityNotFound, EntityOwnershipMismatch, InputFailure
 from mreg_cli.types import IP_networkTV
 from mreg_cli.utilities.api import get, get_typed
 from mreg_cli.utilities.validators import is_valid_ip, is_valid_network
@@ -27,7 +27,9 @@ def get_network_first_unused_ip(network: dict[str, Any]) -> str:
     """
     unused = get_network_first_unused(network["network"])
     if not unused:
-        raise CliWarning("No free addresses remaining on network {}".format(network["network"]))
+        raise EntityNotFound(
+            "No free addresses remaining on network {}".format(network["network"])
+        )
     return unused
 
 
@@ -72,9 +74,11 @@ def get_network(ip: str) -> Network | None:
         net = Network.get_by_ip(ipaddress.ip_address(ip))
         if net:
             return net
-        raise CliWarning("ip address exists but is not an address in any existing network")
+        raise EntityOwnershipMismatch(
+            "ip address exists but is not an address in any existing network"
+        )
     else:
-        raise CliWarning("Not a valid ip range or ip address")
+        raise InputFailure("Not a valid ip range or ip address")
 
 
 def get_network_used_count(ip_range: str) -> int:

--- a/mreg_cli/utilities/output.py
+++ b/mreg_cli/utilities/output.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 from typing import Any
 
-
+from mreg_cli.exceptions import EntityNotFound, MultipleEntititesFound
 from mreg_cli.outputmanager import OutputManager
 from mreg_cli.utilities.api import get_list
 from mreg_cli.utilities.validators import is_valid_ipv4, is_valid_ipv6
@@ -323,7 +323,9 @@ def output_ip_info(ip: str) -> None:
 
     output_ipaddresses(ipaddresses, names=True)
     if len(ipaddresses) > 1 and ptrhost is None:
-        raise CliWarning(f"IP {ip} used by {len(ipaddresses)} hosts, but no PTR override")
+        raise MultipleEntititesFound(
+            f"IP {ip} used by {len(ipaddresses)} hosts, but no PTR override"
+        )
     if ptrhost is None:
         path = "/api/v1/hosts/"
         params = {
@@ -335,5 +337,5 @@ def output_ip_info(ip: str) -> None:
         elif ipaddresses:
             ptrhost = "default"
     if not ipaddresses and ptrhost is None:
-        raise CliWarning(f"Found no hosts or ptr override matching IP {ip}")
+        raise EntityNotFound(f"Found no hosts or ptr override matching IP {ip}")
     output_ptr(ip, str(ptrhost))

--- a/mreg_cli/utilities/shared.py
+++ b/mreg_cli/utilities/shared.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 from typing import Any
 
-
+from mreg_cli.exceptions import InputFailure
 
 
 # Temporary, to avoid circular imports and to allow old code to remain without
@@ -25,7 +25,7 @@ def clean_hostname(name: str | bytes) -> str:
 
     # bytes?
     if not isinstance(name, (str, bytes)):
-        raise CliWarning(f"Invalid input for hostname: {name}")
+        raise InputFailure(f"Invalid input for hostname: {name}")
 
     if isinstance(name, bytes):
         name = name.decode()
@@ -34,7 +34,7 @@ def clean_hostname(name: str | bytes) -> str:
 
     # invalid characters?
     if re.search(r"^(\*\.)?([a-z0-9_][a-z0-9\-]*\.?)+$", name) is None:
-        raise CliWarning(f"Invalid input for hostname: {name}")
+        raise InputFailure(f"Invalid input for hostname: {name}")
 
     # Assume user is happy with domain, but strip the dot.
     if name.endswith("."):
@@ -57,7 +57,7 @@ def string_to_int(value: Any, error_tag: str) -> int:
     try:
         return int(value)
     except ValueError:
-        raise CliWarning("%s: Not a valid integer" % error_tag)
+        raise InputFailure("%s: Not a valid integer" % error_tag)
 
 
 def format_mac(mac: str) -> str:

--- a/mreg_cli/utilities/validators.py
+++ b/mreg_cli/utilities/validators.py
@@ -10,7 +10,7 @@ import ipaddress
 import re
 
 from mreg_cli.config import MregCliConfig
-
+from mreg_cli.exceptions import InputFailure, InvalidIPv4Address, InvalidIPv6Address
 from mreg_cli.types import IP_Version
 
 
@@ -92,9 +92,9 @@ def is_ipversion(ip: str, ipversion: IP_Version) -> None:
     # Ip sanity check
     if ipversion == 4:
         if not is_valid_ipv4(ip):
-            raise CliWarning(f"not a valid ipv4: {ip}")
+            raise InvalidIPv4Address(f"not a valid ipv4: {ip}")
     elif ipversion == 6:
         if not is_valid_ipv6(ip):
-            raise CliWarning(f"not a valid ipv6: {ip}")
+            raise InvalidIPv6Address(f"not a valid ipv6: {ip}")
     else:
-        raise CliWarning(f"Unknown ipversion: {ipversion}")
+        raise InputFailure(f"Unknown ipversion: {ipversion}")

--- a/mreg_cli/utilities/zone.py
+++ b/mreg_cli/utilities/zone.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-
+from mreg_cli.exceptions import EntityOwnershipMismatch, ForceMissing
 from mreg_cli.utilities.api import get
 
 
@@ -24,9 +24,9 @@ def zone_check_for_hostname(name: str, force: bool, require_zone: bool = False) 
     zoneinfo = zoneinfo_for_hostname(name)
     if zoneinfo is None:
         if require_zone:
-            raise CliWarning(f"{name} isn't in a zone controlled by MREG.")
+            raise EntityOwnershipMismatch(f"{name} isn't in a zone controlled by MREG.")
         if not force:
-            raise CliWarning(f"{name} isn't in a zone controlled by MREG, must force")
+            raise ForceMissing(f"{name} isn't in a zone controlled by MREG, must force")
     elif "delegation" in zoneinfo and not force:
         delegation = zoneinfo["delegation"]["name"]
-        raise CliWarning(f"{name} is in zone delegation {delegation}, must force")
+        raise ForceMissing(f"{name} is in zone delegation {delegation}, must force")


### PR DESCRIPTION
  - This PR migrates all use of CliError and CliWarning to more specialized exceptions.
  - Also fix a bug with handling broken filter expressions.
  - Prefixes Errors with ERROR as not everyone has color vision.