### PR TITLE
Fix fetching networks given a location

### DIFF
--- a/mreg_cli/api/abstracts.py
+++ b/mreg_cli/api/abstracts.py
@@ -403,8 +403,8 @@ class APIMixin(ABC):
     @classmethod
     def get_by_location(cls, location: str) -> Self | None:
         """Fetch an object by its location as returned by a `POST` request."""
-        external_id_field = cls.endpoint().external_id_field()
-        if external_id_field == "id":
+        id_field = cls.field_for_endpoint()
+        if id_field == "id":
             id_ = location.rpartition("/")[-1]
             if not id_:
                 raise GetError(f"Could not extract ID from location {location}.")
@@ -412,14 +412,14 @@ class APIMixin(ABC):
                 return cls.get_by_id(int(id_))
             except TypeError:
                 raise GetError(f"Could not extract numeric ID from location {location}") from None
-        elif external_id_field == "network":
+        elif id_field == "network":
             parts = location.split("/")
             if len(parts) <= 2:
                 raise GetError(f"Could not extract network from location {location}.")
             network = "/".join(parts[-2:])
-            return cls.get_by_field(external_id_field, network)
+            return cls.get_by_field(id_field, network)
         else:
-            return cls.get_by_field(external_id_field, location.rpartition("/")[-1])
+            return cls.get_by_field(id_field, location.rpartition("/")[-1])
 
     def refetch(self) -> Self:
         """Fetch an updated version of the object.

--- a/mreg_cli/api/endpoints.py
+++ b/mreg_cli/api/endpoints.py
@@ -3,29 +3,8 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any, Callable
-from mreg_cli.outputmanager import OutputManager
+from typing import Literal
 from urllib.parse import quote, urljoin
-
-
-class hybridmethod:
-    """Decorator to allow a method to be called both as a class method and an instance method."""
-
-    def __init__(self, func: Callable[..., Any]):
-        """Initialize the hybrid method."""
-        self.func = func
-
-    def __get__(self, obj: object | None, cls: type | None = None):
-        """Return a method that can be called both as a class method and an instance method."""
-        if obj is None:
-            return classmethod(self.func).__get__(None, cls)
-        else:
-            # Called on an instance, act like an instance method
-            return self.func.__get__(obj)
-
-    def __call__(self, *args: Any, **kwargs: Any):
-        """Caller method."""
-        return self.func(*args, **kwargs)
 
 
 class Endpoint(str, Enum):
@@ -107,8 +86,7 @@ class Endpoint(str, Enum):
         """Return True if this endpoint requires a search for an ID."""
         return self.external_id_field() != "id"
 
-    @hybridmethod
-    def external_id_field(self) -> str:
+    def external_id_field(self) -> Literal["id", "name", "network", "host"]:
         """Return the name of the field that holds the external ID."""
         if self in (
             Endpoint.Hosts,
@@ -128,7 +106,6 @@ class Endpoint(str, Enum):
             return "host"
         return "id"
 
-    # Add methods via composition
     def with_id(self, identity: str | int) -> str:
         """Return the endpoint with an ID."""
         id_field = quote(str(identity))


### PR DESCRIPTION
This PR fixes fetching networks given a location returned by the API. 

In order to make the `Literal` annotation for the `Endpoint.external_id_field()` method work, I had to remove the `@hybridmethod` decorator, but i seemed to be unnecessary anyway? We always call `external_id_field()` on instances of `Endpoint`.