### PR TITLE
Instantiate JSON mapping validator at top level

### DIFF
--- a/mreg_cli/utilities/api.py
+++ b/mreg_cli/utilities/api.py
@@ -48,6 +48,8 @@ HTTP_TIMEOUT = 20
 
 T = TypeVar("T")
 
+JsonMappingValidator = TypeAdapter(JsonMapping)
+
 
 def error(msg: str | Exception, code: int = os.EX_UNAVAILABLE) -> NoReturn:
     """Print an error message and exits with the given code."""
@@ -362,10 +364,8 @@ def get_list_unique(
     ret = get_list_generic(path, params, ok404, expect_one_result=True)
     if not ret:
         return None
-
     try:
-        validator = TypeAdapter(JsonMapping)
-        return validator.validate_python(ret)
+        return JsonMappingValidator.validate_python(ret)
     except ValueError as e:
         raise ValidationError(f"Failed to validate response from {path}: {e}") from e
 


### PR DESCRIPTION
This PR moves the instantiation of the JSON mapping validator from `get_list_unique()` to the global scope.