### PR TITLE
Fix fetching paginated endpoints twice in `get_list_generic`

### DIFF
--- a/mreg_cli/utilities/api.py
+++ b/mreg_cli/utilities/api.py
@@ -475,23 +475,6 @@ def get_list_generic(
 
     :returns: A list of dictionaries or a dictionary if expect_one_result is True.
     """
-
-    def _check_expect_one_result(
-        ret: list[Json],
-    ) -> Json | list[Json]:
-        if expect_one_result:
-            if len(ret) == 0:
-                return {}
-            if len(ret) != 1:
-                raise MultipleEntititesFound(f"Expected exactly one result, got {len(ret)}.")
-
-            return ret[0]
-
-        return ret
-
-    if params is None:
-        params = {}
-
     response = get(path, params)
 
     # Non-paginated results, return them directly
@@ -511,7 +494,13 @@ def get_list_generic(
             break
         resp = validate_paginated_response(response)
         ret.extend(resp.results)
-    return _check_expect_one_result(ret)
+    if expect_one_result:
+        if len(ret) == 0:
+            return {}
+        if len(ret) != 1:
+            raise MultipleEntititesFound(f"Expected exactly one result, got {len(ret)}.")
+        return ret[0]
+    return ret
 
 
 def get_typed(

--- a/mreg_cli/utilities/api.py
+++ b/mreg_cli/utilities/api.py
@@ -508,7 +508,7 @@ def get_list_generic(
     while resp.next:
         response = get(resp.next, params=params, ok404=ok404)
         if response is None:
-            return _check_expect_one_result(ret)
+            break
         resp = validate_paginated_response(response)
         ret.extend(resp.results)
     return _check_expect_one_result(ret)


### PR DESCRIPTION
When writing unit tests for `get_list`, I discovered that we fetch the first page twice when dealing with paginated content that has more than one page of results.

Here's what is currently happening:

1. We fetch, then check if we are dealing with paginated content
2. If we are dealing with paginated content, we fetch the first page again and check for a `next` value.
3. We loop until there are no new `next` values.

This PR eliminates step 2, and enters the while-loop as long as we have a `next` value. If we only have a single page, the loop is never entered.

## Reproducing

By setting the page size to 1 and fetching something known to have more than 1 result, we can see that the first page is fetched twice when adding a print statement to the `get()` function:

```
mreg-test.uio.no> network find -desc *bio*

# Debugger is entered here to set page size
>>> path
'/api/v1/networks/?description__regex=.%2Abio.%2A'
>>> path+="&page_size=1"
>>> path 
'/api/v1/networks/?description__regex=.%2Abio.%2A&page_size=1'

# Application continues executing here
/api/v1/networks/?description__regex=.%2Abio.%2A&page_size=1
/api/v1/networks/?description__regex=.%2Abio.%2A&page_size=1
http://mreg-test.uio.no/api/v1/networks/?description__regex=.%2Abio.%2A&page=2&page_size=1
http://mreg-test.uio.no/api/v1/networks/?description__regex=.%2Abio.%2A&page=3&page_size=1
http://mreg-test.uio.no/api/v1/networks/?description__regex=.%2Abio.%2A&page=4&page_size=1
http://mreg-test.uio.no/api/v1/networks/?description__regex=.%2Abio.%2A&page=5&page_size=1
http://mreg-test.uio.no/api/v1/networks/?description__regex=.%2Abio.%2A&page=6&page_size=1
http://mreg-test.uio.no/api/v1/networks/?description__regex=.%2Abio.%2A&page=7&page_size=1
```

The first page (`/api/v1/networks/?description__regex=.%2Abio.%2A&page_size=1`) is fetched twice in this case.


## Testing

We never caught this in the integration test suite because we don't have enough data for any of the endpoints to return more than one page of results. Pagination unit tests have been added to #251 to ensure pagination works as expected.