### PR TITLE
Fix PyInstaller `host_submodules` imports

### DIFF
--- a/mreg_cli/commands/host_submodules/__init__.py
+++ b/mreg_cli/commands/host_submodules/__init__.py
@@ -11,3 +11,16 @@ command module, which is a bit hacky, but it works.
 Note: This design will imply circular imports, so the core host command
 imports the submodules after it has been initialized.
 """
+
+# We have to import each of the submodules explictly here in order to
+# ensure they are included when we build binaries with PyInstaller.
+# We also cannot do `from . import *`. Each module must be specified.
+from . import a_aaaa, bacnet, cname, core, rr
+
+__all__ = [
+    "a_aaaa",
+    "bacnet",
+    "cname",
+    "core",
+    "rr",
+]


### PR DESCRIPTION
This PR fixes the built PyInstaller binaries not including the `host_submodules` commands.

Currently we get this:

```
mreg-test.uio.no> host info
usage: mreg-cli [-h] <command> ...
mreg-cli: error: unrecognized arguments: info
```

This happens because even though PyInstaller follows the `mreg_cli.commands.host_submodules` import, it cannot infer that it should import every module in the `host_submodules` namespace unless we explicitly perform an import of them in `__init__.py`.