### PR TITLE
Colorize diffs with Rich

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           python -m ensurepip --upgrade
           pip install -r requirements.txt
-          pip install -e .
+          pip install -e .[dev]
       - name: Test and compare api calls
         run: ci/run_testsuite_and_record.sh
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
 dynamic = ["version"]
 
 [project.optional-dependencies]
-dev = ["ruff", "tox", "pyinstaller"]
+dev = ["ruff", "tox", "pyinstaller", "rich"]
 
 [project.urls]
 Repository = 'https://github.com/unioslo/mreg-cli/'


### PR DESCRIPTION
This PR adds color to the diff produced by `ci/diff.py`:

<img width="1128" alt="image" src="https://github.com/unioslo/mreg-cli/assets/107681714/d6203da5-9626-4137-bab5-7b27c26832cf">

This is a stepping stone to eventually adding interactive diff reviewing similar to `pytest --inline-snapshot=review`:

<img width="1126" alt="image" src="https://github.com/unioslo/mreg-cli/assets/107681714/dfc5ce78-c778-4915-b5b1-c1f0071e460c">

## Compatibility

I stored the terminal output of `diff.py` before and after the code changes, and they produce identical output (except `diff_post` has color when not redirected to a file):

```
# Before:
❯ python diff.py testsuite-result.json new_testsuite_log.json > diff_pre
# After:
❯ python diff.py testsuite-result.json new_testsuite_log.json > diff_post
❯ diff -s diff_pre diff_post
Files diff_pre and diff_post are identical
```