### PR TITLE
Escape messages only in formatted exceptions

### DIFF
--- a/mreg_cli/exceptions.py
+++ b/mreg_cli/exceptions.py
@@ -25,8 +25,8 @@ class CliExit(Exception):
 class CliException(Exception):
     """Base exception class for the CLI."""
 
-    def escaped(self) -> str:
-        """Return a HTML-escaped string representation of the exception."""
+    def escape(self) -> str:
+        """Get an HTML-escaped string representation of the exception."""
         return html_escape(str(self))
 
     def formatted_exception(self) -> str:
@@ -61,7 +61,7 @@ class CliError(CliException):
 
         :returns: Formatted error message.
         """
-        return f"<ansired>ERROR: {self.escaped()}</ansired>"
+        return f"<ansired>ERROR: {self.escape()}</ansired>"
 
 
 class CliWarning(CliException):
@@ -83,7 +83,7 @@ class CliWarning(CliException):
 
         :returns: Formatted warning message.
         """
-        return f"<i>{self.escaped()}</i>"
+        return f"<i>{self.escape()}</i>"
 
 
 class CreateError(CliError):
@@ -232,7 +232,7 @@ class LoginFailedError(CliException):
 
         :returns: Formatted error message.
         """
-        return f"Login failed: {self.escaped()}"
+        return f"Login failed: {self.escape()}"
 
     def __str__(self) -> str:
         """Return the error message."""

--- a/mreg_cli/exceptions.py
+++ b/mreg_cli/exceptions.py
@@ -25,9 +25,9 @@ class CliExit(Exception):
 class CliException(Exception):
     """Base exception class for the CLI."""
 
-    def __str__(self) -> str:
+    def escaped(self) -> str:
         """Return a HTML-escaped string representation of the exception."""
-        return html_escape(super().__str__())
+        return html_escape(str(self))
 
     def formatted_exception(self) -> str:
         """Return a formatted string representation of the exception.
@@ -61,7 +61,7 @@ class CliError(CliException):
 
         :returns: Formatted error message.
         """
-        return f"<ansired>ERROR: {self}</ansired>"
+        return f"<ansired>ERROR: {self.escaped()}</ansired>"
 
 
 class CliWarning(CliException):
@@ -72,10 +72,10 @@ class CliWarning(CliException):
 
     def __init__(self, *args: Any, **kwargs: Any):
         """Initialize the warning."""
-        super().__init__(*args, **kwargs)
-        logging.getLogger(__name__).warning(str(self))
         from mreg_cli.outputmanager import OutputManager
 
+        super().__init__(*args, **kwargs)
+        logging.getLogger(__name__).warning(str(self))
         OutputManager().add_warning(str(self))
 
     def formatted_exception(self) -> str:
@@ -83,7 +83,7 @@ class CliWarning(CliException):
 
         :returns: Formatted warning message.
         """
-        return f"<i>{self}</i>"
+        return f"<i>{self.escaped()}</i>"
 
 
 class CreateError(CliError):
@@ -232,7 +232,7 @@ class LoginFailedError(CliException):
 
         :returns: Formatted error message.
         """
-        return f"Login failed: {super().__str__()}"
+        return f"Login failed: {self.escaped()}"
 
     def __str__(self) -> str:
         """Return the error message."""


### PR DESCRIPTION
This PR changes the interface for escaping exception messages, allowing us to escape them before passing them to prompt_toolkit, while also allowing us to log the real exception message verbatim.