### PR TITLE
Add `QueryParams` type

### DIFF
--- a/mreg_cli/api/abstracts.py
+++ b/mreg_cli/api/abstracts.py
@@ -19,7 +19,7 @@ from mreg_cli.exceptions import (
     PatchError,
 )
 from mreg_cli.outputmanager import OutputManager
-from mreg_cli.types import JsonMapping
+from mreg_cli.types import JsonMapping, QueryParams
 from mreg_cli.utilities.api import (
     delete,
     get,
@@ -308,7 +308,7 @@ class APIMixin(ABC):
 
         :returns: A list of objects if found, an empty list otherwise.
         """
-        params = {field: value}
+        params: QueryParams = {field: value}
         if ordering:
             params["ordering"] = ordering
 
@@ -316,7 +316,7 @@ class APIMixin(ABC):
 
     @classmethod
     def get_by_query(
-        cls, query: dict[str, str], ordering: str | None = None, limit: int | None = 500
+        cls, query: QueryParams, ordering: str | None = None, limit: int | None = 500
     ) -> list[Self]:
         """Get a list of objects by a query.
 
@@ -329,12 +329,12 @@ class APIMixin(ABC):
         if ordering:
             query["ordering"] = ordering
 
-        return get_typed(cls.endpoint().with_query(query), list[cls], limit=limit)
+        return get_typed(cls.endpoint(), list[cls], query, limit=limit)
 
     @classmethod
     def get_by_query_unique_or_raise(
         cls,
-        query: dict[str, str],
+        query: QueryParams,
         exc_type: type[Exception] = EntityNotFound,
         exc_message: str | None = None,
     ) -> Self:
@@ -358,7 +358,7 @@ class APIMixin(ABC):
     @classmethod
     def get_by_query_unique_and_raise(
         cls,
-        query: dict[str, str],
+        query: QueryParams,
         exc_type: type[Exception] = EntityAlreadyExists,
         exc_message: str | None = None,
     ) -> None:
@@ -380,7 +380,7 @@ class APIMixin(ABC):
         return None
 
     @classmethod
-    def get_by_query_unique(cls, data: dict[str, str]) -> Self | None:
+    def get_by_query_unique(cls, data: QueryParams) -> Self | None:
         """Get an object with the given data.
 
         :param data: The data to search for.

--- a/mreg_cli/api/endpoints.py
+++ b/mreg_cli/api/endpoints.py
@@ -126,12 +126,3 @@ class Endpoint(str, Enum):
             )
         encoded_params = (quote(str(param)) for param in params)
         return self.value.format(*encoded_params)
-
-    def with_query(self, query: dict[str, str]) -> str:
-        """Construct and return an endpoint URL with a query string.
-
-        :param query: A dictionary of query parameters.
-        :returns: A fully constructed endpoint URL with a query string.
-        """
-        query_string = "&".join(f"{quote(key)}={quote(value)}" for key, value in query.items())
-        return f"{self.value}?{query_string}"

--- a/mreg_cli/api/history.py
+++ b/mreg_cli/api/history.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel, Field, field_validator
 from mreg_cli.api.endpoints import Endpoint
 from mreg_cli.exceptions import EntityNotFound, InternalError
 from mreg_cli.outputmanager import OutputManager
+from mreg_cli.types import QueryParams
 from mreg_cli.utilities.api import get_typed
 
 
@@ -125,7 +126,7 @@ class HistoryItem(BaseModel):
     @classmethod
     def get(cls, name: str, resource: HistoryResource) -> list[Self]:
         """Get history items for a resource."""
-        params: dict[str, str] = {"resource": resource.resource(), "name": name}
+        params: QueryParams = {"resource": resource.resource(), "name": name}
         ret = get_typed(Endpoint.History, list[cls], params=params)
         if len(ret) == 0:
             raise EntityNotFound(f"No history found for {name}")

--- a/mreg_cli/api/models.py
+++ b/mreg_cli/api/models.py
@@ -42,7 +42,7 @@ from mreg_cli.exceptions import (
     ValidationError,
 )
 from mreg_cli.outputmanager import OutputManager
-from mreg_cli.types import IP_AddressT, IP_NetworkT, IP_Version
+from mreg_cli.types import IP_AddressT, IP_NetworkT, IP_Version, QueryParams
 from mreg_cli.utilities.api import (
     delete,
     get,
@@ -717,7 +717,7 @@ class Zone(FrozenModelWithTimestamps, WithTTL, APIMixin):
         :param expire: The expire interval for the zone.
         :param soa_ttl: The TTL for the zone.
         """
-        params: dict[str, str | int | None] = {
+        params: QueryParams = {
             "primary_ns": primary_ns,
             "email": email,
             "serialno": serialno,
@@ -2691,7 +2691,7 @@ class Host(FrozenModelWithTimestamps, WithTTL, WithHistory, APIMixin):
 
         :returns: A new Host object fetched from the API with the updated IP address.
         """
-        params: dict[str, str | None] = {"ipaddress": str(ip), "host": str(self.id)}
+        params: QueryParams = {"ipaddress": str(ip), "host": str(self.id)}
         if mac:
             params["macaddress"] = mac.address
 
@@ -3109,7 +3109,7 @@ class HostList(FrozenModel):
         return Endpoint.Hosts
 
     @classmethod
-    def get(cls, params: dict[str, Any] | None = None) -> HostList:
+    def get(cls, params: QueryParams | None = None) -> HostList:
         """Get a list of hosts.
 
         :param params: Optional parameters to pass to the API.

--- a/mreg_cli/commands/host_submodules/core.py
+++ b/mreg_cli/commands/host_submodules/core.py
@@ -36,7 +36,7 @@ from mreg_cli.exceptions import (
     PatchError,
 )
 from mreg_cli.outputmanager import OutputManager
-from mreg_cli.types import Flag
+from mreg_cli.types import Flag, JsonMapping, QueryParams
 from mreg_cli.utilities.shared import convert_wildcard_to_regex
 
 
@@ -118,7 +118,7 @@ def add(args: argparse.Namespace) -> None:
         except ValueError as e:
             raise InputFailure(f"invalid MAC address: {macaddress}") from e
 
-    data: dict[str, str | None] = {
+    data: JsonMapping = {
         "name": hname.hostname,
         "contact": args.contact or None,
         "comment": args.comment or None,
@@ -377,7 +377,7 @@ def find(args: argparse.Namespace) -> None:
     if not any([args.name, args.comment, args.contact]):
         raise InputFailure("Need at least one search critera")
 
-    params: dict[str, str | int] = {
+    params: QueryParams = {
         "ordering": "name",
     }
 

--- a/mreg_cli/commands/host_submodules/rr.py
+++ b/mreg_cli/commands/host_submodules/rr.py
@@ -742,8 +742,7 @@ def sshfp_add(args: argparse.Namespace) -> None:
     if existing_sshfp:
         raise EntityAlreadyExists(f"{host} already has that SSHFP defined.")
 
-    arg_data = {k: v for k, v in data.items()}
-    SSHFP.create(arg_data)
+    SSHFP.create(data)
     OutputManager().add_ok(f"Added SSHFP record for {host.name.hostname}.")
 
 

--- a/mreg_cli/commands/network.py
+++ b/mreg_cli/commands/network.py
@@ -17,7 +17,7 @@ from mreg_cli.exceptions import (
     NetworkOverlap,
 )
 from mreg_cli.outputmanager import OutputManager
-from mreg_cli.types import Flag
+from mreg_cli.types import Flag, QueryParams
 from mreg_cli.utilities.shared import convert_wildcard_to_regex, string_to_int
 from mreg_cli.utilities.validators import is_valid_category_tag, is_valid_location_tag
 
@@ -191,7 +191,7 @@ def find(args: argparse.Namespace) -> None:
         addr = IPAddressField(address=ip_arg)
         networks = [Network.get_by_ip_or_raise(addr.address)]
     else:
-        params: dict[str, str] = {}
+        params: QueryParams = {}
         param_names = [
             "network",
             "description",

--- a/mreg_cli/commands/permission.py
+++ b/mreg_cli/commands/permission.py
@@ -10,7 +10,7 @@ from mreg_cli.commands.base import BaseCommand
 from mreg_cli.commands.registry import CommandRegistry
 from mreg_cli.exceptions import DeleteError, EntityNotFound
 from mreg_cli.outputmanager import OutputManager
-from mreg_cli.types import Flag
+from mreg_cli.types import Flag, QueryParams
 from mreg_cli.utilities.shared import convert_wildcard_to_regex
 
 command_registry = CommandRegistry()
@@ -46,7 +46,7 @@ def network_list(args: argparse.Namespace) -> None:
     """
     permission_list: list[Permission] = []
 
-    params: dict[str, str] = {}
+    params: QueryParams = {}
     if args.group is not None:
         param, value = convert_wildcard_to_regex("group", args.group)
         params[param] = value

--- a/mreg_cli/types.py
+++ b/mreg_cli/types.py
@@ -11,6 +11,7 @@ from typing import (
     Any,
     Literal,
     Mapping,
+    MutableMapping,
     NamedTuple,
     Sequence,
     TypeAlias,
@@ -90,6 +91,7 @@ Json = TypeAliasType(
     ],
 )
 JsonMapping = Mapping[str, Json]
+QueryParams = MutableMapping[str, str | int | None]
 
 
 class Flag:

--- a/mreg_cli/utilities/api.py
+++ b/mreg_cli/utilities/api.py
@@ -31,7 +31,7 @@ from mreg_cli.exceptions import (
 )
 from mreg_cli.outputmanager import OutputManager
 from mreg_cli.tokenfile import TokenFile
-from mreg_cli.types import Json, JsonMapping
+from mreg_cli.types import Json, JsonMapping, QueryParams
 
 session = requests.Session()
 session.headers.update({"User-Agent": "mreg-cli"})
@@ -225,7 +225,7 @@ def _strip_none(data: dict[str, Any]) -> dict[str, Any]:
 def _request_wrapper(
     operation_type: str,
     path: str,
-    params: JsonMapping | None = None,
+    params: QueryParams | None = None,
     ok404: bool = False,
     first: bool = True,
     **data: Any,
@@ -292,22 +292,22 @@ def _request_wrapper(
 
 
 @overload
-def get(path: str, params: JsonMapping | None, ok404: Literal[True]) -> Response | None: ...
+def get(path: str, params: QueryParams | None, ok404: Literal[True]) -> Response | None: ...
 
 
 @overload
-def get(path: str, params: JsonMapping | None, ok404: Literal[False]) -> Response: ...
+def get(path: str, params: QueryParams | None, ok404: Literal[False]) -> Response: ...
 
 
 @overload
-def get(path: str, params: JsonMapping | None = ..., *, ok404: bool) -> Response | None: ...
+def get(path: str, params: QueryParams | None = ..., *, ok404: bool) -> Response | None: ...
 
 
 @overload
-def get(path: str, params: JsonMapping | None = ...) -> Response: ...
+def get(path: str, params: QueryParams | None = ...) -> Response: ...
 
 
-def get(path: str, params: JsonMapping | None = None, ok404: bool = False) -> Response | None:
+def get(path: str, params: QueryParams | None = None, ok404: bool = False) -> Response | None:
     """Make a standard get request."""
     if params is None:
         params = {}
@@ -316,7 +316,7 @@ def get(path: str, params: JsonMapping | None = None, ok404: bool = False) -> Re
 
 def get_list(
     path: str,
-    params: dict[str, Any] | None = None,
+    params: QueryParams | None = None,
     ok404: bool = False,
     limit: int | None = 500,
 ) -> list[Json]:
@@ -382,7 +382,7 @@ def get_item_by_key_value(
 
 def get_list_unique(
     path: str,
-    params: dict[str, str] | None = None,
+    params: QueryParams | None = None,
     ok404: bool = False,
 ) -> None | JsonMapping:
     """Do a get request that returns a single result from a search.
@@ -464,28 +464,26 @@ def validate_paginated_response(response: Response) -> PaginatedResponse:
 @overload
 def get_list_generic(
     path: str,
-    params: JsonMapping | None = None,
+    params: QueryParams | None = None,
     ok404: bool = False,
     limit: int | None = 500,
     expect_one_result: Literal[True] = True,
-) -> Json:
-    ...
+) -> Json: ...
 
 
 @overload
 def get_list_generic(
     path: str,
-    params: JsonMapping | None = None,
+    params: QueryParams | None = None,
     ok404: bool = False,
     limit: int | None = 500,
     expect_one_result: Literal[False] = False,
-) -> list[Json]:
-    ...
+) -> list[Json]: ...
 
 
 def get_list_generic(
     path: str,
-    params: JsonMapping | None = None,
+    params: QueryParams | None = None,
     ok404: bool = False,
     limit: int | None = 500,
     expect_one_result: bool | None = False,
@@ -540,7 +538,7 @@ def get_list_generic(
 def get_typed(
     path: str,
     type_: type[T],
-    params: dict[str, Any] | None = None,
+    params: QueryParams | None = None,
     limit: int | None = 500,
 ) -> T:
     """Fetch and deserialize JSON from an endpoint into a specific type.
@@ -566,21 +564,21 @@ def get_typed(
         return adapter.validate_json(resp.text)
 
 
-def post(path: str, params: dict[str, Any] | None = None, **kwargs: Any) -> Response | None:
+def post(path: str, params: QueryParams | None = None, **kwargs: Any) -> Response | None:
     """Use requests to make a post request. Assumes that all kwargs are data fields."""
     if params is None:
         params = {}
     return _request_wrapper("post", path, params=params, **kwargs)
 
 
-def patch(path: str, params: dict[str, Any] | None = None, **kwargs: Any) -> Response | None:
+def patch(path: str, params: QueryParams | None = None, **kwargs: Any) -> Response | None:
     """Use requests to make a patch request. Assumes that all kwargs are data fields."""
     if params is None:
         params = {}
     return _request_wrapper("patch", path, params=params, **kwargs)
 
 
-def delete(path: str, params: dict[str, Any] | None = None) -> Response | None:
+def delete(path: str, params: QueryParams | None = None) -> Response | None:
     """Use requests to make a delete request."""
     if params is None:
         params = {}


### PR DESCRIPTION
This PR replaces all bare dict annotations with a new `QueryParams` type. This type is more limited than `JsonMapping`, and does not allow dict, list and float values (maybe float should be allowed?). 

Everywhere where we construct inline query param dicts has been rewritten to use this new type annotation. Furthermore, all explicit conversion of query param values to strings has been removed, since passing ints and None as query param values is valid.

As part of this PR, the `Endpoint.with_query()` method has been removed, since we delegate the construction of the query param string to the requests library instead of doing it ourselves.

## Future work

`APIMixin.get_by_field()` and `get_item_by_key_value()` should be looked at to support integer values in addition to strings.