### PR TITLE
Fix problems with history output

### DIFF
--- a/ci/testsuite-result.json
+++ b/ci/testsuite-result.json
@@ -13343,7 +13343,7 @@
       },
       {
         "method": "GET",
-        "url": "/api/v1/networks/ip/2001%3Adb8%3A%3Abae0%3A964%3A14d5%3Ac553",
+        "url": "/api/v1/networks/ip/2001%3Adb8%3A%3A2b28%3Aa469%3Aa3e9%3Aaded",
         "data": {},
         "status": 200,
         "response": {
@@ -14227,10 +14227,10 @@
     "error": [],
     "output": [
       "<TIME> [test]: HostGroup create: name = 'mygroup', description = 'This describes the group'",
-      "<TIME> [test]: Host add: testhost1.example.org",
-      "<TIME> [test]: Host add: testhost2.example.org",
-      "<TIME> [test]: Group add: myself",
-      "<TIME> [test]: Host remove: testhost2.example.org"
+      "<TIME> [test]: Host add: host testhost1.example.org to group mygroup",
+      "<TIME> [test]: Host add: host testhost2.example.org to group mygroup",
+      "<TIME> [test]: Group add: owner myself to group mygroup",
+      "<TIME> [test]: Host remove: host testhost2.example.org from group mygroup"
     ],
     "api_requests": [
       {
@@ -14823,14 +14823,14 @@
     "error": [],
     "output": [
       "<TIME> [test]: HostGroup create: name = 'mygroup', description = 'This describes the group'",
-      "<TIME> [test]: Host add: testhost1.example.org",
-      "<TIME> [test]: Host add: testhost2.example.org",
-      "<TIME> [test]: Group add: myself",
-      "<TIME> [test]: Host remove: testhost2.example.org",
-      "<TIME> [test]: HostGroup add: yourgroup",
-      "<TIME> [test]: HostGroup remove: yourgroup",
-      "<TIME> [test]: Group add: anotherowner",
-      "<TIME> [test]: Group remove: myself"
+      "<TIME> [test]: Host add: host testhost1.example.org to group mygroup",
+      "<TIME> [test]: Host add: host testhost2.example.org to group mygroup",
+      "<TIME> [test]: Group add: owner myself to group mygroup",
+      "<TIME> [test]: Host remove: host testhost2.example.org from group mygroup",
+      "<TIME> [test]: HostGroup add: group yourgroup to group mygroup",
+      "<TIME> [test]: HostGroup remove: group yourgroup from group mygroup",
+      "<TIME> [test]: Group add: owner anotherowner to group mygroup",
+      "<TIME> [test]: Group remove: owner myself from group mygroup"
     ],
     "api_requests": [
       {
@@ -16257,7 +16257,7 @@
     "command_filter_negate": false,
     "command_issued": "policy add_atom fruit apple",
     "ok": [
-      "OK: : Added atom 'apple' to role 'fruit'"
+      "Added atom 'apple' to role 'fruit'"
     ],
     "warning": [],
     "error": [],
@@ -16265,40 +16265,26 @@
     "api_requests": [
       {
         "method": "GET",
-        "url": "/api/v1/hostpolicy/roles/?name=fruit",
+        "url": "/api/v1/hostpolicy/roles/fruit",
         "data": {},
         "status": 200,
         "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
-            {
-              "hosts": [],
-              "atoms": [],
-              "description": "5 a day",
-              "name": "fruit",
-              "labels": []
-            }
-          ]
+          "hosts": [],
+          "atoms": [],
+          "description": "5 a day",
+          "name": "fruit",
+          "labels": []
         }
       },
       {
         "method": "GET",
-        "url": "/api/v1/hostpolicy/atoms/?name=apple",
+        "url": "/api/v1/hostpolicy/atoms/apple",
         "data": {},
         "status": 200,
         "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
-            {
-              "roles": [],
-              "description": "Here's the description",
-              "name": "apple"
-            }
-          ]
+          "roles": [],
+          "description": "Here's the description",
+          "name": "apple"
         }
       },
       {
@@ -16318,7 +16304,7 @@
     "command_filter_negate": false,
     "command_issued": "policy add_atom fruit orange",
     "ok": [
-      "OK: : Added atom 'orange' to role 'fruit'"
+      "Added atom 'orange' to role 'fruit'"
     ],
     "warning": [],
     "error": [],
@@ -16326,44 +16312,30 @@
     "api_requests": [
       {
         "method": "GET",
-        "url": "/api/v1/hostpolicy/roles/?name=fruit",
+        "url": "/api/v1/hostpolicy/roles/fruit",
         "data": {},
         "status": 200,
         "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
+          "hosts": [],
+          "atoms": [
             {
-              "hosts": [],
-              "atoms": [
-                {
-                  "name": "apple"
-                }
-              ],
-              "description": "5 a day",
-              "name": "fruit",
-              "labels": []
+              "name": "apple"
             }
-          ]
+          ],
+          "description": "5 a day",
+          "name": "fruit",
+          "labels": []
         }
       },
       {
         "method": "GET",
-        "url": "/api/v1/hostpolicy/atoms/?name=orange",
+        "url": "/api/v1/hostpolicy/atoms/orange",
         "data": {},
         "status": 200,
         "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
-            {
-              "roles": [],
-              "description": "Round and orange",
-              "name": "orange"
-            }
-          ]
+          "roles": [],
+          "description": "Round and orange",
+          "name": "orange"
         }
       },
       {
@@ -16388,6 +16360,7 @@
     "output": [
       "Name: orange",
       "Created: <TIME>",
+      "Updated: <TIME>",
       "Description: Round and orange",
       "Roles where this atom is a member:",
       " fruit"
@@ -16395,24 +16368,17 @@
     "api_requests": [
       {
         "method": "GET",
-        "url": "/api/v1/hostpolicy/atoms/?name=orange",
+        "url": "/api/v1/hostpolicy/atoms/orange",
         "data": {},
         "status": 200,
         "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
+          "roles": [
             {
-              "roles": [
-                {
-                  "name": "fruit"
-                }
-              ],
-              "description": "Round and orange",
-              "name": "orange"
+              "name": "fruit"
             }
-          ]
+          ],
+          "description": "Round and orange",
+          "name": "orange"
         }
       }
     ],
@@ -16429,51 +16395,41 @@
     "output": [
       "Name: fruit",
       "Created: <TIME>",
+      "Updated: <TIME>",
       "Description: 5 a day",
       "Atom members:",
       " apple",
       " orange",
-      "Labels:",
-      " None"
+      "Labels:"
     ],
     "api_requests": [
       {
         "method": "GET",
-        "url": "/api/v1/hostpolicy/atoms/?name=fruit",
+        "url": "/api/v1/hostpolicy/atoms/fruit",
         "data": {},
-        "status": 200,
+        "status": 404,
         "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
+          "detail": "Not found."
         }
       },
       {
         "method": "GET",
-        "url": "/api/v1/hostpolicy/roles/?name=fruit",
+        "url": "/api/v1/hostpolicy/roles/fruit",
         "data": {},
         "status": 200,
         "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
+          "hosts": [],
+          "atoms": [
             {
-              "hosts": [],
-              "atoms": [
-                {
-                  "name": "apple"
-                },
-                {
-                  "name": "orange"
-                }
-              ],
-              "description": "5 a day",
-              "name": "fruit",
-              "labels": []
+              "name": "apple"
+            },
+            {
+              "name": "orange"
             }
-          ]
+          ],
+          "description": "5 a day",
+          "name": "fruit",
+          "labels": []
         }
       }
     ],
@@ -16495,29 +16451,22 @@
     "api_requests": [
       {
         "method": "GET",
-        "url": "/api/v1/hostpolicy/roles/?name=fruit",
+        "url": "/api/v1/hostpolicy/roles/fruit",
         "data": {},
         "status": 200,
         "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
+          "hosts": [],
+          "atoms": [
             {
-              "hosts": [],
-              "atoms": [
-                {
-                  "name": "apple"
-                },
-                {
-                  "name": "orange"
-                }
-              ],
-              "description": "5 a day",
-              "name": "fruit",
-              "labels": []
+              "name": "apple"
+            },
+            {
+              "name": "orange"
             }
-          ]
+          ],
+          "description": "5 a day",
+          "name": "fruit",
+          "labels": []
         }
       }
     ],
@@ -16533,7 +16482,7 @@
     "error": [],
     "output": [
       "<TIME> [test]: HostPolicyAtom create: description = 'Here's the description', name = 'apple'",
-      "<TIME> [test]: HostPolicyAtom add to: hostpolicy_role fruit"
+      "<TIME> [test]: HostPolicyAtom add: atom apple to role fruit"
     ],
     "api_requests": [
       {
@@ -16619,30 +16568,23 @@
     "ok": [],
     "warning": [],
     "error": [
-      "ERROR: : Atom apple used in roles: fruit"
+      "Atom 'apple' used in roles: fruit"
     ],
     "output": [],
     "api_requests": [
       {
         "method": "GET",
-        "url": "/api/v1/hostpolicy/atoms/?name=apple",
+        "url": "/api/v1/hostpolicy/atoms/apple",
         "data": {},
         "status": 200,
         "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
+          "roles": [
             {
-              "roles": [
-                {
-                  "name": "fruit"
-                }
-              ],
-              "description": "Here's the description",
-              "name": "apple"
+              "name": "fruit"
             }
-          ]
+          ],
+          "description": "Here's the description",
+          "name": "apple"
         }
       },
       {
@@ -16681,7 +16623,7 @@
     "command_filter_negate": false,
     "command_issued": "policy remove_atom fruit apple",
     "ok": [
-      "OK: : Removed atom 'apple' from role 'fruit'"
+      "Removed atom 'apple' from role 'fruit'"
     ],
     "warning": [],
     "error": [],
@@ -16689,29 +16631,22 @@
     "api_requests": [
       {
         "method": "GET",
-        "url": "/api/v1/hostpolicy/roles/?name=fruit",
+        "url": "/api/v1/hostpolicy/roles/fruit",
         "data": {},
         "status": 200,
         "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
+          "hosts": [],
+          "atoms": [
             {
-              "hosts": [],
-              "atoms": [
-                {
-                  "name": "apple"
-                },
-                {
-                  "name": "orange"
-                }
-              ],
-              "description": "5 a day",
-              "name": "fruit",
-              "labels": []
+              "name": "apple"
+            },
+            {
+              "name": "orange"
             }
-          ]
+          ],
+          "description": "5 a day",
+          "name": "fruit",
+          "labels": []
         }
       },
       {
@@ -16733,8 +16668,8 @@
     "error": [],
     "output": [
       "<TIME> [test]: HostPolicyAtom create: description = 'Here's the description', name = 'apple'",
-      "<TIME> [test]: HostPolicyAtom add to: hostpolicy_role fruit",
-      "<TIME> [test]: HostPolicyAtom remove from: hostpolicy_role fruit"
+      "<TIME> [test]: HostPolicyAtom add: atom apple to role fruit",
+      "<TIME> [test]: HostPolicyAtom remove: atom apple from role fruit"
     ],
     "api_requests": [
       {
@@ -16831,7 +16766,7 @@
     "command_filter_negate": false,
     "command_issued": "policy atom_delete apple",
     "ok": [
-      "OK: : Deleted atom apple"
+      "Deleted atom apple"
     ],
     "warning": [],
     "error": [],
@@ -16839,20 +16774,13 @@
     "api_requests": [
       {
         "method": "GET",
-        "url": "/api/v1/hostpolicy/atoms/?name=apple",
+        "url": "/api/v1/hostpolicy/atoms/apple",
         "data": {},
         "status": 200,
         "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
-            {
-              "roles": [],
-              "description": "Here's the description",
-              "name": "apple"
-            }
-          ]
+          "roles": [],
+          "description": "Here's the description",
+          "name": "apple"
         }
       },
       {
@@ -16882,7 +16810,7 @@
     "command_filter_negate": false,
     "command_issued": "policy set_description orange \"Juicy\"",
     "ok": [
-      "OK: : updated description to 'Juicy' for 'orange'"
+      "updated description to 'Juicy' for 'orange'"
     ],
     "warning": [],
     "error": [],
@@ -16890,24 +16818,17 @@
     "api_requests": [
       {
         "method": "GET",
-        "url": "/api/v1/hostpolicy/atoms/?name=orange",
+        "url": "/api/v1/hostpolicy/atoms/orange",
         "data": {},
         "status": 200,
         "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
+          "roles": [
             {
-              "roles": [
-                {
-                  "name": "fruit"
-                }
-              ],
-              "description": "Round and orange",
-              "name": "orange"
+              "name": "fruit"
             }
-          ]
+          ],
+          "description": "Round and orange",
+          "name": "orange"
         }
       },
       {
@@ -16917,25 +16838,10 @@
           "description": "Juicy"
         },
         "status": 204
-      }
-    ],
-    "time": null
-  },
-  {
-    "command": "policy rename orange tangerine",
-    "command_filter": null,
-    "command_filter_negate": false,
-    "command_issued": "policy rename orange tangerine",
-    "ok": [
-      "OK: : Renamed 'orange' to 'tangerine'"
-    ],
-    "warning": [],
-    "error": [],
-    "output": [],
-    "api_requests": [
+      },
       {
         "method": "GET",
-        "url": "/api/v1/hostpolicy/atoms/?name=orange",
+        "url": "/api/v1/hostpolicy/atoms/?id=2",
         "data": {},
         "status": 200,
         "response": {
@@ -16954,6 +16860,54 @@
             }
           ]
         }
+      }
+    ],
+    "time": null
+  },
+  {
+    "command": "policy rename orange tangerine",
+    "command_filter": null,
+    "command_filter_negate": false,
+    "command_issued": "policy rename orange tangerine",
+    "ok": [
+      "Renamed 'orange' to 'tangerine'"
+    ],
+    "warning": [],
+    "error": [],
+    "output": [],
+    "api_requests": [
+      {
+        "method": "GET",
+        "url": "/api/v1/hostpolicy/atoms/tangerine",
+        "data": {},
+        "status": 404,
+        "response": {
+          "detail": "Not found."
+        }
+      },
+      {
+        "method": "GET",
+        "url": "/api/v1/hostpolicy/roles/tangerine",
+        "data": {},
+        "status": 404,
+        "response": {
+          "detail": "Not found."
+        }
+      },
+      {
+        "method": "GET",
+        "url": "/api/v1/hostpolicy/atoms/orange",
+        "data": {},
+        "status": 200,
+        "response": {
+          "roles": [
+            {
+              "name": "fruit"
+            }
+          ],
+          "description": "Juicy",
+          "name": "orange"
+        }
       },
       {
         "method": "PATCH",
@@ -16962,6 +16916,28 @@
           "name": "tangerine"
         },
         "status": 204
+      },
+      {
+        "method": "GET",
+        "url": "/api/v1/hostpolicy/atoms/?id=2",
+        "data": {},
+        "status": 200,
+        "response": {
+          "count": 1,
+          "next": null,
+          "previous": null,
+          "results": [
+            {
+              "roles": [
+                {
+                  "name": "fruit"
+                }
+              ],
+              "description": "Juicy",
+              "name": "tangerine"
+            }
+          ]
+        }
       }
     ],
     "time": null
@@ -16972,24 +16948,35 @@
     "command_filter_negate": false,
     "command_issued": "host add foo",
     "ok": [
-      "OK: : created host foo.example.org"
+      "Created host foo.example.org"
     ],
-    "warning": [
-      "WARNING: : host not found: foo.example.org"
-    ],
+    "warning": [],
     "error": [],
-    "output": [],
+    "output": [
+      "Name: foo.example.org",
+      "Contact: ",
+      "TTL: (Default)",
+      "TXT: v=spf1 -all",
+      "Created: <TIME>",
+      "Updated: <TIME>"
+    ],
     "api_requests": [
       {
         "method": "GET",
-        "url": "/api/v1/hosts/?name=foo.example.org",
+        "url": "/api/v1/hosts/foo.example.org",
         "data": {},
-        "status": 200,
+        "status": 404,
         "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
+          "detail": "Not found."
+        }
+      },
+      {
+        "method": "GET",
+        "url": "/api/v1/cnames/foo.example.org",
+        "data": {},
+        "status": 404,
+        "response": {
+          "detail": "Not found."
         }
       },
       {
@@ -17018,8 +17005,42 @@
         }
       },
       {
+        "method": "POST",
+        "url": "/api/v1/hosts/",
+        "data": {
+          "name": "foo.example.org"
+        },
+        "status": 201
+      },
+      {
         "method": "GET",
-        "url": "/api/v1/cnames/?name=foo.example.org",
+        "url": "/api/v1/hosts/foo.example.org",
+        "data": {},
+        "status": 200,
+        "response": {
+          "ipaddresses": [],
+          "cnames": [],
+          "mxs": [],
+          "txts": [
+            {
+              "txt": "v=spf1 -all",
+              "host": 12
+            }
+          ],
+          "ptr_overrides": [],
+          "hinfo": null,
+          "loc": null,
+          "bacnetid": null,
+          "name": "foo.example.org",
+          "contact": "",
+          "ttl": null,
+          "comment": "",
+          "zone": 1
+        }
+      },
+      {
+        "method": "GET",
+        "url": "/api/v1/srvs/?host=12",
         "data": {},
         "status": 200,
         "response": {
@@ -17030,14 +17051,52 @@
         }
       },
       {
-        "method": "POST",
-        "url": "/api/v1/hosts/",
-        "data": {
-          "name": "foo.example.org",
-          "contact": null,
-          "comment": null
-        },
-        "status": 201
+        "method": "GET",
+        "url": "/api/v1/naptrs/?host=12",
+        "data": {},
+        "status": 200,
+        "response": {
+          "count": 0,
+          "next": null,
+          "previous": null,
+          "results": []
+        }
+      },
+      {
+        "method": "GET",
+        "url": "/api/v1/sshfps/?host=12",
+        "data": {},
+        "status": 200,
+        "response": {
+          "count": 0,
+          "next": null,
+          "previous": null,
+          "results": []
+        }
+      },
+      {
+        "method": "GET",
+        "url": "/api/v1/hostpolicy/roles/?hosts=12",
+        "data": {},
+        "status": 200,
+        "response": {
+          "count": 0,
+          "next": null,
+          "previous": null,
+          "results": []
+        }
+      },
+      {
+        "method": "GET",
+        "url": "/api/v1/hostgroups/?hosts=12",
+        "data": {},
+        "status": 200,
+        "response": {
+          "count": 0,
+          "next": null,
+          "previous": null,
+          "results": []
+        }
       }
     ],
     "time": null
@@ -17047,16 +17106,16 @@
     "command_filter": null,
     "command_filter_negate": false,
     "command_issued": "host info foo",
-    "ok": [
-      "OK: : printed host info for foo.example.org"
-    ],
+    "ok": [],
     "warning": [],
     "error": [],
     "output": [
       "Name: foo.example.org",
       "Contact: ",
       "TTL: (Default)",
-      "TXT: v=spf1 -all"
+      "TXT: v=spf1 -all",
+      "Created: <TIME>",
+      "Updated: <TIME>"
     ],
     "api_requests": [
       {
@@ -17123,7 +17182,19 @@
       },
       {
         "method": "GET",
-        "url": "/api/v1/hostpolicy/roles/?hosts__name=foo.example.org",
+        "url": "/api/v1/hostpolicy/roles/?hosts=12",
+        "data": {},
+        "status": 200,
+        "response": {
+          "count": 0,
+          "next": null,
+          "previous": null,
+          "results": []
+        }
+      },
+      {
+        "method": "GET",
+        "url": "/api/v1/hostgroups/?hosts=12",
         "data": {},
         "status": 200,
         "response": {
@@ -17143,21 +17214,18 @@
     "command_issued": "policy host_add tangerine foo # should fail, tangerine is an atom, not a role",
     "ok": [],
     "warning": [
-      "WARNING: : Role 'tangerine' does not exist"
+      "Role with name 'tangerine' not found."
     ],
     "error": [],
     "output": [],
     "api_requests": [
       {
         "method": "GET",
-        "url": "/api/v1/hostpolicy/roles/?name=tangerine",
+        "url": "/api/v1/hostpolicy/roles/tangerine",
         "data": {},
-        "status": 200,
+        "status": 404,
         "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
+          "detail": "Not found."
         }
       }
     ],
@@ -17169,7 +17237,7 @@
     "command_filter_negate": false,
     "command_issued": "policy host_add fruit foo",
     "ok": [
-      "OK: : Added host 'foo.example.org' to role 'fruit'"
+      "Added host foo.example.org to role 'fruit'"
     ],
     "warning": [],
     "error": [],
@@ -17177,26 +17245,19 @@
     "api_requests": [
       {
         "method": "GET",
-        "url": "/api/v1/hostpolicy/roles/?name=fruit",
+        "url": "/api/v1/hostpolicy/roles/fruit",
         "data": {},
         "status": 200,
         "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
+          "hosts": [],
+          "atoms": [
             {
-              "hosts": [],
-              "atoms": [
-                {
-                  "name": "tangerine"
-                }
-              ],
-              "description": "5 a day",
-              "name": "fruit",
-              "labels": []
+              "name": "tangerine"
             }
-          ]
+          ],
+          "description": "5 a day",
+          "name": "fruit",
+          "labels": []
         }
       },
       {
@@ -17251,30 +17312,23 @@
     "api_requests": [
       {
         "method": "GET",
-        "url": "/api/v1/hostpolicy/roles/?name=fruit",
+        "url": "/api/v1/hostpolicy/roles/fruit",
         "data": {},
         "status": 200,
         "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
+          "hosts": [
             {
-              "hosts": [
-                {
-                  "name": "foo.example.org"
-                }
-              ],
-              "atoms": [
-                {
-                  "name": "tangerine"
-                }
-              ],
-              "description": "5 a day",
-              "name": "fruit",
-              "labels": []
+              "name": "foo.example.org"
             }
-          ]
+          ],
+          "atoms": [
+            {
+              "name": "tangerine"
+            }
+          ],
+          "description": "5 a day",
+          "name": "fruit",
+          "labels": []
         }
       }
     ],
@@ -17289,7 +17343,7 @@
     "warning": [],
     "error": [],
     "output": [
-      "Roles for 'foo.example.org':",
+      "Roles for foo.example.org:",
       " fruit"
     ],
     "api_requests": [
@@ -17321,7 +17375,7 @@
       },
       {
         "method": "GET",
-        "url": "/api/v1/hostpolicy/roles/?hosts__name=foo.example.org",
+        "url": "/api/v1/hostpolicy/roles/?hosts=12",
         "data": {},
         "status": 200,
         "response": {
@@ -17355,9 +17409,7 @@
     "command_filter": null,
     "command_filter_negate": false,
     "command_issued": "host info foo",
-    "ok": [
-      "OK: : printed host info for foo.example.org"
-    ],
+    "ok": [],
     "warning": [],
     "error": [],
     "output": [
@@ -17365,7 +17417,9 @@
       "Contact: ",
       "TTL: (Default)",
       "TXT: v=spf1 -all",
-      "Policies: fruit"
+      "Roles: fruit",
+      "Created: <TIME>",
+      "Updated: <TIME>"
     ],
     "api_requests": [
       {
@@ -17432,7 +17486,7 @@
       },
       {
         "method": "GET",
-        "url": "/api/v1/hostpolicy/roles/?hosts__name=foo.example.org",
+        "url": "/api/v1/hostpolicy/roles/?hosts=12",
         "data": {},
         "status": 200,
         "response": {
@@ -17457,6 +17511,18 @@
             }
           ]
         }
+      },
+      {
+        "method": "GET",
+        "url": "/api/v1/hostgroups/?hosts=12",
+        "data": {},
+        "status": 200,
+        "response": {
+          "count": 0,
+          "next": null,
+          "previous": null,
+          "results": []
+        }
       }
     ],
     "time": null
@@ -17467,7 +17533,7 @@
     "command_filter_negate": false,
     "command_issued": "policy host_remove fruit foo",
     "ok": [
-      "OK: : Removed host 'foo.example.org' from role 'fruit'"
+      "Removed host foo.example.org from role 'fruit'"
     ],
     "warning": [],
     "error": [],
@@ -17475,30 +17541,23 @@
     "api_requests": [
       {
         "method": "GET",
-        "url": "/api/v1/hostpolicy/roles/?name=fruit",
+        "url": "/api/v1/hostpolicy/roles/fruit",
         "data": {},
         "status": 200,
         "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
+          "hosts": [
             {
-              "hosts": [
-                {
-                  "name": "foo.example.org"
-                }
-              ],
-              "atoms": [
-                {
-                  "name": "tangerine"
-                }
-              ],
-              "description": "5 a day",
-              "name": "fruit",
-              "labels": []
+              "name": "foo.example.org"
             }
-          ]
+          ],
+          "atoms": [
+            {
+              "name": "tangerine"
+            }
+          ],
+          "description": "5 a day",
+          "name": "fruit",
+          "labels": []
         }
       },
       {
@@ -17543,33 +17602,26 @@
     "command_issued": "policy remove_atom fruit banana # should fail",
     "ok": [],
     "warning": [
-      "WARNING: : Atom 'banana' not a member of 'fruit'"
+      "Atom 'banana' not a member of 'fruit'"
     ],
     "error": [],
     "output": [],
     "api_requests": [
       {
         "method": "GET",
-        "url": "/api/v1/hostpolicy/roles/?name=fruit",
+        "url": "/api/v1/hostpolicy/roles/fruit",
         "data": {},
         "status": 200,
         "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
+          "hosts": [],
+          "atoms": [
             {
-              "hosts": [],
-              "atoms": [
-                {
-                  "name": "tangerine"
-                }
-              ],
-              "description": "5 a day",
-              "name": "fruit",
-              "labels": []
+              "name": "tangerine"
             }
-          ]
+          ],
+          "description": "5 a day",
+          "name": "fruit",
+          "labels": []
         }
       }
     ],
@@ -17581,7 +17633,7 @@
     "command_filter_negate": false,
     "command_issued": "policy remove_atom fruit tangerine",
     "ok": [
-      "OK: : Removed atom 'tangerine' from role 'fruit'"
+      "Removed atom 'tangerine' from role 'fruit'"
     ],
     "warning": [],
     "error": [],
@@ -17589,26 +17641,19 @@
     "api_requests": [
       {
         "method": "GET",
-        "url": "/api/v1/hostpolicy/roles/?name=fruit",
+        "url": "/api/v1/hostpolicy/roles/fruit",
         "data": {},
         "status": 200,
         "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
+          "hosts": [],
+          "atoms": [
             {
-              "hosts": [],
-              "atoms": [
-                {
-                  "name": "tangerine"
-                }
-              ],
-              "description": "5 a day",
-              "name": "fruit",
-              "labels": []
+              "name": "tangerine"
             }
-          ]
+          ],
+          "description": "5 a day",
+          "name": "fruit",
+          "labels": []
         }
       },
       {
@@ -17627,21 +17672,18 @@
     "command_issued": "policy role_delete vegetables # fails, that role doesn't exist",
     "ok": [],
     "warning": [
-      "WARNING: : Role 'vegetables' does not exist"
+      "Role with name 'vegetables' not found."
     ],
     "error": [],
     "output": [],
     "api_requests": [
       {
         "method": "GET",
-        "url": "/api/v1/hostpolicy/roles/?name=vegetables",
+        "url": "/api/v1/hostpolicy/roles/vegetables",
         "data": {},
-        "status": 200,
+        "status": 404,
         "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
+          "detail": "Not found."
         }
       }
     ],
@@ -17656,13 +17698,13 @@
     "warning": [],
     "error": [],
     "output": [
-      "<TIME> [test]: HostPolicyRole create: description = '5 a day', name = 'fruit', labels = '[]'",
-      "<TIME> [test]: HostPolicyAtom add: apple",
-      "<TIME> [test]: HostPolicyAtom add: orange",
-      "<TIME> [test]: HostPolicyAtom remove: apple",
-      "<TIME> [test]: Host add: foo.example.org",
-      "<TIME> [test]: Host remove: foo.example.org",
-      "<TIME> [test]: HostPolicyAtom remove: tangerine"
+      "<TIME> [test]: HostPolicyRole create: description = '5 a day', name = 'fruit'",
+      "<TIME> [test]: HostPolicyAtom add: atom apple to role fruit",
+      "<TIME> [test]: HostPolicyAtom add: atom orange to role fruit",
+      "<TIME> [test]: HostPolicyAtom remove: atom apple from role fruit",
+      "<TIME> [test]: Host add: host foo.example.org to role fruit",
+      "<TIME> [test]: Host remove: host foo.example.org from role fruit",
+      "<TIME> [test]: HostPolicyAtom remove: atom tangerine from role fruit"
     ],
     "api_requests": [
       {
@@ -17683,7 +17725,7 @@
               "model_id": 1,
               "model": "HostPolicyRole",
               "action": "create",
-              "data": "{\"description\": \"5 a day\", \"name\": \"fruit\", \"labels\": []}"
+              "data": "{\"description\": \"5 a day\", \"name\": \"fruit\"}"
             },
             {
               "timestamp": "<TIME>",
@@ -17784,7 +17826,7 @@
               "model_id": 1,
               "model": "HostPolicyRole",
               "action": "create",
-              "data": "{\"description\": \"5 a day\", \"name\": \"fruit\", \"labels\": []}"
+              "data": "{\"description\": \"5 a day\", \"name\": \"fruit\"}"
             },
             {
               "timestamp": "<TIME>",
@@ -17888,7 +17930,7 @@
     "command_filter_negate": false,
     "command_issued": "policy role_delete fruit",
     "ok": [
-      "OK: : Deleted role 'fruit'"
+      "Deleted role 'fruit'"
     ],
     "warning": [],
     "error": [],
@@ -17896,22 +17938,15 @@
     "api_requests": [
       {
         "method": "GET",
-        "url": "/api/v1/hostpolicy/roles/?name=fruit",
+        "url": "/api/v1/hostpolicy/roles/fruit",
         "data": {},
         "status": 200,
         "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
-            {
-              "hosts": [],
-              "atoms": [],
-              "description": "5 a day",
-              "name": "fruit",
-              "labels": []
-            }
-          ]
+          "hosts": [],
+          "atoms": [],
+          "description": "5 a day",
+          "name": "fruit",
+          "labels": []
         }
       },
       {
@@ -17929,7 +17964,7 @@
     "command_filter_negate": false,
     "command_issued": "policy atom_delete tangerine",
     "ok": [
-      "OK: : Deleted atom tangerine"
+      "Deleted atom tangerine"
     ],
     "warning": [],
     "error": [],
@@ -17937,20 +17972,13 @@
     "api_requests": [
       {
         "method": "GET",
-        "url": "/api/v1/hostpolicy/atoms/?name=tangerine",
+        "url": "/api/v1/hostpolicy/atoms/tangerine",
         "data": {},
         "status": 200,
         "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
-            {
-              "roles": [],
-              "description": "Juicy",
-              "name": "tangerine"
-            }
-          ]
+          "roles": [],
+          "description": "Juicy",
+          "name": "tangerine"
         }
       },
       {
@@ -17980,7 +18008,7 @@
     "command_filter_negate": false,
     "command_issued": "host remove foo",
     "ok": [
-      "OK: : removed foo.example.org"
+      "removed foo.example.org"
     ],
     "warning": [],
     "error": [],
@@ -18026,7 +18054,7 @@
       },
       {
         "method": "GET",
-        "url": "/api/v1/srvs/?host__name=foo.example.org",
+        "url": "/api/v1/srvs/?host=12",
         "data": {},
         "status": 200,
         "response": {
@@ -18051,12 +18079,24 @@
     "command_filter_negate": false,
     "command_issued": "permission network_add <IPv4>/24 somegroup \"[abc]+.uio.no\"",
     "ok": [
-      "OK: : Added permission to <IPv4>/24"
+      "Added permission to <IPv4>/24"
     ],
     "warning": [],
     "error": [],
     "output": [],
     "api_requests": [
+      {
+        "method": "GET",
+        "url": "/api/v1/permissions/netgroupregex/?range=<IPv4>%2F24&group=somegroup&regex=%5Babc%5D%2B.uio.no",
+        "data": {},
+        "status": 200,
+        "response": {
+          "count": 0,
+          "next": null,
+          "previous": null,
+          "results": []
+        }
+      },
       {
         "method": "POST",
         "url": "/api/v1/permissions/netgroupregex/",
@@ -18110,7 +18150,7 @@
       },
       {
         "method": "GET",
-        "url": "/api/v1/labels/",
+        "url": "/api/v1/labels/?ordering=name",
         "data": {},
         "status": 200,
         "response": {
@@ -18130,7 +18170,7 @@
     "command_issued": "permission network_remove <IPv4>/24 othergroup \"[abc]*.uio.no\" # fails, no match",
     "ok": [],
     "warning": [
-      "WARNING: : No matching permission found"
+      "Permission with query {'group': 'othergroup', 'range': '<IPv4>/24', 'regex': '[abc]*.uio.no'} not found."
     ],
     "error": [],
     "output": [],
@@ -18156,7 +18196,7 @@
     "command_filter_negate": false,
     "command_issued": "permission network_remove <IPv4>/24 somegroup \"[abc]+.uio.no\"",
     "ok": [
-      "OK: : Removed permission for <IPv4>/24"
+      "Removed permission for <IPv4>/24"
     ],
     "warning": [],
     "error": [],
@@ -18196,7 +18236,7 @@
     "command_filter_negate": false,
     "command_issued": "network create -network <IPv4>/24 -desc foo -vlan 1234",
     "ok": [
-      "OK: : created network <IPv4>/24"
+      "created network <IPv4>/24"
     ],
     "warning": [],
     "error": [],
@@ -18221,11 +18261,26 @@
           "network": "<IPv4>/24",
           "description": "foo",
           "vlan": "1234",
-          "category": null,
-          "location": null,
           "frozen": false
         },
         "status": 201
+      },
+      {
+        "method": "GET",
+        "url": "/api/v1/networks/<IPv4>/24",
+        "data": {},
+        "status": 200,
+        "response": {
+          "excluded_ranges": [],
+          "network": "<IPv4>/24",
+          "description": "foo",
+          "vlan": 1234,
+          "dns_delegated": false,
+          "category": "",
+          "location": "",
+          "frozen": false,
+          "reserved": 3
+        }
       }
     ],
     "time": null
@@ -18236,24 +18291,35 @@
     "command_filter_negate": false,
     "command_issued": "host add foo",
     "ok": [
-      "OK: : created host foo.example.org"
+      "Created host foo.example.org"
     ],
-    "warning": [
-      "WARNING: : host not found: foo.example.org"
-    ],
+    "warning": [],
     "error": [],
-    "output": [],
+    "output": [
+      "Name: foo.example.org",
+      "Contact: ",
+      "TTL: (Default)",
+      "TXT: v=spf1 -all",
+      "Created: <TIME>",
+      "Updated: <TIME>"
+    ],
     "api_requests": [
       {
         "method": "GET",
-        "url": "/api/v1/hosts/?name=foo.example.org",
+        "url": "/api/v1/hosts/foo.example.org",
         "data": {},
-        "status": 200,
+        "status": 404,
         "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
+          "detail": "Not found."
+        }
+      },
+      {
+        "method": "GET",
+        "url": "/api/v1/cnames/foo.example.org",
+        "data": {},
+        "status": 404,
+        "response": {
+          "detail": "Not found."
         }
       },
       {
@@ -18282,8 +18348,42 @@
         }
       },
       {
+        "method": "POST",
+        "url": "/api/v1/hosts/",
+        "data": {
+          "name": "foo.example.org"
+        },
+        "status": 201
+      },
+      {
         "method": "GET",
-        "url": "/api/v1/cnames/?name=foo.example.org",
+        "url": "/api/v1/hosts/foo.example.org",
+        "data": {},
+        "status": 200,
+        "response": {
+          "ipaddresses": [],
+          "cnames": [],
+          "mxs": [],
+          "txts": [
+            {
+              "txt": "v=spf1 -all",
+              "host": 13
+            }
+          ],
+          "ptr_overrides": [],
+          "hinfo": null,
+          "loc": null,
+          "bacnetid": null,
+          "name": "foo.example.org",
+          "contact": "",
+          "ttl": null,
+          "comment": "",
+          "zone": 1
+        }
+      },
+      {
+        "method": "GET",
+        "url": "/api/v1/srvs/?host=13",
         "data": {},
         "status": 200,
         "response": {
@@ -18294,14 +18394,52 @@
         }
       },
       {
-        "method": "POST",
-        "url": "/api/v1/hosts/",
-        "data": {
-          "name": "foo.example.org",
-          "contact": null,
-          "comment": null
-        },
-        "status": 201
+        "method": "GET",
+        "url": "/api/v1/naptrs/?host=13",
+        "data": {},
+        "status": 200,
+        "response": {
+          "count": 0,
+          "next": null,
+          "previous": null,
+          "results": []
+        }
+      },
+      {
+        "method": "GET",
+        "url": "/api/v1/sshfps/?host=13",
+        "data": {},
+        "status": 200,
+        "response": {
+          "count": 0,
+          "next": null,
+          "previous": null,
+          "results": []
+        }
+      },
+      {
+        "method": "GET",
+        "url": "/api/v1/hostpolicy/roles/?hosts=13",
+        "data": {},
+        "status": 200,
+        "response": {
+          "count": 0,
+          "next": null,
+          "previous": null,
+          "results": []
+        }
+      },
+      {
+        "method": "GET",
+        "url": "/api/v1/hostgroups/?hosts=13",
+        "data": {},
+        "status": 200,
+        "response": {
+          "count": 0,
+          "next": null,
+          "previous": null,
+          "results": []
+        }
       }
     ],
     "time": null

--- a/mreg_cli/api/history.py
+++ b/mreg_cli/api/history.py
@@ -80,16 +80,17 @@ class HistoryItem(BaseModel):
         action = self.action
         model = self.model
         if action in ("add", "remove"):
-            if self.resource == "groups" and model in ("Host", "Group", "HostGroup"):
-                msg = self.data["name"]
-            elif self.name == basename:
-                msg = self.name
-            else:
-                msg = self.resource + " " + self.name
-                if action == "add":
-                    action = "add to"
-                elif action == "remove":
-                    action = "remove from"
+            if action == "add":
+                direction = "to"
+            elif action == "remove":
+                direction = "from"
+            rel = self.data["relation"][:-1]
+            cls = str(self.resource)
+            if "." in cls:
+                cls = cls[cls.rindex(".")+1:]
+            cls = cls.replace("HostPolicy_","")
+            cls = cls.lower()
+            msg = f"{rel} {self.data["name"]} {direction} {cls} {self.name}"
         elif action == "create":
             msg = ", ".join(f"{k} = '{v}'" for k, v in self.data.items())
         elif action == "update":


### PR DESCRIPTION
Some of the history commands gave incorrect output for add/remove operations after we modified the history api. This commit seeks to fix that by trying to handle history items in a generic way and make the output more verbose.

```
"2024-06-26 18:03:20 [test]: Host add: host testhost2.example.org to group mygroup",
"2024-06-26 18:03:20 [test]: Group add: owner myself to group mygroup",
"2024-06-26 18:03:20 [test]: Host remove: host testhost2.example.org from group mygroup",
"2024-06-26 18:03:21 [test]: HostGroup add: group yourgroup to group mygroup",

"2024-06-26 18:03:25 [test]: HostPolicyAtom add: atom apple to role fruit"
```


Also, update more test results.