### PR TITLE
Fix more minor issues found when looking through test suite results

### DIFF
--- a/ci/diff.py
+++ b/ci/diff.py
@@ -27,6 +27,7 @@ datetime_str_pattern = re.compile(
 serial_pattern = re.compile(r"\b[sS]erial:\s+\d+")
 ipv4_pattern = re.compile(r"((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)\.?\b){4}")
 ipv6_pattern = re.compile(r"\b([0-9a-fA-F]{1,4}::?){1,7}[0-9a-fA-F]{1,4}\b")
+mac_pattern = re.compile(r"\b([0-9a-f]{2}:){5}[0-9a-f]{2}\b")
 
 
 class DiffError(Exception):
@@ -62,6 +63,7 @@ def group_objects(json_file_path: str) -> list[dict[str, Any]]:
         s = timestamp_pattern.sub("<TIME>", s)
         s = datetime_str_pattern.sub("<TIME>", s)
         s = serial_pattern.sub("Serial: <NUMBER>", s)
+        s = mac_pattern.sub("<macaddress>", s)
         s = ipv4_pattern.sub("<IPv4>", s)
         s = ipv6_pattern.sub("<IPv6>", s)
         s = re.sub(

--- a/ci/testsuite-result.json
+++ b/ci/testsuite-result.json
@@ -11389,7 +11389,9 @@
     "command_filter": null,
     "command_filter_negate": false,
     "command_issued": "host a_add somehost <IPv4>/24 -force",
-    "ok": [],
+    "ok": [
+      "Added ipaddress <IPv4> to somehost.example.org"
+    ],
     "warning": [],
     "error": [],
     "output": [],
@@ -11468,50 +11470,6 @@
           "macaddress": "",
           "ipaddress": "<IPv4>",
           "host": 4
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hosts/?id=4",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
-            {
-              "ipaddresses": [
-                {
-                  "macaddress": "",
-                  "ipaddress": "<IPv4>",
-                  "host": 4
-                },
-                {
-                  "macaddress": "",
-                  "ipaddress": "<IPv4>",
-                  "host": 4
-                }
-              ],
-              "cnames": [],
-              "mxs": [],
-              "txts": [
-                {
-                  "txt": "v=spf1 -all",
-                  "host": 4
-                }
-              ],
-              "ptr_overrides": [],
-              "hinfo": null,
-              "loc": null,
-              "bacnetid": null,
-              "name": "somehost.example.org",
-              "contact": "new-support@example.org",
-              "ttl": null,
-              "comment": "",
-              "zone": 1
-            }
-          ]
         }
       },
       {
@@ -13097,7 +13055,9 @@
     "command_filter": null,
     "command_filter_negate": false,
     "command_issued": "host aaaa_add somehost <IPv6>::/64 -force",
-    "ok": [],
+    "ok": [
+      "Added ipaddress <IPv6> to somehost.example.org"
+    ],
     "warning": [],
     "error": [],
     "output": [],
@@ -13176,50 +13136,6 @@
           "macaddress": "",
           "ipaddress": "<IPv6>",
           "host": 8
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hosts/?id=8",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
-            {
-              "ipaddresses": [
-                {
-                  "macaddress": "",
-                  "ipaddress": "<IPv6>",
-                  "host": 8
-                },
-                {
-                  "macaddress": "",
-                  "ipaddress": "<IPv6>",
-                  "host": 8
-                }
-              ],
-              "cnames": [],
-              "mxs": [],
-              "txts": [
-                {
-                  "txt": "v=spf1 -all",
-                  "host": 8
-                }
-              ],
-              "ptr_overrides": [],
-              "hinfo": null,
-              "loc": null,
-              "bacnetid": null,
-              "name": "somehost.example.org",
-              "contact": "support@example.org",
-              "ttl": null,
-              "comment": "",
-              "zone": 1
-            }
-          ]
         }
       },
       {
@@ -18450,54 +18366,12 @@
     "command_filter_negate": false,
     "command_issued": "host a_add foo <IPv4>",
     "ok": [
-      "OK: : added ip <IPv4> to foo.example.org"
+      "Added ipaddress <IPv4> to foo.example.org"
     ],
     "warning": [],
     "error": [],
     "output": [],
     "api_requests": [
-      {
-        "method": "GET",
-        "url": "/api/v1/hosts/?ipaddresses__ipaddress=<IPv4>",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/ip/<IPv4>",
-        "data": {},
-        "status": 200,
-        "response": {
-          "excluded_ranges": [],
-          "network": "<IPv4>/24",
-          "description": "foo",
-          "vlan": 1234,
-          "dns_delegated": false,
-          "category": "",
-          "location": "",
-          "frozen": false,
-          "reserved": 3
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/<IPv4>/24/reserved_list",
-        "data": {},
-        "status": 200,
-        "response": [
-          "<IPv4>",
-          "<IPv4>",
-          "<IPv4>",
-          "<IPv4>",
-          "<IPv4>"
-        ]
-      },
       {
         "method": "GET",
         "url": "/api/v1/hosts/foo.example.org",
@@ -18525,17 +18399,85 @@
         }
       },
       {
+        "method": "GET",
+        "url": "/api/v1/networks/ip/<IPv4>",
+        "data": {},
+        "status": 200,
+        "response": {
+          "excluded_ranges": [],
+          "network": "<IPv4>/24",
+          "description": "foo",
+          "vlan": 1234,
+          "dns_delegated": false,
+          "category": "",
+          "location": "",
+          "frozen": false,
+          "reserved": 3
+        }
+      },
+      {
+        "method": "GET",
+        "url": "/api/v1/hosts/?ipaddresses__ipaddress=<IPv4>&ordering=name",
+        "data": {},
+        "status": 200,
+        "response": {
+          "count": 0,
+          "next": null,
+          "previous": null,
+          "results": []
+        }
+      },
+      {
         "method": "POST",
         "url": "/api/v1/ipaddresses/",
         "data": {
-          "host": 13,
-          "ipaddress": "<IPv4>"
+          "ipaddress": "<IPv4>",
+          "host": "13"
         },
         "status": 201,
         "response": {
           "macaddress": "",
           "ipaddress": "<IPv4>",
           "host": 13
+        }
+      },
+      {
+        "method": "GET",
+        "url": "/api/v1/hosts/?id=13",
+        "data": {},
+        "status": 200,
+        "response": {
+          "count": 1,
+          "next": null,
+          "previous": null,
+          "results": [
+            {
+              "ipaddresses": [
+                {
+                  "macaddress": "",
+                  "ipaddress": "<IPv4>",
+                  "host": 13
+                }
+              ],
+          "cnames": [],
+          "mxs": [],
+          "txts": [
+            {
+              "txt": "v=spf1 -all",
+              "host": 13
+            }
+          ],
+          "ptr_overrides": [],
+          "hinfo": null,
+          "loc": null,
+          "bacnetid": null,
+          "name": "foo.example.org",
+          "contact": "",
+          "ttl": null,
+          "comment": "",
+          "zone": 1
+        }
+          ]
         }
       }
     ],

--- a/ci/testsuite-result.json
+++ b/ci/testsuite-result.json
@@ -18459,24 +18459,24 @@
                   "host": 13
                 }
               ],
-          "cnames": [],
-          "mxs": [],
-          "txts": [
-            {
-              "txt": "v=spf1 -all",
-              "host": 13
+              "cnames": [],
+              "mxs": [],
+              "txts": [
+                {
+                  "txt": "v=spf1 -all",
+                  "host": 13
+                }
+              ],
+              "ptr_overrides": [],
+              "hinfo": null,
+              "loc": null,
+              "bacnetid": null,
+              "name": "foo.example.org",
+              "contact": "",
+              "ttl": null,
+              "comment": "",
+              "zone": 1
             }
-          ],
-          "ptr_overrides": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "name": "foo.example.org",
-          "contact": "",
-          "ttl": null,
-          "comment": "",
-          "zone": 1
-        }
           ]
         }
       }
@@ -18490,11 +18490,23 @@
     "command_issued": "dhcp assoc <IPv4> <macaddress> # doesn't work, because ip addr doesn't exist",
     "ok": [],
     "warning": [
-      "WARNING: : ip <IPv4> doesn't exist."
+      "IP address <IPv4> does not exist."
     ],
     "error": [],
     "output": [],
     "api_requests": [
+      {
+        "method": "GET",
+        "url": "/api/v1/ipaddresses/?macaddress=aa%3Abb%3Acc%3Add%3Aee%3Aff",
+        "data": {},
+        "status": 200,
+        "response": {
+          "count": 0,
+          "next": null,
+          "previous": null,
+          "results": []
+        }
+      },
       {
         "method": "GET",
         "url": "/api/v1/ipaddresses/?ipaddress=<IPv4>",
@@ -18524,6 +18536,18 @@
     "api_requests": [
       {
         "method": "GET",
+        "url": "/api/v1/ipaddresses/?macaddress=aa%3Abb%3Acc%3Add%3Aee%3Aff",
+        "data": {},
+        "status": 200,
+        "response": {
+          "count": 0,
+          "next": null,
+          "previous": null,
+          "results": []
+        }
+      },
+      {
+        "method": "GET",
         "url": "/api/v1/ipaddresses/?ipaddress=<IPv4>",
         "data": {},
         "status": 200,
@@ -18541,24 +18565,23 @@
         }
       },
       {
+        "method": "PATCH",
+        "url": "/api/v1/ipaddresses/8",
+        "data": {
+          "macaddress": "<macaddress>"
+        },
+        "status": 204
+      },
+      {
         "method": "GET",
-        "url": "/api/v1/ipaddresses/?macaddress=aa%3Abb%3Acc%3Add%3Aee%3Aff&ordering=ipaddress",
+        "url": "/api/v1/ipaddresses/8",
         "data": {},
         "status": 200,
         "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
+          "macaddress": "<macaddress>",
+          "ipaddress": "<IPv4>",
+          "host": 13
         }
-      },
-      {
-        "method": "PATCH",
-        "url": "/api/v1/ipaddresses/6",
-        "data": {
-          "macaddress": "<IPv6>"
-        },
-        "status": 204
       }
     ],
     "time": null
@@ -18570,7 +18593,7 @@
     "command_issued": "dhcp disassoc <IPv4> # ip addr dosnt exst",
     "ok": [],
     "warning": [
-      "WARNING: : ip <IPv4> doesn't exist."
+      "IP address <IPv4> does not exist."
     ],
     "error": [],
     "output": [],
@@ -18622,11 +18645,22 @@
       },
       {
         "method": "PATCH",
-        "url": "/api/v1/ipaddresses/6",
+        "url": "/api/v1/ipaddresses/8",
         "data": {
           "macaddress": ""
         },
         "status": 204
+      },
+      {
+        "method": "GET",
+        "url": "/api/v1/ipaddresses/8",
+        "data": {},
+        "status": 200,
+        "response": {
+          "macaddress": "",
+          "ipaddress": "<IPv4>",
+          "host": 13
+        }
       }
     ],
     "time": null
@@ -18638,11 +18672,23 @@
     "command_issued": "dhcp assoc meh <macaddress> # host not found",
     "ok": [],
     "warning": [
-      "WARNING: : host not found: 'meh.example.org'"
+      "Host meh not found."
     ],
     "error": [],
     "output": [],
     "api_requests": [
+      {
+        "method": "GET",
+        "url": "/api/v1/ipaddresses/?macaddress=11%3A22%3A33%3A44%3A55%3A66",
+        "data": {},
+        "status": 200,
+        "response": {
+          "count": 0,
+          "next": null,
+          "previous": null,
+          "results": []
+        }
+      },
       {
         "method": "GET",
         "url": "/api/v1/hosts/meh.example.org",
@@ -18654,14 +18700,11 @@
       },
       {
         "method": "GET",
-        "url": "/api/v1/hosts/?cnames__name=meh.example.org",
+        "url": "/api/v1/cnames/meh.example.org",
         "data": {},
-        "status": 200,
+        "status": 404,
         "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
+          "detail": "Not found."
         }
       }
     ],
@@ -18673,12 +18716,24 @@
     "command_filter_negate": false,
     "command_issued": "dhcp assoc foo <macaddress>",
     "ok": [
-      "OK: : associated mac address <IPv6> with ip <IPv4>"
+      "Associated mac address <macaddress> with ip <IPv4>"
     ],
     "warning": [],
     "error": [],
     "output": [],
     "api_requests": [
+      {
+        "method": "GET",
+        "url": "/api/v1/ipaddresses/?macaddress=aa%3Abb%3Acc%3Add%3Aee%3Aff",
+        "data": {},
+        "status": 200,
+        "response": {
+          "count": 0,
+          "next": null,
+          "previous": null,
+          "results": []
+        }
+      },
       {
         "method": "GET",
         "url": "/api/v1/hosts/foo.example.org",
@@ -18712,24 +18767,23 @@
         }
       },
       {
+        "method": "PATCH",
+        "url": "/api/v1/ipaddresses/8",
+        "data": {
+          "macaddress": "<macaddress>"
+        },
+        "status": 204
+      },
+      {
         "method": "GET",
-        "url": "/api/v1/ipaddresses/?macaddress=aa%3Abb%3Acc%3Add%3Aee%3Aff&ordering=ipaddress",
+        "url": "/api/v1/ipaddresses/8",
         "data": {},
         "status": 200,
         "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
+          "macaddress": "<macaddress>",
+          "ipaddress": "<IPv4>",
+          "host": 13
         }
-      },
-      {
-        "method": "PATCH",
-        "url": "/api/v1/ipaddresses/6",
-        "data": {
-          "macaddress": "<IPv6>"
-        },
-        "status": 204
       }
     ],
     "time": null
@@ -18740,7 +18794,7 @@
     "command_filter_negate": false,
     "command_issued": "dhcp disassoc foo",
     "ok": [
-      "OK: : disassociated mac address <IPv6> from ip <IPv4>"
+      "Disassociated mac address <macaddress> from ip <IPv4>"
     ],
     "warning": [],
     "error": [],
@@ -18780,11 +18834,22 @@
       },
       {
         "method": "PATCH",
-        "url": "/api/v1/ipaddresses/6",
+        "url": "/api/v1/ipaddresses/8",
         "data": {
           "macaddress": ""
         },
         "status": 204
+      },
+      {
+        "method": "GET",
+        "url": "/api/v1/ipaddresses/8",
+        "data": {},
+        "status": 200,
+        "response": {
+          "macaddress": "",
+          "ipaddress": "<IPv4>",
+          "host": 13
+        }
       }
     ],
     "time": null
@@ -18796,7 +18861,7 @@
     "command_issued": "dhcp disassoc meh # host not found",
     "ok": [],
     "warning": [
-      "WARNING: : host not found: 'meh.example.org'"
+      "Host meh not found."
     ],
     "error": [],
     "output": [],
@@ -18812,14 +18877,11 @@
       },
       {
         "method": "GET",
-        "url": "/api/v1/hosts/?cnames__name=meh.example.org",
+        "url": "/api/v1/cnames/meh.example.org",
         "data": {},
-        "status": 200,
+        "status": 404,
         "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
+          "detail": "Not found."
         }
       }
     ],
@@ -18831,7 +18893,7 @@
     "command_filter_negate": false,
     "command_issued": "host a_remove foo <IPv4>",
     "ok": [
-      "OK: : removed ip <IPv4> from foo.example.org"
+      "Removed ipaddress <IPv4> from foo.example.org"
     ],
     "warning": [],
     "error": [],
@@ -18844,357 +18906,6 @@
         "status": 200,
         "response": {
           "ipaddresses": [
-            {
-              "macaddress": "",
-              "ipaddress": "<IPv4>",
-              "host": 13
-            }
-          ],
-          "cnames": [],
-          "mxs": [],
-          "txts": [
-            {
-              "txt": "v=spf1 -all",
-              "host": 13
-            }
-          ],
-          "ptr_overrides": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "name": "foo.example.org",
-          "contact": "",
-          "ttl": null,
-          "comment": "",
-          "zone": 1
-        }
-      },
-      {
-        "method": "DELETE",
-        "url": "/api/v1/ipaddresses/6",
-        "data": {},
-        "status": 204
-      }
-    ],
-    "time": null
-  },
-  {
-    "command": "dhcp assoc foo <macaddress>",
-    "command_filter": null,
-    "command_filter_negate": false,
-    "command_issued": "dhcp assoc foo <macaddress> # doesn't work, because the host doesn't have any ip addresses",
-    "ok": [],
-    "warning": [
-      "WARNING: : foo doesn't have any ip addresses."
-    ],
-    "error": [],
-    "output": [],
-    "api_requests": [
-      {
-        "method": "GET",
-        "url": "/api/v1/hosts/foo.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [],
-          "cnames": [],
-          "mxs": [],
-          "txts": [
-            {
-              "txt": "v=spf1 -all",
-              "host": 13
-            }
-          ],
-          "ptr_overrides": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "name": "foo.example.org",
-          "contact": "",
-          "ttl": null,
-          "comment": "",
-          "zone": 1
-        }
-      }
-    ],
-    "time": null
-  },
-  {
-    "command": "host a_add foo <IPv4>",
-    "command_filter": null,
-    "command_filter_negate": false,
-    "command_issued": "host a_add foo <IPv4>",
-    "ok": [
-      "OK: : added ip <IPv4> to foo.example.org"
-    ],
-    "warning": [],
-    "error": [],
-    "output": [],
-    "api_requests": [
-      {
-        "method": "GET",
-        "url": "/api/v1/hosts/?ipaddresses__ipaddress=<IPv4>",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/ip/<IPv4>",
-        "data": {},
-        "status": 200,
-        "response": {
-          "excluded_ranges": [],
-          "network": "<IPv4>/24",
-          "description": "foo",
-          "vlan": 1234,
-          "dns_delegated": false,
-          "category": "",
-          "location": "",
-          "frozen": false,
-          "reserved": 3
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/<IPv4>/24/reserved_list",
-        "data": {},
-        "status": 200,
-        "response": [
-          "<IPv4>",
-          "<IPv4>",
-          "<IPv4>",
-          "<IPv4>",
-          "<IPv4>"
-        ]
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hosts/foo.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [],
-          "cnames": [],
-          "mxs": [],
-          "txts": [
-            {
-              "txt": "v=spf1 -all",
-              "host": 13
-            }
-          ],
-          "ptr_overrides": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "name": "foo.example.org",
-          "contact": "",
-          "ttl": null,
-          "comment": "",
-          "zone": 1
-        }
-      },
-      {
-        "method": "POST",
-        "url": "/api/v1/ipaddresses/",
-        "data": {
-          "host": 13,
-          "ipaddress": "<IPv4>"
-        },
-        "status": 201,
-        "response": {
-          "macaddress": "",
-          "ipaddress": "<IPv4>",
-          "host": 13
-        }
-      }
-    ],
-    "time": null
-  },
-  {
-    "command": "host a_add foo <IPv4> -f",
-    "command_filter": null,
-    "command_filter_negate": false,
-    "command_issued": "host a_add foo <IPv4> -f",
-    "ok": [
-      "OK: : added ip <IPv4> to foo.example.org"
-    ],
-    "warning": [],
-    "error": [],
-    "output": [],
-    "api_requests": [
-      {
-        "method": "GET",
-        "url": "/api/v1/hosts/?ipaddresses__ipaddress=<IPv4>",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/ip/<IPv4>",
-        "data": {},
-        "status": 200,
-        "response": {
-          "excluded_ranges": [],
-          "network": "<IPv4>/24",
-          "description": "foo",
-          "vlan": 1234,
-          "dns_delegated": false,
-          "category": "",
-          "location": "",
-          "frozen": false,
-          "reserved": 3
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/<IPv4>/24/reserved_list",
-        "data": {},
-        "status": 200,
-        "response": [
-          "<IPv4>",
-          "<IPv4>",
-          "<IPv4>",
-          "<IPv4>",
-          "<IPv4>"
-        ]
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hosts/foo.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "",
-              "ipaddress": "<IPv4>",
-              "host": 13
-            }
-          ],
-          "cnames": [],
-          "mxs": [],
-          "txts": [
-            {
-              "txt": "v=spf1 -all",
-              "host": 13
-            }
-          ],
-          "ptr_overrides": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "name": "foo.example.org",
-          "contact": "",
-          "ttl": null,
-          "comment": "",
-          "zone": 1
-        }
-      },
-      {
-        "method": "POST",
-        "url": "/api/v1/ipaddresses/",
-        "data": {
-          "host": 13,
-          "ipaddress": "<IPv4>"
-        },
-        "status": 201,
-        "response": {
-          "macaddress": "",
-          "ipaddress": "<IPv4>",
-          "host": 13
-        }
-      }
-    ],
-    "time": null
-  },
-  {
-    "command": "dhcp assoc foo <macaddress>",
-    "command_filter": null,
-    "command_filter_negate": false,
-    "command_issued": "dhcp assoc foo <macaddress> # should fail, two IPs of same type",
-    "ok": [],
-    "warning": [
-      "WARNING: : foo has multiple addresses in the same address family. Please specify a specific address to use instead."
-    ],
-    "error": [],
-    "output": [],
-    "api_requests": [
-      {
-        "method": "GET",
-        "url": "/api/v1/hosts/foo.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "",
-              "ipaddress": "<IPv4>",
-              "host": 13
-            },
-            {
-              "macaddress": "",
-              "ipaddress": "<IPv4>",
-              "host": 13
-            }
-          ],
-          "cnames": [],
-          "mxs": [],
-          "txts": [
-            {
-              "txt": "v=spf1 -all",
-              "host": 13
-            }
-          ],
-          "ptr_overrides": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "name": "foo.example.org",
-          "contact": "",
-          "ttl": null,
-          "comment": "",
-          "zone": 1
-        }
-      }
-    ],
-    "time": null
-  },
-  {
-    "command": "host a_remove foo <IPv4>",
-    "command_filter": null,
-    "command_filter_negate": false,
-    "command_issued": "host a_remove foo <IPv4>",
-    "ok": [
-      "OK: : removed ip <IPv4> from foo.example.org"
-    ],
-    "warning": [],
-    "error": [],
-    "output": [],
-    "api_requests": [
-      {
-        "method": "GET",
-        "url": "/api/v1/hosts/foo.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "",
-              "ipaddress": "<IPv4>",
-              "host": 13
-            },
             {
               "macaddress": "",
               "ipaddress": "<IPv4>",
@@ -19230,12 +18941,432 @@
     "time": null
   },
   {
+    "command": "dhcp assoc foo <macaddress>",
+    "command_filter": null,
+    "command_filter_negate": false,
+    "command_issued": "dhcp assoc foo <macaddress> # doesn't work, because the host doesn't have any ip addresses",
+    "ok": [],
+    "warning": [
+      "Host foo.example.org has no IP addresses."
+    ],
+    "error": [],
+    "output": [],
+    "api_requests": [
+      {
+        "method": "GET",
+        "url": "/api/v1/ipaddresses/?macaddress=aa%3Abb%3Acc%3Add%3Aee%3Aff",
+        "data": {},
+        "status": 200,
+        "response": {
+          "count": 0,
+          "next": null,
+          "previous": null,
+          "results": []
+        }
+      },
+      {
+        "method": "GET",
+        "url": "/api/v1/hosts/foo.example.org",
+        "data": {},
+        "status": 200,
+        "response": {
+          "ipaddresses": [],
+          "cnames": [],
+          "mxs": [],
+          "txts": [
+            {
+              "txt": "v=spf1 -all",
+              "host": 13
+            }
+          ],
+          "ptr_overrides": [],
+          "hinfo": null,
+          "loc": null,
+          "bacnetid": null,
+          "name": "foo.example.org",
+          "contact": "",
+          "ttl": null,
+          "comment": "",
+          "zone": 1
+        }
+      }
+    ],
+    "time": null
+  },
+  {
+    "command": "host a_add foo <IPv4>",
+    "command_filter": null,
+    "command_filter_negate": false,
+    "command_issued": "host a_add foo <IPv4>",
+    "ok": [
+      "Added ipaddress <IPv4> to foo.example.org"
+    ],
+    "warning": [],
+    "error": [],
+    "output": [],
+    "api_requests": [
+      {
+        "method": "GET",
+        "url": "/api/v1/hosts/foo.example.org",
+        "data": {},
+        "status": 200,
+        "response": {
+          "ipaddresses": [],
+          "cnames": [],
+          "mxs": [],
+          "txts": [
+            {
+              "txt": "v=spf1 -all",
+              "host": 13
+            }
+          ],
+          "ptr_overrides": [],
+          "hinfo": null,
+          "loc": null,
+          "bacnetid": null,
+          "name": "foo.example.org",
+          "contact": "",
+          "ttl": null,
+          "comment": "",
+          "zone": 1
+        }
+      },
+      {
+        "method": "GET",
+        "url": "/api/v1/networks/ip/<IPv4>",
+        "data": {},
+        "status": 200,
+        "response": {
+          "excluded_ranges": [],
+          "network": "<IPv4>/24",
+          "description": "foo",
+          "vlan": 1234,
+          "dns_delegated": false,
+          "category": "",
+          "location": "",
+          "frozen": false,
+          "reserved": 3
+        }
+      },
+      {
+        "method": "GET",
+        "url": "/api/v1/hosts/?ipaddresses__ipaddress=<IPv4>&ordering=name",
+        "data": {},
+        "status": 200,
+        "response": {
+          "count": 0,
+          "next": null,
+          "previous": null,
+          "results": []
+        }
+      },
+      {
+        "method": "POST",
+        "url": "/api/v1/ipaddresses/",
+        "data": {
+          "ipaddress": "<IPv4>",
+          "host": "13"
+        },
+        "status": 201,
+        "response": {
+          "macaddress": "",
+          "ipaddress": "<IPv4>",
+          "host": 13
+        }
+      },
+      {
+        "method": "GET",
+        "url": "/api/v1/hosts/?id=13",
+        "data": {},
+        "status": 200,
+        "response": {
+          "count": 1,
+          "next": null,
+          "previous": null,
+          "results": [
+            {
+              "ipaddresses": [
+                {
+                  "macaddress": "",
+                  "ipaddress": "<IPv4>",
+                  "host": 13
+                }
+              ],
+              "cnames": [],
+              "mxs": [],
+              "txts": [
+                {
+                  "txt": "v=spf1 -all",
+                  "host": 13
+                }
+              ],
+              "ptr_overrides": [],
+              "hinfo": null,
+              "loc": null,
+              "bacnetid": null,
+              "name": "foo.example.org",
+              "contact": "",
+              "ttl": null,
+              "comment": "",
+              "zone": 1
+            }
+          ]
+        }
+      }
+    ],
+    "time": null
+  },
+  {
+    "command": "host a_add foo <IPv4> -f",
+    "command_filter": null,
+    "command_filter_negate": false,
+    "command_issued": "host a_add foo <IPv4> -f",
+    "ok": [
+      "Added ipaddress <IPv4> to foo.example.org"
+    ],
+    "warning": [],
+    "error": [],
+    "output": [],
+    "api_requests": [
+      {
+        "method": "GET",
+        "url": "/api/v1/hosts/foo.example.org",
+        "data": {},
+        "status": 200,
+        "response": {
+          "ipaddresses": [
+            {
+              "macaddress": "",
+              "ipaddress": "<IPv4>",
+              "host": 13
+            }
+          ],
+          "cnames": [],
+          "mxs": [],
+          "txts": [
+            {
+              "txt": "v=spf1 -all",
+              "host": 13
+            }
+          ],
+          "ptr_overrides": [],
+          "hinfo": null,
+          "loc": null,
+          "bacnetid": null,
+          "name": "foo.example.org",
+          "contact": "",
+          "ttl": null,
+          "comment": "",
+          "zone": 1
+        }
+      },
+      {
+        "method": "GET",
+        "url": "/api/v1/networks/ip/<IPv4>",
+        "data": {},
+        "status": 200,
+        "response": {
+          "excluded_ranges": [],
+          "network": "<IPv4>/24",
+          "description": "foo",
+          "vlan": 1234,
+          "dns_delegated": false,
+          "category": "",
+          "location": "",
+          "frozen": false,
+          "reserved": 3
+        }
+      },
+      {
+        "method": "POST",
+        "url": "/api/v1/ipaddresses/",
+        "data": {
+          "ipaddress": "<IPv4>",
+          "host": "13"
+        },
+        "status": 201,
+        "response": {
+          "macaddress": "",
+          "ipaddress": "<IPv4>",
+          "host": 13
+        }
+      },
+      {
+        "method": "GET",
+        "url": "/api/v1/hosts/?id=13",
+        "data": {},
+        "status": 200,
+        "response": {
+          "count": 1,
+          "next": null,
+          "previous": null,
+          "results": [
+            {
+              "ipaddresses": [
+                {
+                  "macaddress": "",
+                  "ipaddress": "<IPv4>",
+                  "host": 13
+                },
+                {
+                  "macaddress": "",
+                  "ipaddress": "<IPv4>",
+                  "host": 13
+                }
+              ],
+              "cnames": [],
+              "mxs": [],
+              "txts": [
+                {
+                  "txt": "v=spf1 -all",
+                  "host": 13
+                }
+              ],
+              "ptr_overrides": [],
+              "hinfo": null,
+              "loc": null,
+              "bacnetid": null,
+              "name": "foo.example.org",
+              "contact": "",
+              "ttl": null,
+              "comment": "",
+              "zone": 1
+            }
+          ]
+        }
+      }
+    ],
+    "time": null
+  },
+  {
+    "command": "dhcp assoc foo <macaddress>",
+    "command_filter": null,
+    "command_filter_negate": false,
+    "command_issued": "dhcp assoc foo <macaddress> # should fail, two IPs of same type",
+    "ok": [],
+    "warning": [
+      "Host foo.example.org has multiple IPs, cannot determine which one to use."
+    ],
+    "error": [],
+    "output": [],
+    "api_requests": [
+      {
+        "method": "GET",
+        "url": "/api/v1/ipaddresses/?macaddress=aa%3Abb%3Acc%3Add%3Aee%3Aff",
+        "data": {},
+        "status": 200,
+        "response": {
+          "count": 0,
+          "next": null,
+          "previous": null,
+          "results": []
+        }
+      },
+      {
+        "method": "GET",
+        "url": "/api/v1/hosts/foo.example.org",
+        "data": {},
+        "status": 200,
+        "response": {
+          "ipaddresses": [
+            {
+              "macaddress": "",
+              "ipaddress": "<IPv4>",
+              "host": 13
+            },
+            {
+              "macaddress": "",
+              "ipaddress": "<IPv4>",
+              "host": 13
+            }
+          ],
+          "cnames": [],
+          "mxs": [],
+          "txts": [
+            {
+              "txt": "v=spf1 -all",
+              "host": 13
+            }
+          ],
+          "ptr_overrides": [],
+          "hinfo": null,
+          "loc": null,
+          "bacnetid": null,
+          "name": "foo.example.org",
+          "contact": "",
+          "ttl": null,
+          "comment": "",
+          "zone": 1
+        }
+      }
+    ],
+    "time": null
+  },
+  {
+    "command": "host a_remove foo <IPv4>",
+    "command_filter": null,
+    "command_filter_negate": false,
+    "command_issued": "host a_remove foo <IPv4>",
+    "ok": [
+      "Removed ipaddress <IPv4> from foo.example.org"
+    ],
+    "warning": [],
+    "error": [],
+    "output": [],
+    "api_requests": [
+      {
+        "method": "GET",
+        "url": "/api/v1/hosts/foo.example.org",
+        "data": {},
+        "status": 200,
+        "response": {
+          "ipaddresses": [
+            {
+              "macaddress": "",
+              "ipaddress": "<IPv4>",
+              "host": 13
+            },
+            {
+              "macaddress": "",
+              "ipaddress": "<IPv4>",
+              "host": 13
+            }
+          ],
+          "cnames": [],
+          "mxs": [],
+          "txts": [
+            {
+              "txt": "v=spf1 -all",
+              "host": 13
+            }
+          ],
+          "ptr_overrides": [],
+          "hinfo": null,
+          "loc": null,
+          "bacnetid": null,
+          "name": "foo.example.org",
+          "contact": "",
+          "ttl": null,
+          "comment": "",
+          "zone": 1
+        }
+      },
+      {
+        "method": "DELETE",
+        "url": "/api/v1/ipaddresses/10",
+        "data": {},
+        "status": 204
+      }
+    ],
+    "time": null
+  },
+  {
     "command": "network create -network <IPv6>::/64 -desc \"foo_ipv6\" -vlan 1234",
     "command_filter": null,
     "command_filter_negate": false,
     "command_issued": "network create -network <IPv6>::/64 -desc \"foo_ipv6\" -vlan 1234",
     "ok": [
-      "OK: : created network <IPv6>::/64"
+      "created network <IPv6>::/64"
     ],
     "warning": [],
     "error": [],
@@ -19272,11 +19403,26 @@
           "network": "<IPv6>::/64",
           "description": "foo_ipv6",
           "vlan": "1234",
-          "category": null,
-          "location": null,
           "frozen": false
         },
         "status": 201
+      },
+      {
+        "method": "GET",
+        "url": "/api/v1/networks/<IPv6>::/64",
+        "data": {},
+        "status": 200,
+        "response": {
+          "excluded_ranges": [],
+          "network": "<IPv6>::/64",
+          "description": "foo_ipv6",
+          "vlan": 1234,
+          "dns_delegated": false,
+          "category": "",
+          "location": "",
+          "frozen": false,
+          "reserved": 3
+        }
       }
     ],
     "time": null
@@ -19287,7 +19433,7 @@
     "command_filter_negate": false,
     "command_issued": "network create -network <IPv6>::/64 -desc \"notfoo_ipv6\" -vlan 1235",
     "ok": [
-      "OK: : created network <IPv6>::/64"
+      "created network <IPv6>::/64"
     ],
     "warning": [],
     "error": [],
@@ -19335,42 +19481,13 @@
           "network": "<IPv6>::/64",
           "description": "notfoo_ipv6",
           "vlan": "1235",
-          "category": null,
-          "location": null,
           "frozen": false
         },
         "status": 201
-      }
-    ],
-    "time": null
-  },
-  {
-    "command": "host aaaa_add foo <IPv6> -f",
-    "command_filter": null,
-    "command_filter_negate": false,
-    "command_issued": "host aaaa_add foo <IPv6> -f",
-    "ok": [
-      "OK: : added ip <IPv6> to foo.example.org"
-    ],
-    "warning": [],
-    "error": [],
-    "output": [],
-    "api_requests": [
-      {
-        "method": "GET",
-        "url": "/api/v1/hosts/?ipaddresses__ipaddress=2001%3Adb9%3A%3A5",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
       },
       {
         "method": "GET",
-        "url": "/api/v1/networks/ip/2001%3Adb9%3A%3A5",
+        "url": "/api/v1/networks/<IPv6>::/64",
         "data": {},
         "status": 200,
         "response": {
@@ -19384,19 +19501,22 @@
           "frozen": false,
           "reserved": 3
         }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/2001%3Adb9%3A%3A/64/reserved_list",
-        "data": {},
-        "status": 200,
-        "response": [
-          "<IPv6>::",
-          "<IPv6>",
-          "<IPv6>",
-          "<IPv6>"
-        ]
-      },
+      }
+    ],
+    "time": null
+  },
+  {
+    "command": "host aaaa_add foo <IPv6> -f",
+    "command_filter": null,
+    "command_filter_negate": false,
+    "command_issued": "host aaaa_add foo <IPv6> -f",
+    "ok": [
+      "Added ipaddress <IPv6> to foo.example.org"
+    ],
+    "warning": [],
+    "error": [],
+    "output": [],
+    "api_requests": [
       {
         "method": "GET",
         "url": "/api/v1/hosts/foo.example.org",
@@ -19430,17 +19550,78 @@
         }
       },
       {
+        "method": "GET",
+        "url": "/api/v1/networks/ip/2001%3Adb9%3A%3A5",
+        "data": {},
+        "status": 200,
+        "response": {
+          "excluded_ranges": [],
+          "network": "<IPv6>::/64",
+          "description": "notfoo_ipv6",
+          "vlan": 1235,
+          "dns_delegated": false,
+          "category": "",
+          "location": "",
+          "frozen": false,
+          "reserved": 3
+        }
+      },
+      {
         "method": "POST",
         "url": "/api/v1/ipaddresses/",
         "data": {
-          "host": 13,
-          "ipaddress": "<IPv6>"
+          "ipaddress": "<IPv6>",
+          "host": "13"
         },
         "status": 201,
         "response": {
           "macaddress": "",
           "ipaddress": "<IPv6>",
           "host": 13
+        }
+      },
+      {
+        "method": "GET",
+        "url": "/api/v1/hosts/?id=13",
+        "data": {},
+        "status": 200,
+        "response": {
+          "count": 1,
+          "next": null,
+          "previous": null,
+          "results": [
+            {
+              "ipaddresses": [
+                {
+                  "macaddress": "",
+                  "ipaddress": "<IPv4>",
+                  "host": 13
+                },
+                {
+                  "macaddress": "",
+                  "ipaddress": "<IPv6>",
+                  "host": 13
+                }
+              ],
+              "cnames": [],
+              "mxs": [],
+              "txts": [
+                {
+                  "txt": "v=spf1 -all",
+                  "host": 13
+                }
+              ],
+              "ptr_overrides": [],
+              "hinfo": null,
+              "loc": null,
+              "bacnetid": null,
+              "name": "foo.example.org",
+              "contact": "",
+              "ttl": null,
+              "comment": "",
+              "zone": 1
+            }
+          ]
         }
       }
     ],
@@ -19453,11 +19634,23 @@
     "command_issued": "dhcp assoc foo <macaddress> # should fail, the host has two IPs of different types on different VLANs.",
     "ok": [],
     "warning": [
-      "WARNING: : foo.example.org has one IPv4 and one IPv6 address, but they are on different VLANs. Please specify a specific address to use instead."
+      "Host foo.example.org has multiple IPs, cannot determine which one to use."
     ],
     "error": [],
     "output": [],
     "api_requests": [
+      {
+        "method": "GET",
+        "url": "/api/v1/ipaddresses/?macaddress=aa%3Abb%3Acc%3Add%3Aee%3Aff",
+        "data": {},
+        "status": 200,
+        "response": {
+          "count": 0,
+          "next": null,
+          "previous": null,
+          "results": []
+        }
+      },
       {
         "method": "GET",
         "url": "/api/v1/hosts/foo.example.org",
@@ -19538,7 +19731,7 @@
     "command_filter_negate": false,
     "command_issued": "host aaaa_remove foo <IPv6>",
     "ok": [
-      "OK: : removed ip <IPv6> from foo.example.org"
+      "Removed ipaddress <IPv6> from foo.example.org"
     ],
     "warning": [],
     "error": [],
@@ -19583,7 +19776,7 @@
       },
       {
         "method": "DELETE",
-        "url": "/api/v1/ipaddresses/9",
+        "url": "/api/v1/ipaddresses/11",
         "data": {},
         "status": 204
       }
@@ -19596,53 +19789,12 @@
     "command_filter_negate": false,
     "command_issued": "host aaaa_add foo <IPv6> -f",
     "ok": [
-      "OK: : added ip <IPv6> to foo.example.org"
+      "Added ipaddress <IPv6> to foo.example.org"
     ],
     "warning": [],
     "error": [],
     "output": [],
     "api_requests": [
-      {
-        "method": "GET",
-        "url": "/api/v1/hosts/?ipaddresses__ipaddress=2001%3Adb8%3A%3A5",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/ip/2001%3Adb8%3A%3A5",
-        "data": {},
-        "status": 200,
-        "response": {
-          "excluded_ranges": [],
-          "network": "<IPv6>::/64",
-          "description": "foo_ipv6",
-          "vlan": 1234,
-          "dns_delegated": false,
-          "category": "",
-          "location": "",
-          "frozen": false,
-          "reserved": 3
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/2001%3Adb8%3A%3A/64/reserved_list",
-        "data": {},
-        "status": 200,
-        "response": [
-          "<IPv6>::",
-          "<IPv6>",
-          "<IPv6>",
-          "<IPv6>"
-        ]
-      },
       {
         "method": "GET",
         "url": "/api/v1/hosts/foo.example.org",
@@ -19676,17 +19828,78 @@
         }
       },
       {
+        "method": "GET",
+        "url": "/api/v1/networks/ip/2001%3Adb8%3A%3A5",
+        "data": {},
+        "status": 200,
+        "response": {
+          "excluded_ranges": [],
+          "network": "<IPv6>::/64",
+          "description": "foo_ipv6",
+          "vlan": 1234,
+          "dns_delegated": false,
+          "category": "",
+          "location": "",
+          "frozen": false,
+          "reserved": 3
+        }
+      },
+      {
         "method": "POST",
         "url": "/api/v1/ipaddresses/",
         "data": {
-          "host": 13,
-          "ipaddress": "<IPv6>"
+          "ipaddress": "<IPv6>",
+          "host": "13"
         },
         "status": 201,
         "response": {
           "macaddress": "",
           "ipaddress": "<IPv6>",
           "host": 13
+        }
+      },
+      {
+        "method": "GET",
+        "url": "/api/v1/hosts/?id=13",
+        "data": {},
+        "status": 200,
+        "response": {
+          "count": 1,
+          "next": null,
+          "previous": null,
+          "results": [
+            {
+              "ipaddresses": [
+                {
+                  "macaddress": "",
+                  "ipaddress": "<IPv4>",
+                  "host": 13
+                },
+                {
+                  "macaddress": "",
+                  "ipaddress": "<IPv6>",
+                  "host": 13
+                }
+              ],
+              "cnames": [],
+              "mxs": [],
+              "txts": [
+                {
+                  "txt": "v=spf1 -all",
+                  "host": 13
+                }
+              ],
+              "ptr_overrides": [],
+              "hinfo": null,
+              "loc": null,
+              "bacnetid": null,
+              "name": "foo.example.org",
+              "contact": "",
+              "ttl": null,
+              "comment": "",
+              "zone": 1
+            }
+          ]
         }
       }
     ],
@@ -19698,12 +19911,24 @@
     "command_filter_negate": false,
     "command_issued": "dhcp assoc foo <macaddress> # should work, the host now has two IPs of different types on the same VLAN.",
     "ok": [
-      "OK: : associated mac address <IPv6> with ip <IPv4>"
+      "Associated mac address <macaddress> with ip <IPv4>"
     ],
     "warning": [],
     "error": [],
     "output": [],
     "api_requests": [
+      {
+        "method": "GET",
+        "url": "/api/v1/ipaddresses/?macaddress=aa%3Abb%3Acc%3Add%3Aee%3Aff",
+        "data": {},
+        "status": 200,
+        "response": {
+          "count": 0,
+          "next": null,
+          "previous": null,
+          "results": []
+        }
+      },
       {
         "method": "GET",
         "url": "/api/v1/hosts/foo.example.org",
@@ -19776,24 +20001,23 @@
         }
       },
       {
+        "method": "PATCH",
+        "url": "/api/v1/ipaddresses/9",
+        "data": {
+          "macaddress": "<macaddress>"
+        },
+        "status": 204
+      },
+      {
         "method": "GET",
-        "url": "/api/v1/ipaddresses/?macaddress=aa%3Abb%3Acc%3Add%3Aee%3Aff&ordering=ipaddress",
+        "url": "/api/v1/ipaddresses/9",
         "data": {},
         "status": 200,
         "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
+          "macaddress": "<macaddress>",
+          "ipaddress": "<IPv4>",
+          "host": 13
         }
-      },
-      {
-        "method": "PATCH",
-        "url": "/api/v1/ipaddresses/7",
-        "data": {
-          "macaddress": "<IPv6>"
-        },
-        "status": 204
       }
     ],
     "time": null
@@ -19804,7 +20028,7 @@
     "command_filter_negate": false,
     "command_issued": "host remove foo -f",
     "ok": [
-      "OK: : removed foo.example.org"
+      "removed foo.example.org"
     ],
     "warning": [],
     "error": [],
@@ -19818,7 +20042,7 @@
         "response": {
           "ipaddresses": [
             {
-              "macaddress": "<IPv6>",
+              "macaddress": "<macaddress>",
               "ipaddress": "<IPv4>",
               "host": 13
             },
@@ -19895,7 +20119,7 @@
       },
       {
         "method": "GET",
-        "url": "/api/v1/srvs/?host__name=foo.example.org",
+        "url": "/api/v1/srvs/?host=13",
         "data": {},
         "status": 200,
         "response": {
@@ -19920,7 +20144,7 @@
     "command_filter_negate": false,
     "command_issued": "network remove <IPv4>/24 -f",
     "ok": [
-      "OK: : removed network <IPv4>/24"
+      "Removed network <IPv4>/24"
     ],
     "warning": [],
     "error": [],
@@ -19928,10 +20152,27 @@
     "api_requests": [
       {
         "method": "GET",
-        "url": "/api/v1/networks/<IPv4>/24/used_list",
+        "url": "/api/v1/networks/<IPv4>/24",
         "data": {},
         "status": 200,
-        "response": []
+        "response": {
+          "excluded_ranges": [],
+          "network": "<IPv4>/24",
+          "description": "foo",
+          "vlan": 1234,
+          "dns_delegated": false,
+          "category": "",
+          "location": "",
+          "frozen": false,
+          "reserved": 3
+        }
+      },
+      {
+        "method": "GET",
+        "url": "/api/v1/networks/<IPv4>/24/used_count",
+        "data": {},
+        "status": 200,
+        "response": 0
       },
       {
         "method": "DELETE",
@@ -19948,7 +20189,7 @@
     "command_filter_negate": false,
     "command_issued": "network remove <IPv6>::/64 -f",
     "ok": [
-      "OK: : removed network <IPv6>::/64"
+      "Removed network <IPv6>::/64"
     ],
     "warning": [],
     "error": [],
@@ -19956,10 +20197,27 @@
     "api_requests": [
       {
         "method": "GET",
-        "url": "/api/v1/networks/2001%3Adb8%3A%3A/64/used_list",
+        "url": "/api/v1/networks/2001%3Adb8%3A%3A/64",
         "data": {},
         "status": 200,
-        "response": []
+        "response": {
+          "excluded_ranges": [],
+          "network": "<IPv6>::/64",
+          "description": "foo_ipv6",
+          "vlan": 1234,
+          "dns_delegated": false,
+          "category": "",
+          "location": "",
+          "frozen": false,
+          "reserved": 3
+        }
+      },
+      {
+        "method": "GET",
+        "url": "/api/v1/networks/2001%3Adb8%3A%3A/64/used_count",
+        "data": {},
+        "status": 200,
+        "response": 0
       },
       {
         "method": "DELETE",
@@ -19976,7 +20234,7 @@
     "command_filter_negate": false,
     "command_issued": "network remove <IPv6>::/64 -f",
     "ok": [
-      "OK: : removed network <IPv6>::/64"
+      "Removed network <IPv6>::/64"
     ],
     "warning": [],
     "error": [],
@@ -19984,10 +20242,27 @@
     "api_requests": [
       {
         "method": "GET",
-        "url": "/api/v1/networks/2001%3Adb9%3A%3A/64/used_list",
+        "url": "/api/v1/networks/2001%3Adb9%3A%3A/64",
         "data": {},
         "status": 200,
-        "response": []
+        "response": {
+          "excluded_ranges": [],
+          "network": "<IPv6>::/64",
+          "description": "notfoo_ipv6",
+          "vlan": 1235,
+          "dns_delegated": false,
+          "category": "",
+          "location": "",
+          "frozen": false,
+          "reserved": 3
+        }
+      },
+      {
+        "method": "GET",
+        "url": "/api/v1/networks/2001%3Adb9%3A%3A/64/used_count",
+        "data": {},
+        "status": 200,
+        "response": 0
       },
       {
         "method": "DELETE",

--- a/ci/testsuite-result.json
+++ b/ci/testsuite-result.json
@@ -18542,10 +18542,10 @@
     "time": null
   },
   {
-    "command": "dhcp assoc <IPv4> <IPv6>",
+    "command": "dhcp assoc <IPv4> <macaddress>",
     "command_filter": null,
     "command_filter_negate": false,
-    "command_issued": "dhcp assoc <IPv4> <IPv6> # doesn't work, because ip addr doesn't exist",
+    "command_issued": "dhcp assoc <IPv4> <macaddress> # doesn't work, because ip addr doesn't exist",
     "ok": [],
     "warning": [
       "WARNING: : ip <IPv4> doesn't exist."
@@ -18569,12 +18569,12 @@
     "time": null
   },
   {
-    "command": "dhcp assoc <IPv4> <IPv6>",
+    "command": "dhcp assoc <IPv4> <macaddress>",
     "command_filter": null,
     "command_filter_negate": false,
-    "command_issued": "dhcp assoc <IPv4> <IPv6>",
+    "command_issued": "dhcp assoc <IPv4> <macaddress>",
     "ok": [
-      "OK: : associated mac address <IPv6> with ip <IPv4>"
+      "Associated mac address <macaddress> with ip <IPv4>"
     ],
     "warning": [],
     "error": [],
@@ -18654,7 +18654,7 @@
     "command_filter_negate": false,
     "command_issued": "dhcp disassoc <IPv4>",
     "ok": [
-      "OK: : disassociated mac address <IPv6> from ip <IPv4>"
+      "Disassociated mac address <macaddress> from ip <IPv4>"
     ],
     "warning": [],
     "error": [],
@@ -18671,7 +18671,7 @@
           "previous": null,
           "results": [
             {
-              "macaddress": "<IPv6>",
+              "macaddress": "<macaddress>",
               "ipaddress": "<IPv4>",
               "host": 13
             }
@@ -18690,10 +18690,10 @@
     "time": null
   },
   {
-    "command": "dhcp assoc meh <IPv6>",
+    "command": "dhcp assoc meh <macaddress>",
     "command_filter": null,
     "command_filter_negate": false,
-    "command_issued": "dhcp assoc meh <IPv6> # host not found",
+    "command_issued": "dhcp assoc meh <macaddress> # host not found",
     "ok": [],
     "warning": [
       "WARNING: : host not found: 'meh.example.org'"
@@ -18726,10 +18726,10 @@
     "time": null
   },
   {
-    "command": "dhcp assoc foo <IPv6>",
+    "command": "dhcp assoc foo <macaddress>",
     "command_filter": null,
     "command_filter_negate": false,
-    "command_issued": "dhcp assoc foo <IPv6>",
+    "command_issued": "dhcp assoc foo <macaddress>",
     "ok": [
       "OK: : associated mac address <IPv6> with ip <IPv4>"
     ],
@@ -18812,7 +18812,7 @@
         "response": {
           "ipaddresses": [
             {
-              "macaddress": "<IPv6>",
+              "macaddress": "<macaddress>",
               "ipaddress": "<IPv4>",
               "host": 13
             }
@@ -18937,10 +18937,10 @@
     "time": null
   },
   {
-    "command": "dhcp assoc foo <IPv6>",
+    "command": "dhcp assoc foo <macaddress>",
     "command_filter": null,
     "command_filter_negate": false,
-    "command_issued": "dhcp assoc foo <IPv6> # doesn't work, because the host doesn't have any ip addresses",
+    "command_issued": "dhcp assoc foo <macaddress> # doesn't work, because the host doesn't have any ip addresses",
     "ok": [],
     "warning": [
       "WARNING: : foo doesn't have any ip addresses."
@@ -19178,10 +19178,10 @@
     "time": null
   },
   {
-    "command": "dhcp assoc foo <IPv6>",
+    "command": "dhcp assoc foo <macaddress>",
     "command_filter": null,
     "command_filter_negate": false,
-    "command_issued": "dhcp assoc foo <IPv6> # should fail, two IPs of same type",
+    "command_issued": "dhcp assoc foo <macaddress> # should fail, two IPs of same type",
     "ok": [],
     "warning": [
       "WARNING: : foo has multiple addresses in the same address family. Please specify a specific address to use instead."
@@ -19505,10 +19505,10 @@
     "time": null
   },
   {
-    "command": "dhcp assoc foo <IPv6>",
+    "command": "dhcp assoc foo <macaddress>",
     "command_filter": null,
     "command_filter_negate": false,
-    "command_issued": "dhcp assoc foo <IPv6> # should fail, the host has two IPs of different types on different VLANs.",
+    "command_issued": "dhcp assoc foo <macaddress> # should fail, the host has two IPs of different types on different VLANs.",
     "ok": [],
     "warning": [
       "WARNING: : foo.example.org has one IPv4 and one IPv6 address, but they are on different VLANs. Please specify a specific address to use instead."
@@ -19751,10 +19751,10 @@
     "time": null
   },
   {
-    "command": "dhcp assoc foo <IPv6>",
+    "command": "dhcp assoc foo <macaddress>",
     "command_filter": null,
     "command_filter_negate": false,
-    "command_issued": "dhcp assoc foo <IPv6> # should work, the host now has two IPs of different types on the same VLAN.",
+    "command_issued": "dhcp assoc foo <macaddress> # should work, the host now has two IPs of different types on the same VLAN.",
     "ok": [
       "OK: : associated mac address <IPv6> with ip <IPv4>"
     ],
@@ -20149,10 +20149,10 @@
     "time": null
   },
   {
-    "command": "host add foo -ip <IPv4> -contact hi@ho.com -comment \"meh\" -macaddress <IPv6>",
+    "command": "host add foo -ip <IPv4> -contact hi@ho.com -comment \"meh\" -macaddress <macaddress>",
     "command_filter": null,
     "command_filter_negate": false,
-    "command_issued": "host add foo -ip <IPv4> -contact hi@ho.com -comment \"meh\" -macaddress <IPv6>",
+    "command_issued": "host add foo -ip <IPv4> -contact hi@ho.com -comment \"meh\" -macaddress <macaddress>",
     "ok": [
       "OK: : created host foo.example.org with IP <IPv4>"
     ],
@@ -21228,10 +21228,10 @@
     "time": null
   },
   {
-    "command": "host a_add bar <IPv4> -macaddress <IPv6> -force",
+    "command": "host a_add bar <IPv4> -macaddress <macaddress> -force",
     "command_filter": null,
     "command_filter_negate": false,
-    "command_issued": "host a_add bar <IPv4> -macaddress <IPv6> -force",
+    "command_issued": "host a_add bar <IPv4> -macaddress <macaddress> -force",
     "ok": [
       "OK: : added ip <IPv4> to bar.example.org"
     ],
@@ -22020,10 +22020,10 @@
     "time": null
   },
   {
-    "command": "host aaaa_add bar <IPv6> -macaddress <IPv6> -f",
+    "command": "host aaaa_add bar <IPv6> -macaddress <macaddress> -f",
     "command_filter": null,
     "command_filter_negate": false,
-    "command_issued": "host aaaa_add bar <IPv6> -macaddress <IPv6> -f",
+    "command_issued": "host aaaa_add bar <IPv6> -macaddress <macaddress> -f",
     "ok": [
       "OK: : added ip <IPv6> to bar.example.org"
     ],

--- a/mreg_cli/api/fields.py
+++ b/mreg_cli/api/fields.py
@@ -69,6 +69,13 @@ class IPAddressField(FrozenModel):
         """Check if the IP address is IPv6."""
         return isinstance(self.address, ipaddress.IPv6Address)
 
+    def is_valid(value: str) -> bool:
+        try:
+            ipaddress.ip_address(value)
+            return True
+        except:
+            return False
+
     def __str__(self) -> str:
         """Return the IP address as a string."""
         return str(self.address)

--- a/mreg_cli/api/models.py
+++ b/mreg_cli/api/models.py
@@ -2756,7 +2756,7 @@ class Host(FrozenModelWithTimestamps, WithTTL, WithHistory, APIMixin):
                 return ipv4s[0]
 
         raise EntityOwnershipMismatch(
-            f"Host {self} has multiple IPs and cannot determine which one to use."
+            f"Host {self} has multiple IPs, cannot determine which one to use."
         )
 
     def has_ptr_override(self, arg_ip: IP_AddressT) -> bool:

--- a/mreg_cli/commands/dhcp.py
+++ b/mreg_cli/commands/dhcp.py
@@ -34,6 +34,8 @@ def ipaddress_from_ip_arg(arg: str) -> IPAddress | None:
     :raises InputFailure: If the IP address is valid but does not exist.
     :raises EntityOwnershipMismatch: If the IP address is in use by multiple hosts.
     """
+    if not IPAddressField.is_valid(arg):
+        return None
     try:
         addr = IPAddressField.from_string(arg)
     except InputFailure:

--- a/mreg_cli/commands/host_submodules/a_aaaa.py
+++ b/mreg_cli/commands/host_submodules/a_aaaa.py
@@ -193,8 +193,9 @@ def _add_ip(
     if not args.force:
         _bail_if_ip_in_use_and_not_force(ipaddr)
 
-    host.add_ip(ipaddr, mac)
-    return host.refetch()
+    host = host.add_ip(ipaddr, mac)  # returns the refetched host
+    OutputManager().add_ok(f"Added ipaddress {ipaddr} to {host}")
+    return host
 
 
 @command_registry.register_command(


### PR DESCRIPTION
- [Add a regex for macaddress to diff.py](https://github.com/unioslo/mreg-cli/commit/ed1212b380be684d1ee582c42f741db36ba35d01).
Macaddresses were caught by the IPv6 regex, which made certain commands in the testsuite look like the wrong type of parameter was supplied.
- [Add OK message to a_add when success](https://github.com/unioslo/mreg-cli/commit/dda10742597b33dfcdaa20b3ed599e478c350eff). Also, avoid refetching the host twice.
- [Remove unnecessary warning from dhcp assoc](https://github.com/unioslo/mreg-cli/commit/e0cd8edd1c8f83a8275c5e1f7af35030a99259ce)
`dhcp assoc <hostname> <ip>` would warn that the hostname isn't a valid ip address. This commit changes the code so the exception isn't raised, but otherwise it works the same. _I am interested in your opinion on whether this is a good solution._