### PR TITLE
Fix `host ttl_remove`

### DIFF
--- a/mreg_cli/api/models.py
+++ b/mreg_cli/api/models.py
@@ -248,7 +248,7 @@ class WithTTL(BaseModel):
 
     def valid_ttl_patch_value_with_default(
         self, ttl: int | Literal["default"] | None
-    ) -> int | Literal[""]:
+    ) -> int | None:
         """Return a valid TTL value for patching with a possible default value.
 
         Note: The ttl fields are not nullable, so we need to convert None to an empty string.
@@ -264,7 +264,7 @@ class WithTTL(BaseModel):
         :returns: A valid TTL value that can be fed to the API.
         """
         if ttl == "default" or ttl is None:
-            return ""
+            return None
 
         try:
             ttl = int(ttl)
@@ -724,7 +724,7 @@ class Zone(FrozenModelWithTimestamps, WithTTL, APIMixin):
             "refresh": refresh,
             "retry": retry,
             "expire": expire,
-            "soa_ttl": soa_ttl,
+            "soa_ttl": self.valid_numeric_ttl(soa_ttl) if soa_ttl is not None else None,
         }
         params = {k: v for k, v in params.items() if v is not None}
         if not params:

--- a/mreg_cli/commands/host_submodules/rr.py
+++ b/mreg_cli/commands/host_submodules/rr.py
@@ -863,8 +863,9 @@ def ttl_set(args: argparse.Namespace) -> None:
     valid_ttl = target.valid_ttl_patch_value_with_default(args.ttl)
 
     result = target.patch({"ttl": valid_ttl})
+    new_ttl = result.ttl or args.ttl  # prefer the actual value if it exists
     if result:
-        OutputManager().add_ok(f"Set TTL for {target} to {args.ttl}.")
+        OutputManager().add_ok(f"Set TTL for {target} to {new_ttl}.")
     else:
         raise PatchError(f"Failed to set TTL for {target}")
 

--- a/mreg_cli/utilities/api.py
+++ b/mreg_cli/utilities/api.py
@@ -250,7 +250,7 @@ def _request_wrapper(
         logger.debug("Data: %s", data)
 
     # Strip None values from data
-    if data:
+    if data and operation_type != "patch":
         data = _strip_none(data)
 
     if operation_type == "get":


### PR DESCRIPTION
This PR fixes `host ttl_remove` by disabling stripping of `None` values from PATCH data. 

Furthermore, steps have been taken to ensure we never send empty strings as TTL values, and instead preferring to send `None` to these nullable fields.