### PR TITLE
Improve diff numbering + messages

### DIFF
--- a/ci/diff.py
+++ b/ci/diff.py
@@ -16,7 +16,10 @@ from rich.panel import Panel
 from rich.prompt import Prompt
 
 console = Console(soft_wrap=True, highlight=False)
-err_console = Console(stderr=True)
+"""Stdout console used to print diffs."""
+
+err_console = Console(stderr=True, highlight=False)
+"""Stderr console used to print messages and errors."""
 
 timestamp_pattern = re.compile(
     r"\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:[+-]\d{2}:\d{2})?|\d{4}-\d{2}-\d{2}"
@@ -146,11 +149,11 @@ class CommandDiffer:
         diff = differ.compare(expected_commands, result_commands)
         differences = [line for line in diff if line.startswith("-") or line.startswith("+")]
         if differences:
-            console.print(
+            err_console.print(
                 "Diff between what commands were run in the recorded result and the current testsuite:"
             )
             for line in differences:
-                console.print(fmt_line(line))
+                err_console.print(fmt_line(line))
             raise CommandCountError(len(expected_commands), len(result_commands))
 
     def diff_command_results(self) -> None:
@@ -247,7 +250,7 @@ def main() -> None:
     resolved = differ.diff_resolved
     unresolved = differ.diff_unresolved
     if resolved:
-        console.print(f"[green]Resolved {resolved} diffs between {file1} and {file2}[/]")
+        err_console.print(f"[green]Resolved {resolved} diffs between {file1} and {file2}[/]")
     if unresolved:  # non-zero exit code if unresolved diffs
         err_console.print(f"[red]{unresolved} unresolved diff(s) between {file1} and {file2}.[/]")
         sys.exit(1)

--- a/ci/diff.py
+++ b/ci/diff.py
@@ -41,15 +41,8 @@ class CommandCountError(DiffError):
         self.expected = expected
         self.result = result
         super().__init__(
-            f"Expected {expected} commands, got {result} commands. Resolve the diff manually."
+            f"Expected {expected} commands, got {result} commands. Diff must be resolved manually."
         )
-
-
-class UnresolvedDiffError(DiffError):
-    """Exception raised when the commands in the two files are different."""
-
-    def __init__(self, file1: str, file2: str, n_diffs: int) -> None:  # noqa: D107
-        super().__init__(f"{n_diffs} unresolved diff(s) between {file1} and {file2}.")
 
 
 def group_objects(json_file_path: str) -> list[dict[str, Any]]:
@@ -242,7 +235,12 @@ def main() -> None:
     review: bool = args.review
 
     differ = CommandDiffer(file1, file2, review=review)
-    differ.diff()
+
+    try:
+        differ.diff()
+    except DiffError as e:
+        err_console.print(f"[red]{e}[/]")
+        sys.exit(2)
 
     # We can print a combination of messages here.
     # I.e. resolved msg followed by unresolved msg with non-zero exit code

--- a/ci/diff.py
+++ b/ci/diff.py
@@ -252,7 +252,7 @@ def main() -> None:
     if resolved:
         err_console.print(f"[green]Resolved {resolved} diffs between {file1} and {file2}[/]")
     if unresolved:  # non-zero exit code if unresolved diffs
-        err_console.print(f"[red]{unresolved} unresolved diff(s) between {file1} and {file2}.[/]")
+        err_console.print(f"[red]{unresolved} unresolved diffs between {file1} and {file2}.[/]")
         sys.exit(1)
     if not resolved and not unresolved:  # no diffs found
         err_console.print(f"No differences found between {file1} and {file2}")

--- a/ci/diff.py
+++ b/ci/diff.py
@@ -239,7 +239,7 @@ def main() -> None:
     try:
         differ.diff()
     except DiffError as e:
-        err_console.print(f"[red]{e}[/]")
+        err_console.print(f"[red]ERROR: {e}[/]")
         sys.exit(2)
 
     # We can print a combination of messages here.
@@ -249,9 +249,7 @@ def main() -> None:
     if resolved:
         console.print(f"[green]Resolved {resolved} diffs between {file1} and {file2}[/]")
     if unresolved:  # non-zero exit code if unresolved diffs
-        err_console.print(
-            f"[red]ERROR: {unresolved} unresolved diff(s) between {file1} and {file2}.[/]"
-        )
+        err_console.print(f"[red]{unresolved} unresolved diff(s) between {file1} and {file2}.[/]")
         sys.exit(1)
     if not resolved and not unresolved:  # no diffs found
         err_console.print(f"No differences found between {file1} and {file2}")


### PR DESCRIPTION
## Numbering

This PR adds a number for each diff for better readability when reviewing them. 

**Number shown before diff**
<img width="670" alt="image" src="https://github.com/user-attachments/assets/41c0ee92-59dd-4671-b213-184873cffd05">

**Number shown when reviewing the change**
<img width="667" alt="image" src="https://github.com/user-attachments/assets/87a876dd-05f4-4aa0-add1-1f2bf5cd9f55">

**Added breathing room between each diff**
<img width="674" alt="image" src="https://github.com/user-attachments/assets/d98c9149-9f45-43fb-b889-6ee5f3a12a6e">

## Improved messages


We also keep track of the number of resolved and unresolved diffs and print messages and exit accordingly.

**All diffs resolved**
<img width="660" alt="image" src="https://github.com/user-attachments/assets/e14f26f9-bede-4aeb-b831-6c2b3426d2f2">

**Mix of resolved and unresolved diffs**
<img width="660" alt="image" src="https://github.com/user-attachments/assets/ff43f601-f8ba-464d-a0e6-f95c9f497c1f">

**No diffs found**
<img width="666" alt="image" src="https://github.com/user-attachments/assets/b639f984-1079-4606-b978-f05cd70d0124">

