### PR TITLE
Improve safety of TTL methods for non-nullable fields

### DIFF
--- a/mreg_cli/api/endpoints.py
+++ b/mreg_cli/api/endpoints.py
@@ -99,6 +99,7 @@ class Endpoint(str, Enum):
             Endpoint.ReverseZonesDelegations,
             Endpoint.HostPolicyRoles,
             Endpoint.HostPolicyAtoms,
+            Endpoint.Nameservers,
         ):
             return "name"
         if self in (Endpoint.Networks,):

--- a/mreg_cli/api/endpoints.py
+++ b/mreg_cli/api/endpoints.py
@@ -24,6 +24,7 @@ class Endpoint(str, Enum):
     Locs = "/api/v1/locs/"
     Mxs = "/api/v1/mxs/"
     NAPTRs = "/api/v1/naptrs/"
+    Nameservers = "/api/v1/nameservers/"
 
     HostGroups = "/api/v1/hostgroups/"
     HostGroupsAddHostGroups = "/api/v1/hostgroups/{}/groups/"

--- a/mreg_cli/commands/host_submodules/rr.py
+++ b/mreg_cli/commands/host_submodules/rr.py
@@ -853,17 +853,18 @@ def ttl_set(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name, ttl)
     """
-    target = Host.get_by_any_means(args.name)
+    name: str = args.name
+    ttl: str = args.ttl
+
+    target = Host.get_by_any_means(name)
     if not target:
-        target = Srv.get_by_field("name", args.name)
+        target = Srv.get_by_field("name", name)
 
     if not target:
-        raise EntityNotFound(f"No host or SRV record found for {args.name}")
+        raise EntityNotFound(f"No host or SRV record found for {name}")
 
-    valid_ttl = target.valid_ttl_patch_value_with_default(args.ttl)
-
-    result = target.patch({"ttl": valid_ttl})
-    new_ttl = result.ttl or args.ttl  # prefer the actual value if it exists
+    result = target.set_ttl(ttl)
+    new_ttl = result.ttl or ttl  # prefer the actual value if it exists
     if result:
         OutputManager().add_ok(f"Set TTL for {target} to {new_ttl}.")
     else:


### PR DESCRIPTION
This PR makes the methods inherited from `WithTTL` safe to use for models with non-nullable TTL fields (`Zone.default_ttl`& `Zone.soa_ttl`).

Furthermore, a new method `WithTTL.set_ttl()` has been added, which supports both nullable and non-nullable fields.