### PR TITLE
Replace IDs & IPs in test result URLs

### DIFF
--- a/ci/diff.py
+++ b/ci/diff.py
@@ -61,9 +61,7 @@ class CommandCountError(DiffError):
 
 def unquote_url(match: re.Match[str]) -> str:
     """Unquote URL encoded text in a /api/v1/ URL."""
-    url_encoded_text = match.group(0)[1:-1]
-    url_decoded_text = urllib.parse.unquote(url_encoded_text)
-    return f'"{url_decoded_text}"'  # ensure double quotes
+    return urllib.parse.unquote(match.group(0))
 
 
 def replace_url_id(match: re.Match[str]) -> str:

--- a/ci/diff.py
+++ b/ci/diff.py
@@ -66,8 +66,8 @@ def unquote_url(match: re.Match[str]) -> str:
 
 def replace_url_id(match: re.Match[str]) -> str:
     """Replace the final number (ID) in a URL with a placeholder."""
-    # match.group(1) contains the part before the separator
-    # match.group(2) contains the separator
+    # match.group(1) contains the part before the separator (`"url": "/api/...`)
+    # match.group(2) contains the separator (/ or =)
     # match.group(3) contains the number we want to replace
     # match.group(4) contains the closing double quote
     return f"{match.group(1)}{match.group(2)}<ID>{match.group(4)}"

--- a/ci/diff.py
+++ b/ci/diff.py
@@ -36,7 +36,7 @@ mac_pattern = re.compile(r"\b([0-9a-f]{2}:){5}[0-9a-f]{2}\b")
 # Pattern matching strings starting with `"url": "/api/v1/` and ending with `"`
 api_v1_pattern = re.compile(r'"url":\s*"/api/v1/.*?"')
 # Pattern matching URLs where the final component is a number
-# Defines 3 capture groups to be able to replace the number with a placeholder.
+# Defines 4 capture groups to be able to replace the number with a placeholder.
 # Only matches the number if it is preceded by a `/` or `=`
 # Does not match patterns containing `<IPv4>` and `<IPv6>` after `/api/v1/`.
 api_v1_pattern_with_number = re.compile(


### PR DESCRIPTION
This PR adds regex patterns for replacing IDs and IP adresses in URLs in the test suite results. This adds a band-aid fix for the URLs and IDs currently not being deterministic.



## IDs

`new_testsuite_results.json`:
<img width="516" alt="image" src="https://github.com/user-attachments/assets/ec907090-4acc-4516-a407-754788ddb1e5">


**Result:**
<img width="982" alt="image" src="https://github.com/user-attachments/assets/ab6cc354-99e6-45d0-b9ff-7ce09793a43d">

Note how only the new query is marked as a difference. The other IDs are replaced by placeholders and thus ignored.

## URL encoded IPs

`new_testsuite_results.json`:
<img width="649" alt="image" src="https://github.com/user-attachments/assets/f63c7120-3437-4d55-a9c6-8e1967afde91">

**Result:**
<img width="987" alt="image" src="https://github.com/user-attachments/assets/d3d9af20-fffd-4bdf-9be2-fb91df0abd7b">

URL encoded IP addresses are also matched and replaced when comparing.
