### PR TITLE
Write back original lines in diff review

### DIFF
--- a/ci/diff.py
+++ b/ci/diff.py
@@ -163,7 +163,7 @@ class TestCommand(NamedTuple):
     original: dict[str, Any]
 
 
-class TestSuiteLog:
+class TestSuiteResult:
     """The results of a test suite run."""
 
     def __init__(self, file: str) -> None:
@@ -172,9 +172,9 @@ class TestSuiteLog:
         self.commands_original = load_commands(file, preprocess=False)
 
     def iterate(
-        self, other: TestSuiteLog
+        self, other: TestSuiteResult
     ) -> Generator[tuple[TestCommand, TestCommand], None, None]:
-        """Iterate over commands from two TestSuiteLog objects."""
+        """Iterate over commands from two TestSuiteResult objects."""
         for command, other_command in zip(self, other):
             yield command, other_command
 
@@ -183,7 +183,7 @@ class TestSuiteLog:
         for i, command in enumerate(self.commands):
             yield TestCommand(command, self.commands_original[i])
 
-    def ensure_comparable(self, other: TestSuiteLog) -> None:
+    def ensure_comparable(self, other: TestSuiteResult) -> None:
         """Check if self and other have the same number of commands."""
         if len(self.commands) != len(other.commands):
             raise CommandCountError(len(self.commands), len(other.commands))
@@ -205,8 +205,8 @@ class CommandDiffer:
         self.review = review
 
         # Load files
-        self.expected = TestSuiteLog(file1)
-        self.result = TestSuiteLog(file2)
+        self.expected = TestSuiteResult(file1)
+        self.result = TestSuiteResult(file2)
 
         self.diff_resolved = 0
         self.diff_unresolved = 0


### PR DESCRIPTION
This PR makes diff.py write back the original lines (before placeholders have been inserted) to `testsuite-result.json` when they are accepted in review mode.

The code for loading and processing of the test suite results has been refactored into a class-based approach to reduce the amount of noise when iterating over them in `CommandDiffer.diff_command_results()`.

----


After merging #289, we should do a manual pass where we run the test suite and replace `testsuite-result.json` with the resulting `new_testsuite_log.json` to restore all values replaced by placeholders. This has no effect on the actual tests, but makes it easier for us to search through the log to find specific IPs, MACs, etc.