### PR TITLE
Use uv in CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,10 @@ on:
 concurrency:
   group: build-mreg-cli-${{ github.head_ref }}
 
+env:
+  # https://docs.astral.sh/uv/guides/integration/github/#using-uv-pip
+  UV_SYSTEM_PYTHON: 1 
+
 jobs:
   build_pypi:
     name: Build wheels and source distribution
@@ -25,13 +29,14 @@ jobs:
         with:
           python-version: '3.12'
       
-      - uses: hynek/setup-cached-uv@v2
+      - name: Install uv
+        uses: astral-sh/setup-uv@v2
       
       - name: Install build dependencies
-        run: uv pip install --system --upgrade build
+        run: uv pip install --upgrade build
 
       - name: Build source distribution
-        run: python -m build
+        run: uv run python -m build
 
       - uses: actions/upload-artifact@v4
         with:
@@ -54,10 +59,13 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: hynek/setup-cached-uv@v2
+      
+      - name: Install uv
+        uses: astral-sh/setup-uv@v2
+      
       - name: Run PyInstaller with Tox
         run: |
-          uv pip install --system tox-uv tox-gh-actions
+          uv pip install tox-uv tox-gh-actions
           tox
       
       - name: Rename binary

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,10 +8,6 @@ on:
 concurrency:
   group: build-mreg-cli-${{ github.head_ref }}
 
-env:
-  # https://docs.astral.sh/uv/guides/integration/github/#using-uv-pip
-  UV_SYSTEM_PYTHON: 1 
-
 jobs:
   build_pypi:
     name: Build wheels and source distribution

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,9 +19,16 @@ jobs:
       - name: Exit if not on master branch
         if: github.ref_name != 'master'
         run: exit -1
-
+      
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      
+      - uses: hynek/setup-cached-uv@v2
+      
       - name: Install build dependencies
-        run: python -m pip install --upgrade build
+        run: uv pip install --system --upgrade build
 
       - name: Build source distribution
         run: python -m build
@@ -47,11 +54,10 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      
+      - uses: hynek/setup-cached-uv@v2
       - name: Run PyInstaller with Tox
         run: |
-          python -m ensurepip --upgrade
-          python -m pip install tox tox-uv tox-gh-actions
+          uv pip install --system tox-uv tox-gh-actions
           tox
       
       - name: Rename binary

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,16 +24,16 @@ jobs:
         if: github.ref_name != 'master'
         run: exit -1
       
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-      
       - name: Install uv
         uses: astral-sh/setup-uv@v2
-      
+
+      - name: Set up Python 3.12
+        run: uv python install 3.12
+
       - name: Install build dependencies
-        run: uv pip install --upgrade build
+        run: |
+          uv venv
+          uv pip install --upgrade build
 
       - name: Build source distribution
         run: uv run python -m build
@@ -55,16 +55,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-      
       - name: Install uv
         uses: astral-sh/setup-uv@v2
       
+      - name: Set up Python ${{ matrix.python-version }}
+        run: uv python install ${{ matrix.python-version }}
+      
       - name: Run PyInstaller with Tox
         run: |
+          uv venv
           uv pip install tox-uv tox-gh-actions
           tox
       

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,5 +54,5 @@ jobs:
       - name: Install dependencies
         run: uv pip install tox-uv tox-gh-actions 
       - name: Test with tox
-        run: tox r
+        run: uv run tox r
         

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,9 @@
 on: [push, pull_request]
 
 
-env:
-  # https://docs.astral.sh/uv/guides/integration/github/#using-uv-pip
-  UV_SYSTEM_PYTHON: 1
+# env:
+#   # https://docs.astral.sh/uv/guides/integration/github/#using-uv-pip
+#   UV_SYSTEM_PYTHON: 1
 
 name: CI
 jobs:
@@ -24,10 +24,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Install uv
         uses: astral-sh/setup-uv@v2
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.python-version }}
+        run: uv python install ${{ matrix.python-version }}
       - name: Install mreg-cli
         run: uv pip install -e .[dev]
       - name: Test and compare api calls

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,12 +45,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
       - name: Install uv
         uses: astral-sh/setup-uv@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        run: uv python install ${{ matrix.python-version }}
       - name: Install dependencies
         run: uv pip install tox-uv tox-gh-actions 
       - name: Test with tox

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,10 @@
 on: [push, pull_request]
 
+
+env:
+  # https://docs.astral.sh/uv/guides/integration/github/#using-uv-pip
+  UV_SYSTEM_PYTHON: 1
+
 name: CI
 jobs:
   test:
@@ -17,14 +22,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - uses: hynek/setup-cached-uv@v2
+      - name: Install uv
+        uses: astral-sh/setup-uv@v2
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install mreg-cli
-        run: |
-          uv pip install --system -e .[dev]
+        run: uv pip install -e .[dev]
       - name: Test and compare api calls
         run: ci/run_testsuite_and_record.sh
 
@@ -44,11 +49,10 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: hynek/setup-cached-uv@v2
+      - name: Install uv
+        uses: astral-sh/setup-uv@v2
       - name: Install dependencies
-        run: |
-          python -m ensurepip --upgrade
-          uv pip install --system tox-uv tox-gh-actions 
+        run: uv pip install tox-uv tox-gh-actions 
       - name: Test with tox
         run: tox r
         

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,23 +17,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-#      - name: Cache pip
-#        uses: actions/cache@v3
-#        with:
-#          path: ~/.cache/pip
-#          key: v1-pip-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('requirements-*.txt') }}
-#          restore-keys: |
-#            v1-pip-${{ runner.os }}-${{ matrix.python-version }}
-#            v1-pip-${{ runner.os }}
-#            v1-pip-
+      - uses: hynek/setup-cached-uv@v2
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install mreg-cli
         run: |
-          python -m ensurepip --upgrade
-          pip install -e .[dev]
+          uv pip install --system -e .[dev]
       - name: Test and compare api calls
         run: ci/run_testsuite_and_record.sh
 
@@ -53,10 +44,11 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+      - uses: hynek/setup-cached-uv@v2
       - name: Install dependencies
         run: |
           python -m ensurepip --upgrade
-          python -m pip install tox tox-uv tox-gh-actions 
+          uv pip install --system tox-uv tox-gh-actions 
       - name: Test with tox
         run: tox r
         

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
           uv venv
           uv pip install -e .[dev]
       - name: Test and compare api calls
-        run: ci/run_testsuite_and_record.sh
+        run: uv run ci/run_testsuite_and_record.sh
 
   tox:
     name: tox

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,6 @@
 on: [push, pull_request]
 
 
-# env:
-#   # https://docs.astral.sh/uv/guides/integration/github/#using-uv-pip
-#   UV_SYSTEM_PYTHON: 1
-
 name: CI
 jobs:
   test:
@@ -27,7 +23,9 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
       - name: Install mreg-cli
-        run: uv pip install -e .[dev]
+        run: |
+          uv venv
+          uv pip install -e .[dev]
       - name: Test and compare api calls
         run: ci/run_testsuite_and_record.sh
 
@@ -48,7 +46,9 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
       - name: Install dependencies
-        run: uv pip install tox-uv tox-gh-actions 
+        run: |
+          uv venv
+          uv pip install tox-uv tox-gh-actions 
       - name: Test with tox
         run: uv run tox r
         

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
 dynamic = ["version"]
 
 [project.optional-dependencies]
-dev = ["ruff", "tox", "rich"]
+dev = ["ruff", "tox-uv", "rich", "setuptools", "setuptools-scm", "build"]
 
 [project.urls]
 Repository = 'https://github.com/unioslo/mreg-cli/'


### PR DESCRIPTION
This PR replaces all `pip install` invocations in CI with `uv pip install` using the much faster [uv](https://github.com/astral-sh/uv) Python package manager.