### PR TITLE
Build Linux PyInstaller binary in CentOS 8 container

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,12 +42,17 @@ jobs:
 
   build_pyinstaller:
     name: Build pyinstaller binary
-    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         python-version:
           - '3.12'
+        include:
+          - os: ubuntu-latest
+            container: centos:8
+    runs-on: ${{ matrix.os }}
+    container: ${{ matrix.container }}
+
     steps:
       - uses: actions/checkout@v4
       

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -117,22 +117,11 @@ jobs:
           merge-multiple: true
 
       - name: Create GitHub release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          body: |
-            Release notes for ${{ github.ref }}
-          draft: false
-          prerelease: false
-
-      - name: Upload release asset
-        id: upload-release-asset
         uses: softprops/action-gh-release@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           files: dist/*
+          body: |
+            Release ${{ github.ref_name }}
+          draft: false
+          prerelease: false
+    


### PR DESCRIPTION
Also adds GitHub release step from [zabbix-cli](https://github.com/unioslo/zabbix-cli/blob/3cd13d3624bc15984c999f5e8e057f0d5dff6522/.github/workflows/build.yml#L115-L122), simplifying the release step in CI.