### PR TITLE
Change publish tag pattern

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: build mreg-cli
 on:
   push:
     tags:
-      - mreg-cli-v*
+      - '[0-9]+.[0-9]+.[0-9]+**'
 
 concurrency:
   group: build-mreg-cli-${{ github.head_ref }}


### PR DESCRIPTION
This PR changes the tag pattern for triggering releases from `mreg-cli-v*` to `x.y.z[.<pre-release>]`. This reduces noise in tags and release headers.