### PR TITLE
Add `getattr` default in `APIMixin.refetch`

### DIFF
--- a/mreg_cli/api/abstracts.py
+++ b/mreg_cli/api/abstracts.py
@@ -397,8 +397,7 @@ class APIMixin(ABC):
         :returns: The fetched object.
         """
         id_field = self.endpoint().external_id_field()
-        identifier = getattr(self, id_field)
-
+        identifier = getattr(self, id_field, None)
         if not identifier:
             raise InternalError(
                 f"Could not get identifier for {self.__class__.__name__} via {id_field}."


### PR DESCRIPTION
The `getattr()` call should have a default so we can raise our `InternalError` exception instead of an `AttributeError`.