### PR TITLE
Omit params when fetching paginated content

### DIFF
--- a/mreg_cli/utilities/api.py
+++ b/mreg_cli/utilities/api.py
@@ -531,7 +531,7 @@ def get_list_generic(
     # Iterate over all pages and collect the results
     ret: list[Json] = resp.results
     while resp.next:
-        response = get(resp.next, params=params, ok404=ok404)
+        response = get(resp.next, ok404=ok404)
         if response is None:
             break
         resp = validate_paginated_response(response)


### PR DESCRIPTION
Given the path `/api/v1/hostpolicy/roles/` and the params `{"name__regex": "."}`, we send:

```
/api/v1/hostpolicy/roles/?name__regex=.
``` 

And get back this Next URL in the response headers:

```
/api/v1/hostpolicy/roles/?name__regex=.&page=2
``` 

If we pass the original params to `get()` along with the Next URL, we end up requesting the path:

```
/api/v1/hostpolicy/roles/?name__regex=.&page=2&name__regex=.'
```

We should probably just trust that Django gives us a valid Next URL after the first request and omit the original params.