### PR TITLE
Reorder `get_list_generic` overloads

### DIFF
--- a/mreg_cli/utilities/api.py
+++ b/mreg_cli/utilities/api.py
@@ -474,21 +474,21 @@ def validate_paginated_response(response: Response) -> PaginatedResponse:
 @overload
 def get_list_generic(
     path: str,
-    params: QueryParams | None = None,
-    ok404: bool = False,
-    limit: int | None = 500,
-    expect_one_result: Literal[True] = True,
-) -> Json: ...
+    params: QueryParams | None = ...,
+    ok404: bool = ...,
+    limit: int | None = ...,
+    expect_one_result: Literal[False] = False,
+) -> list[Json]: ...
 
 
 @overload
 def get_list_generic(
     path: str,
-    params: QueryParams | None = None,
-    ok404: bool = False,
-    limit: int | None = 500,
-    expect_one_result: Literal[False] = False,
-) -> list[Json]: ...
+    params: QueryParams | None = ...,
+    ok404: bool = ...,
+    limit: int | None = ...,
+    expect_one_result: Literal[True] = True,
+) -> Json: ...
 
 
 def get_list_generic(


### PR DESCRIPTION
`list[Json]` is a subset (or contravariant or whatever type theory calls it) of `Json`, so Pyright complained about the order of these overloads.

I also replaced all the defaults for the overloads with `...` to preserve the defaults of the actual function definition, instead of duplicating them in our overloads.