### PR TITLE
Fix unquoted regex error handling

### DIFF
--- a/mreg_cli/outputmanager.py
+++ b/mreg_cli/outputmanager.py
@@ -383,6 +383,7 @@ class OutputManager:
             split_index = self._find_split_index(command)
 
             if split_index != -1:
+                command_issued = command
                 filter_str = command[split_index + 1 :].strip()
                 command = command[:split_index].strip()
 
@@ -393,7 +394,7 @@ class OutputManager:
                 try:
                     filter_re = re.compile(filter_str)
                 except re.error as exc:
-                    if "|" in filter_str:
+                    if "|" in command_issued:
                         raise InputFailure(
                             "Command parts that contain a pipe ('|') must be quoted.",
                         ) from exc


### PR DESCRIPTION
We could also solve this by checking `self._command_issued`, but that seems potentially less deterministic/safe/good practice(?) than just adding a temporary variable to hold the original command.