### PR TITLE
Fix cli.py type checking errors

### DIFF
--- a/mreg_cli/cli.py
+++ b/mreg_cli/cli.py
@@ -45,7 +45,7 @@ if TYPE_CHECKING:
     SubparserType = argparse._SubParsersAction[argparse.ArgumentParser]  # type: ignore # private attribute
 
     # Subclasses of BaseCommand change the constructor signature from
-    # 3 arguments to a single argument `cli`. That means we cannot
+    # 6 arguments to a single argument `cli`. That means we cannot
     # declare the list of commands as a list of `type[BaseCommand]`
     # and then instantiate them. Instead, we need to declare this interface
     # which lets the type checker understand what kind of classes we are

--- a/mreg_cli/cli.py
+++ b/mreg_cli/cli.py
@@ -50,9 +50,9 @@ if TYPE_CHECKING:
     # and then instantiate them. Instead, we need to declare this interface
     # which lets the type checker understand what kind of classes we are
     # trying to instantiate.
-    class BaseCommandSubclass(Protocol):  # noqa: D101
-        def __init__(self, cli: "Command") -> None: ...  # noqa: D107
-        def register_all_commands(self) -> None: ...  # noqa: D102
+    class BaseCommandSubclass(Protocol):  # noqa: D101 (undocumented-public-class)
+        def __init__(self, cli: "Command") -> None: ...  # noqa: D107 (undocumented-public-init)
+        def register_all_commands(self) -> None: ...  # noqa: D102 (undocumented-public-method)
 
 
 def _create_command_group(parent: argparse.ArgumentParser) -> SubparserType:


### PR DESCRIPTION
This fixes the type checking errors in `cli.py`.

The type checking of `BaseCommand` subclass instantiation was actually non-trivial, and while the solution presented in this PR looks too hacky and complex, I can assure you that rewriting the constructor of all subclasses is a great deal more complex:

```
❯ git stash show
 mreg_cli/cli.py                 |  5 +++--
 mreg_cli/commands/base.py       | 39 ++++++++++++++++++++++++---------------
 mreg_cli/commands/dhcp.py       | 12 +++++-------
 mreg_cli/commands/group.py      |  8 ++++----
 mreg_cli/commands/help.py       | 19 ++++++++-----------
 mreg_cli/commands/host.py       |  8 ++++----
 mreg_cli/commands/label.py      | 27 ++++++++++++++++++++-------
 mreg_cli/commands/logging.py    | 14 ++++----------
 mreg_cli/commands/network.py    |  8 ++++----
 mreg_cli/commands/permission.py | 10 ++++------
 mreg_cli/commands/policy.py     | 10 ++++------
 mreg_cli/commands/recording.py  | 14 ++++----------
 mreg_cli/commands/root.py       | 15 +++++----------
 mreg_cli/commands/zone.py       |  8 ++++----
 mreg_cli/types.py               |  5 +++++
 15 files changed, 102 insertions(+), 100 deletions(-)
 ```