### PR TITLE
Add defaults for url and domain config options

### DIFF
--- a/data/mreg-cli.conf
+++ b/data/mreg-cli.conf
@@ -1,7 +1,7 @@
 [mreg]
-url=http://127.0.0.1:8000
-user=test
-domain=example.org
-#logfile=cli.log
+# url=http://127.0.0.1:8000
+# user=test
+# domain=example.org
+# logfile=cli.log
 category_tags=cat1,cat2,cat3
 location_tags=loc1,loc2,loc3

--- a/mreg_cli/config.py
+++ b/mreg_cli/config.py
@@ -195,7 +195,7 @@ class MregCliConfig:
 
     def get_default_domain(self):
         """Get the default domain from the application."""
-        return self.get("domain")
+        return self.get("domain", "uio.no")
 
     def get_default_logfile(self):
         """Get the default logfile from the application."""
@@ -213,8 +213,8 @@ class MregCliConfig:
     # it cannot be none once options, env, and config file are parsed.
     def get_url(self) -> str:
         """Get the default url from the application."""
-        url = self.get("url", self.get("default_url"))
-        if url is None:
+        url = self.get("url", self.get("default_url", "https://mreg.uio.no"))
+        if not url:
             raise ValueError("No URL found in config, no defaults available!")
         return url
 

--- a/mreg_cli/main.py
+++ b/mreg_cli/main.py
@@ -28,15 +28,6 @@ def main():
 
     parser = argparse.ArgumentParser(description="The MREG cli")
 
-    # Accept empty url as the default option for the --url parameter.
-    # If the user never sets the URL we will throw a value error on
-    # the initial connection attempt.
-    default_url = ""
-    try:
-        default_url = config.get_url()
-    except ValueError:
-        pass
-
     parser.add_argument(
         "--version",
         help="Show version and exit.",
@@ -46,7 +37,7 @@ def main():
     connect_args = parser.add_argument_group("connection settings")
     connect_args.add_argument(
         "--url",
-        default=default_url,
+        default=config.get_url(),
         help="use mreg server at %(metavar)s (default: %(default)s)",
         metavar="URL",
     )


### PR DESCRIPTION
Sets default values for `--url` and `--domain`. Also comments out `url`, `domain` and `user` from the file `data/mreg-cli.conf` so that local development environments don't load the values from that file when running without `--url`, `--domain`, and `--user`.