### PR TITLE
Build Linux image in redhat/ubi8 container

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,19 +50,23 @@ jobs:
           - '3.12'
         include:
           - os: ubuntu-latest
-            container: centos:8
+            container: redhat/ubi8:latest
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: install git in RHEL 8 container
+        if: contains(matrix.container, 'redhat/ubi8')
+        run: dnf install -y git
       
       - name: Install uv
         uses: astral-sh/setup-uv@v2
       
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
-      
+
       - name: Run PyInstaller with Tox
         run: |
           uv venv


### PR DESCRIPTION
Also installs git in the container. Had to switch container image because the CentOS repo list doesn't even exist any longer. Let's hope `redhat/ubi8` builds container images that are compatible with RHEL8. You would hope and think so at least.