### PR TITLE
Fix building inside redhat/ubi8 container

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: build mreg-cli
 on:
   push:
     tags:
-      - '[0-9]+.[0-9]+.[0-9]+**'
+      - '[0-9]+.[0-9]+.[0-9]+*'
 
 concurrency:
   group: build-mreg-cli-${{ github.head_ref }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,6 +56,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: install git in RHEL 8 container
         if: contains(matrix.container, 'redhat/ubi8')

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,10 +51,10 @@ jobs:
         include:
           - os: ubuntu-latest
             container: redhat/ubi8:latest
-            env:
-              SETUPTOOLS_SCM_PRETEND_VERSION: ${{ github.ref_name }}
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}
+    env:
+      SETUPTOOLS_SCM_PRETEND_VERSION: ${{ github.ref_name }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,7 +51,7 @@ jobs:
         include:
           - os: ubuntu-latest
             container: redhat/ubi8:latest
-            # options: -v "${{ github.workspace }}/.git:/__w/mreg-cli/mreg-cli"
+            options: -v "${{ github.workspace }}/.git:/__w/mreg-cli/mreg-cli/.git"
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,15 +51,17 @@ jobs:
         include:
           - os: ubuntu-latest
             container: redhat/ubi8:latest
+            # options: -v "${{ github.workspace }}/.git:/__w/mreg-cli/mreg-cli"
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}
-    env:
-      SETUPTOOLS_SCM_PRETEND_VERSION: ${{ github.ref_name }}
 
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      
+      - name: Run ls in cwd
+        run: ls -la
 
       - name: install git in RHEL 8 container
         if: contains(matrix.container, 'redhat/ubi8')

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,26 +54,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     container: 
       image: ${{ matrix.container }}
-      # options: -v "${{ github.workspace }}/.git:/__w/mreg-cli/mreg-cli/.git"
 
     steps:
-      - name: install git in RHEL 8 container
+      - name: Install RHEL 8 dependencies
         if: contains(matrix.container, 'redhat/ubi8')
-        run: dnf install -y git
+        run: dnf install -y git binutils
 
       - name: Ensure git is available
         run: git --version
+      
       - uses: actions/checkout@v4
-      #   with:
-      #     fetch-depth: 0
-      #     fetch-tags: true
-      # - name: Print cwd
-      #   run: pwd
-
-      # - name: Run ls in cwd
-      #   run: ls -la
-
-
       
       - name: Install uv
         uses: astral-sh/setup-uv@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,7 +51,7 @@ jobs:
         include:
           - os: ubuntu-latest
             container: redhat/ubi8:latest
-            options: -v "${{ github.workspace }}:/__w/mreg-cli/mreg-cli"
+            options: --mount=source=.git,target=.git,type=bind
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,7 +51,8 @@ jobs:
         include:
           - os: ubuntu-latest
             container: redhat/ubi8:latest
-            options: --mount=source=.git,target=.git,type=bind
+            env:
+              SETUPTOOLS_SCM_PRETEND_VERSION: ${{ github.ref_name }}
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,9 +51,10 @@ jobs:
         include:
           - os: ubuntu-latest
             container: redhat/ubi8:latest
-            options: -v "${{ github.workspace }}/.git:/__w/mreg-cli/mreg-cli/.git"
     runs-on: ${{ matrix.os }}
-    container: ${{ matrix.container }}
+    container: 
+      image: ${{ matrix.container }}
+      options: -v "${{ github.workspace }}/.git:/__w/mreg-cli/mreg-cli/.git"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,6 +51,7 @@ jobs:
         include:
           - os: ubuntu-latest
             container: redhat/ubi8:latest
+            options: -v "${{ github.workspace }}:/__w/mreg-cli/mreg-cli"
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
       
       # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#determining-when-to-use-contexts
       - name: Exit if not on master branch
-        if: ${{ github.ref == 'refs/heads/master' }}
+        if: ${{ github.ref == 'refs/heads/fix-building' }}
         run: exit -1
       
       - name: Install uv
@@ -60,6 +60,9 @@ jobs:
       - name: install git in RHEL 8 container
         if: contains(matrix.container, 'redhat/ubi8')
         run: dnf install -y git
+
+      - name: Ensure git is available
+        run: git --version
       
       - name: Install uv
         uses: astral-sh/setup-uv@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,22 +57,23 @@ jobs:
       # options: -v "${{ github.workspace }}/.git:/__w/mreg-cli/mreg-cli/.git"
 
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          fetch-tags: true
-      - name: Print cwd
-        run: pwd
-
-      - name: Run ls in cwd
-        run: ls -la
-
       - name: install git in RHEL 8 container
         if: contains(matrix.container, 'redhat/ubi8')
         run: dnf install -y git
 
       - name: Ensure git is available
         run: git --version
+      - uses: actions/checkout@v4
+      #   with:
+      #     fetch-depth: 0
+      #     fetch-tags: true
+      # - name: Print cwd
+      #   run: pwd
+
+      # - name: Run ls in cwd
+      #   run: ls -la
+
+
       
       - name: Install uv
         uses: astral-sh/setup-uv@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,7 +59,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      
+      - name: Print cwd
+        run: pwd
+
       - name: Run ls in cwd
         run: ls -la
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,12 +54,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     container: 
       image: ${{ matrix.container }}
-      options: -v "${{ github.workspace }}/.git:/__w/mreg-cli/mreg-cli/.git"
+      # options: -v "${{ github.workspace }}/.git:/__w/mreg-cli/mreg-cli/.git"
 
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
       - name: Print cwd
         run: pwd
 


### PR DESCRIPTION
This PR makes the following changes to the build and publish workflow:

- Installs git _before_ trying to check out the repo
- Installs `binutils` to get the dependency `objdump`
  - `objdump` was installed by default in the CentOS 8 image, but not in `redhat/ubi8` 🙃
- Fixes the tag pattern to work with tags like `1.0.0a1`, `1.0.0rc1`, etc.

Keeping the commit history so the pain I went through to change 18 lines is recorded for the world.