### PR TITLE
Fix broken command completion rendering for top-level commands

### DIFF
--- a/mreg_cli/cli.py
+++ b/mreg_cli/cli.py
@@ -221,10 +221,8 @@ class Command(Completer):
                 if name.startswith(cur) and cur:
                     yield Completion(
                         name,
-                        display_meta=self.children[name].short_desc,
                         start_position=-len(cur),
                     )
-                    break
 
         # if the line starts with one of the sub commands, pass it along
         if words[0] in self.children:

--- a/mreg_cli/cli.py
+++ b/mreg_cli/cli.py
@@ -224,6 +224,7 @@ class Command(Completer):
                         display_meta=self.children[name].short_desc,
                         start_position=-len(cur),
                     )
+                    break
 
         # if the line starts with one of the sub commands, pass it along
         if words[0] in self.children:


### PR DESCRIPTION
The number of words in the short help text of top-level commands (`host`, `help`, etc.) would influence the rendering of their CLI completons, leading to `h` displaying `help` and `host` as completions on the same line, making it look like the suggested completion was `help host`.

Very bizarre. To fix this we just disable `display_meta` for top-level command completions. Yeah, not ideal.