### PR TITLE
Build for x86 macOS

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,15 +45,20 @@ jobs:
     name: Build pyinstaller binary
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version:
-          - '3.12'
         include:
           - os: ubuntu-latest
+            platform: linux-x86_64
             container: redhat/ubi8:latest
+          - os: windows-latest
+            platform: win-x86_64
+          - os: macos-latest
+            platform: macos-x86_64
+          - os: macos-14-xlarge
+            platform: macos-arm64
+        python-version:
+          - '3.12'
     runs-on: ${{ matrix.os }}
-    container: 
-      image: ${{ matrix.container }}
+    container: ${{ matrix.container }}
 
     steps:
       - name: Install RHEL 8 dependencies
@@ -77,14 +82,27 @@ jobs:
           uv pip install tox-uv tox-gh-actions
           uv run tox
       
-      - name: Rename binary
+      - name: Set platform binary names
+        shell: bash
         run: |
-          mv dist/mreg-cli${{ contains(matrix.os, 'windows') && '.exe' || '' }} dist/mreg-cli-${{ matrix.os }}-${{ matrix.python-version }}${{ contains(matrix.os, 'windows') && '.exe' || '' }}
+          VERSION="${{ github.ref_name }}"
+          BASE_NAME="mreg-cli-${VERSION}-${{ matrix.platform }}"
+          if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
+            echo "BINARY_NAME=${BASE_NAME}.exe" >> $GITHUB_ENV
+            echo "SOURCE_NAME=dist/mreg-cli.exe" >> $GITHUB_ENV
+          else
+            echo "BINARY_NAME=${BASE_NAME}" >> $GITHUB_ENV
+            echo "SOURCE_NAME=dist/mreg-cli" >> $GITHUB_ENV
+          fi
+
+      - name: Rename binary
+        shell: bash
+        run: mv "${{ env.SOURCE_NAME }}" "dist/${{ env.BINARY_NAME }}"
       
       - uses: actions/upload-artifact@v4
         with:
-          name: mreg-cli-${{ matrix.os }}-${{ matrix.python-version }}${{ contains(matrix.os, 'windows') && '.exe' || '' }}
-          path: dist/mreg-cli-${{ matrix.os }}-${{ matrix.python-version }}${{ contains(matrix.os, 'windows') && '.exe' || '' }}
+          name: ${{ env.BINARY_NAME }}
+          path: dist/${{ env.BINARY_NAME }}
           if-no-files-found: error
           
   publish_pypi:
@@ -125,12 +143,38 @@ jobs:
           path: dist
           merge-multiple: true
 
+      - name: Generate SHA256 checksums
+        id: sha
+        run: |
+          cd dist
+          echo "checksums<<EOF" >> $GITHUB_OUTPUT
+          sha256sum * >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
         with:
           files: dist/*
           body: |
             Release ${{ github.ref_name }}
+            
+            ## Binary Downloads
+            
+            Platform | Architecture | Download
+            ---------|--------------|----------
+            Linux | x86_64 | [mreg-cli-${{ github.ref_name }}-linux-x86_64](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/mreg-cli-${{ github.ref_name }}-linux-x86_64)
+            Windows | x86_64 | [mreg-cli-${{ github.ref_name }}-win-x86_64.exe](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/mreg-cli-${{ github.ref_name }}-win-x86_64.exe)
+            macOS | x86_64 | [mreg-cli-${{ github.ref_name }}-macos-x86_64](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/mreg-cli-${{ github.ref_name }}-macos-x86_64)
+            macOS | ARM64 | [mreg-cli-${{ github.ref_name }}-macos-arm64](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/mreg-cli-${{ github.ref_name }}-macos-arm64)
+            
+            ## PyPI Package
+            ```bash
+            pip install mreg-cli==${{ github.ref_name }}
+            ```
+            
+            ## SHA256 Checksums
+            ```
+            ${{ steps.sha.outputs.checksums }}
+            ```
           draft: false
           prerelease: false
-    

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
       
       # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#determining-when-to-use-contexts
       - name: Exit if not on master branch
-        if: ${{ github.ref == 'refs/heads/macos-intel' }}
+        if: ${{ github.ref == 'refs/heads/master' }}
         run: exit -1
       
       - name: Install uv

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,9 +51,9 @@ jobs:
             container: redhat/ubi8:latest
           - os: windows-latest
             platform: win-x86_64
-          - os: macos-latest
+          - os: macos-latest-large
             platform: macos-x86_64
-          - os: macos-14-xlarge
+          - os: macos-latest
             platform: macos-arm64
         python-version:
           - '3.12'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -173,6 +173,21 @@ jobs:
             macOS | ARM64 | [mreg-cli-${{ github.ref_name }}-macos-arm64](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/mreg-cli-${{ github.ref_name }}-macos-arm64)
             
             ## PyPI Package
+
+            ### uv
+
+            ```bash
+            uv tool install mreg-cli==${{ github.ref_name }}
+            ```
+
+            ### pipx
+
+            ```bash
+            pipx install mreg-cli==${{ github.ref_name }}
+            ```
+
+            ### pip
+
             ```bash
             pip install mreg-cli==${{ github.ref_name }}
             ```

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,6 +48,7 @@ jobs:
         os:
           - ubuntu-latest
           - windows-latest
+          - macos-13 # only non-large x86 macOS runner image available
           - macos-latest
         include:
           - os: ubuntu-latest
@@ -55,7 +56,7 @@ jobs:
             container: redhat/ubi8:latest
           - os: windows-latest
             platform: win-x86_64
-          - os: macos-latest-large
+          - os: macos-13
             platform: macos-x86_64
           - os: macos-latest
             platform: macos-arm64
@@ -168,6 +169,7 @@ jobs:
             ---------|--------------|----------
             Linux | x86_64 | [mreg-cli-${{ github.ref_name }}-linux-x86_64](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/mreg-cli-${{ github.ref_name }}-linux-x86_64)
             Windows | x86_64 | [mreg-cli-${{ github.ref_name }}-win-x86_64.exe](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/mreg-cli-${{ github.ref_name }}-win-x86_64.exe)
+            macOS | x86_64 | [mreg-cli-${{ github.ref_name }}-macos-x86_64](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/mreg-cli-${{ github.ref_name }}-macos-x86_64)
             macOS | ARM64 | [mreg-cli-${{ github.ref_name }}-macos-arm64](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/mreg-cli-${{ github.ref_name }}-macos-arm64)
             
             ## PyPI Package

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,6 +45,11 @@ jobs:
     name: Build pyinstaller binary
     strategy:
       matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest-large
+          - macos-latest
         include:
           - os: ubuntu-latest
             platform: linux-x86_64

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,7 +48,6 @@ jobs:
         os:
           - ubuntu-latest
           - windows-latest
-          - macos-latest-large
           - macos-latest
         include:
           - os: ubuntu-latest
@@ -169,7 +168,6 @@ jobs:
             ---------|--------------|----------
             Linux | x86_64 | [mreg-cli-${{ github.ref_name }}-linux-x86_64](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/mreg-cli-${{ github.ref_name }}-linux-x86_64)
             Windows | x86_64 | [mreg-cli-${{ github.ref_name }}-win-x86_64.exe](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/mreg-cli-${{ github.ref_name }}-win-x86_64.exe)
-            macOS | x86_64 | [mreg-cli-${{ github.ref_name }}-macos-x86_64](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/mreg-cli-${{ github.ref_name }}-macos-x86_64)
             macOS | ARM64 | [mreg-cli-${{ github.ref_name }}-macos-arm64](https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/mreg-cli-${{ github.ref_name }}-macos-arm64)
             
             ## PyPI Package

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
       
       # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#determining-when-to-use-contexts
       - name: Exit if not on master branch
-        if: ${{ github.ref == 'refs/heads/master' }}
+        if: ${{ github.ref == 'refs/heads/macos-intel' }}
         run: exit -1
       
       - name: Install uv


### PR DESCRIPTION
This PR adds building for Intel Macs (x86_64) using the `macos-13` runner image. We have to use a macOS 13 image because there is no non-`large` or `xlarge` images for macOS >13. 

Additionally, because adding yet another platform necessitates adding more file renaming logic to the workflow, the steps for renaming, uploading/downloading, and publishing the artifacts have been refactored. Furthermore, the artifacts are now listed in a table with download links in the release, as well as SHA256 checksums. 

The new release content can be seen here:

https://github.com/pederhan/mreg-cli/releases/tag/1.0.5