### PR TITLE
Reintroduce support for ending network or ip with `/` during `host add`.

### DIFF
--- a/mreg_cli/api/models.py
+++ b/mreg_cli/api/models.py
@@ -2810,10 +2810,10 @@ class Host(FrozenModelWithTimestamps, WithTTL, WithHistory, APIMixin):
         :returns: A new Host object fetched from the API after updating the IP address.
         """
         if isinstance(mac, str):
-            mac = MACAddressField(address=mac)
+            mac = MACAddressField.validate_mac(mac)
 
         if isinstance(ip, str):
-            ip = IPAddressField(address=ipaddress.ip_address(ip))
+            ip = IPAddressField.from_string(ip)
 
         params: QueryParams = {
             "macaddress": mac.address,

--- a/mreg_cli/commands/host_submodules/core.py
+++ b/mreg_cli/commands/host_submodules/core.py
@@ -14,6 +14,7 @@ Commands implemented:
 from __future__ import annotations
 
 import argparse
+import re
 
 from mreg_cli.api.models import (
     ForwardZone,
@@ -123,8 +124,16 @@ def add(args: argparse.Namespace) -> None:
     }
 
     if network_or_ip:
-        autodetect = network_or_ip.endswith("/")
-        network_or_ip = network_or_ip.rstrip("/")
+        autodetect = False
+
+        # Combine multiple slashes, in case anyone is trying to be funny
+        network_or_ip = re.sub(r"/+", "/", network_or_ip)
+
+        if network_or_ip.endswith("/32"):
+            network_or_ip = network_or_ip[:-3]
+        elif network_or_ip.endswith("/"):
+            autodetect = True
+            network_or_ip = network_or_ip.rstrip("/")
 
         network_or_ip = NetworkOrIP(ip_or_network=network_or_ip)
 

--- a/mreg_cli/commands/host_submodules/core.py
+++ b/mreg_cli/commands/host_submodules/core.py
@@ -146,7 +146,7 @@ def add(args: argparse.Namespace) -> None:
         else:
             raise EntityNotFound(f"Invalid ip or network: {network_or_ip}")
 
-        if network and network.frozen and not getattr(args, "force", False):
+        if network and network.frozen and not args.force:
             raise ForceMissing(f"Network {network.network} is frozen, must force")
 
     host = Host.create(data)

--- a/mreg_cli/commands/host_submodules/core.py
+++ b/mreg_cli/commands/host_submodules/core.py
@@ -126,17 +126,17 @@ def add(args: argparse.Namespace) -> None:
         autodetect = network_or_ip.endswith("/")
         network_or_ip = network_or_ip.rstrip("/")
 
-        network_or_ip_obj = NetworkOrIP(ip_or_network=network_or_ip)
+        network_or_ip = NetworkOrIP(ip_or_network=network_or_ip)
 
-        if network_or_ip_obj.is_ip() and not autodetect:
-            data["ipaddress"] = str(network_or_ip_obj)
-            network = Network.get_by_ip(network_or_ip_obj.as_ip())
+        if network_or_ip.is_ip() and not autodetect:
+            data["ipaddress"] = str(network_or_ip)
+            network = Network.get_by_ip(network_or_ip.as_ip())
 
-        elif network_or_ip_obj.is_network() or autodetect:
+        elif network_or_ip.is_network() or autodetect:
             network = (
-                Network.get_by_ip(network_or_ip_obj.as_ip())
+                Network.get_by_ip(network_or_ip.as_ip())
                 if autodetect
-                else Network.get_by_network(str(network_or_ip_obj))
+                else Network.get_by_network(str(network_or_ip))
             )
             if network:
                 data["network"] = str(network.network)


### PR DESCRIPTION
- Using / at the end of an IP asks mreg-cli to deduce the netmask.

This reintroduces an old behaviour trait from the previous version of the CLI.