### PR TITLE
Fix mac address validation

### DIFF
--- a/mreg_cli/api/history.py
+++ b/mreg_cli/api/history.py
@@ -26,6 +26,7 @@ class HistoryResource(str, Enum):
     """
 
     Host = "hosts"
+    Permissions = "permissions"
     Group = "groups"
     HostPolicy_Role = "roles"
     HostPolicy_Atom = "atoms"

--- a/mreg_cli/api/models.py
+++ b/mreg_cli/api/models.py
@@ -1908,11 +1908,7 @@ class IPAddress(FrozenModelWithTimestamps, WithHost, APIMixin):
         :returns: The IP address if found, None otherwise.
         """
         if isinstance(mac, str):
-            try:
-                mac = MACAddressField(address=mac)
-            except ValueError as e:
-                raise InputFailure(f"Invalid MAC address: {mac}") from e
-
+            mac = MACAddressField.validate_mac(mac)
         return cls.get_by_field("macaddress", mac.address)
 
     @classmethod
@@ -1955,10 +1951,7 @@ class IPAddress(FrozenModelWithTimestamps, WithHost, APIMixin):
         :returns: A new IPAddress object fetched from the API with the updated MAC address.
         """
         if isinstance(mac, str):
-            try:
-                mac = MACAddressField(address=mac)
-            except ValueError as e:
-                raise InputFailure(f"Invalid MAC address: {mac}") from e
+            mac = MACAddressField.validate_mac(mac)
 
         if self.macaddress and not force:
             raise EntityAlreadyExists(

--- a/mreg_cli/commands/host_submodules/a_aaaa.py
+++ b/mreg_cli/commands/host_submodules/a_aaaa.py
@@ -186,10 +186,7 @@ def _add_ip(
 
     mac = None
     if args.macaddress:
-        try:
-            mac = MACAddressField(address=args.macaddress)
-        except ValueError as e:
-            raise InputFailure(f"Invalid MAC address: {mac}") from e
+        mac = MACAddressField.validate_mac(args.macaddress)
 
     if not args.force:
         _bail_if_ip_in_use_and_not_force(ipaddr)

--- a/mreg_cli/commands/host_submodules/core.py
+++ b/mreg_cli/commands/host_submodules/core.py
@@ -92,11 +92,7 @@ def add(args: argparse.Namespace) -> None:
     macaddress = args.macaddress
 
     if macaddress is not None:
-        try:
-            macaddress = MACAddressField(address=macaddress).address
-        except ValueError as e:
-            raise InputFailure(f"invalid MAC address: {macaddress}") from e
-
+        macaddress = MACAddressField.validate_mac(macaddress)
         ip_address = IPAddress.get_by_mac(macaddress)
 
         if ip_address:
@@ -119,12 +115,6 @@ def add(args: argparse.Namespace) -> None:
 
     if "*" in hname.hostname and not args.force:
         raise ForceMissing("Wildcards must be forced.")
-
-    if macaddress is not None:
-        try:
-            macaddress = MACAddressField(address=macaddress)
-        except ValueError as e:
-            raise InputFailure(f"invalid MAC address: {macaddress}") from e
 
     data: JsonMapping = {
         "name": hname.hostname,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
     'requests[socks]>=2.31.0',
     'typing_extensions>=4.12.0',
     "pydantic[email]>=2.7.1",
+    "pydantic-extra-types>=2.1.0",
 ]
 dynamic = ["version"]
 

--- a/tests/api/test_fields.py
+++ b/tests/api/test_fields.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 import pytest
 
 from mreg_cli.api.fields import MACAddressField
+from mreg_cli.exceptions import InputFailure
+
+MacAddresValidationFailure = pytest.mark.xfail(raises=InputFailure, strict=True)
 
 
 @pytest.mark.parametrize(
@@ -26,6 +29,18 @@ from mreg_cli.api.fields import MACAddressField
         ("A1B2.C3D4.E5F6", "a1:b2:c3:d4:e5:f6"),
         ("a1b2.c3d4.e5f6", "a1:b2:c3:d4:e5:f6"),
         ("Ab12.cD34.eF56", "ab:12:cd:34:ef:56"),
+        # Invalid mac addresses
+        pytest.param("00:00:00:00:00:00:00", "", marks=MacAddresValidationFailure),
+        pytest.param("00:00:00:00:00", "", marks=MacAddresValidationFailure),
+        pytest.param("00:00:00:00:00:0", "", marks=MacAddresValidationFailure),
+        pytest.param("00:00:00:00:00:0g", "", marks=MacAddresValidationFailure),
+        pytest.param("00-00-00-00-00-00:00", "", marks=MacAddresValidationFailure),
+        pytest.param("00-00-00-00-00", "", marks=MacAddresValidationFailure),
+        pytest.param("00-00-00-00-00-0", "", marks=MacAddresValidationFailure),
+        pytest.param("00-00-00-00-00-0g", "", marks=MacAddresValidationFailure),
+        pytest.param("ab:cd:ef:12:34", "", marks=MacAddresValidationFailure),
+        pytest.param("ab-cd-ef-12-34", "", marks=MacAddresValidationFailure),
+        pytest.param("abcd.ef12.34", "", marks=MacAddresValidationFailure),
     ],
 )
 def test_mac_address_field(inp: str, expect: str) -> None:

--- a/tests/api/test_fields.py
+++ b/tests/api/test_fields.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import pytest
+
+from mreg_cli.api.fields import MACAddressField
+
+
+@pytest.mark.parametrize(
+    "inp, expect",
+    [
+        # 6-part colon-separated MAC addresses
+        ("00:00:00:00:00:00", "00:00:00:00:00:00"),
+        ("FF:FF:FF:FF:FF:FF", "ff:ff:ff:ff:ff:ff"),
+        ("A1:B2:C3:D4:E5:F6", "a1:b2:c3:d4:e5:f6"),
+        ("a1:b2:c3:d4:e5:f6", "a1:b2:c3:d4:e5:f6"),
+        ("Ab:cD:eF:01:23:45", "ab:cd:ef:01:23:45"),
+        # 6-part hyphen-separated MAC addresses
+        ("00-00-00-00-00-00", "00:00:00:00:00:00"),
+        ("FF-FF-FF-FF-FF-FF", "ff:ff:ff:ff:ff:ff"),
+        ("A1-B2-C3-D4-E5-F6", "a1:b2:c3:d4:e5:f6"),
+        ("a1-b2-c3-d4-e5-f6", "a1:b2:c3:d4:e5:f6"),
+        ("Ab-cD-eF-01-23-45", "ab:cd:ef:01:23:45"),
+        # 3-part dot-separated MAC addresses
+        ("0000.0000.0000", "00:00:00:00:00:00"),
+        ("FFFF.FFFF.FFFF", "ff:ff:ff:ff:ff:ff"),
+        ("A1B2.C3D4.E5F6", "a1:b2:c3:d4:e5:f6"),
+        ("a1b2.c3d4.e5f6", "a1:b2:c3:d4:e5:f6"),
+        ("Ab12.cD34.eF56", "ab:12:cd:34:ef:56"),
+    ],
+)
+def test_mac_address_field(inp: str, expect: str) -> None:
+    """Test the MAC address field."""
+    res = MACAddressField.validate_mac(inp)
+    assert str(res) == expect


### PR DESCRIPTION
Replaces regex with [`pydantic_extra_types.mac_address.MacAddress`](https://docs.pydantic.dev/latest/api/pydantic_extra_types_mac_address/).