### PR TITLE
Hide traceback on failed login

### DIFF
--- a/mreg_cli/exceptions.py
+++ b/mreg_cli/exceptions.py
@@ -34,7 +34,8 @@ class CliException(Exception):
 
         :returns: Formatted string for the exception message.
         """
-        raise NotImplementedError("This method should be implemented by subclasses")
+        # NOTE: override this in subclasses to provide custom formatting.
+        return self.escape()
 
     def print_self(self):
         """Print the exception with appropriate formatting."""

--- a/mreg_cli/exceptions.py
+++ b/mreg_cli/exceptions.py
@@ -224,7 +224,7 @@ class NetworkOverlap(CliWarning):
     pass
 
 
-class LoginFailedError(CliException):
+class LoginFailedError(CliError):
     """Error class for login failure."""
 
     def formatted_exception(self) -> str:
@@ -233,5 +233,3 @@ class LoginFailedError(CliException):
         :returns: Formatted error message.
         """
         return f"Login failed: {self.escape()}"
-
-    pass

--- a/mreg_cli/main.py
+++ b/mreg_cli/main.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import argparse
 import getpass
 import logging
-import sys
 
 from prompt_toolkit import HTML
 from prompt_toolkit.shortcuts import CompleteStyle, PromptSession

--- a/mreg_cli/main.py
+++ b/mreg_cli/main.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import getpass
 import logging
+import sys
 
 from prompt_toolkit import HTML
 from prompt_toolkit.shortcuts import CompleteStyle, PromptSession
@@ -13,7 +14,7 @@ import mreg_cli.utilities.api as api
 from mreg_cli.__about__ import __version__
 from mreg_cli.cli import cli, source
 from mreg_cli.config import MregCliConfig
-from mreg_cli.exceptions import LoginFailedError
+from mreg_cli.exceptions import CliException, LoginFailedError
 from mreg_cli.outputmanager import OutputManager
 from mreg_cli.types import LogLevel
 from mreg_cli.utilities.api import try_token_or_login
@@ -155,10 +156,13 @@ def main():
             str(config.get("url")),
             fail_without_token=args.token_only,
         )
-
     except (EOFError, KeyboardInterrupt, LoginFailedError) as e:
-        print(e)
+        if isinstance(e, LoginFailedError):
+            e.print_self()
+        else:
+            print(e)
         raise SystemExit() from None
+
     if args.show_token:
         print(api.get_session_token() or "Token not found.")
         raise SystemExit() from None
@@ -227,11 +231,15 @@ def main():
             continue
         except EOFError:
             raise SystemExit() from None
-        try:
-            for line in lines.splitlines():
-                cli.process_command_line(line)
-        except ValueError as e:
-            print(e)
+        except CliException as e:
+            e.print_self()
+            raise SystemExit() from None
+        else:
+            try:
+                for line in lines.splitlines():
+                    cli.process_command_line(line)
+            except ValueError as e:
+                print(e)
 
 
 if __name__ == "__main__":

--- a/mreg_cli/main.py
+++ b/mreg_cli/main.py
@@ -193,7 +193,7 @@ def main():
     # session is a PromptSession object from prompt_toolkit which handles
     # some configurations of the prompt for us: the text of the prompt; the
     # completer; and other visual things.
-    session = PromptSession(
+    session: PromptSession[str] = PromptSession(
         message=get_prompt_message,
         search_ignore_case=True,
         completer=cli,

--- a/mreg_cli/utilities/api.py
+++ b/mreg_cli/utilities/api.py
@@ -161,7 +161,7 @@ def logout() -> None:
 
 def prompt_for_password_and_try_update_token() -> None:
     """Prompt for a password and try to update the token."""
-    password = prompt("You need to re-autenticate\nEnter password: ", is_password=True)
+    password = prompt("You need to re-authenticate\nEnter password: ", is_password=True)
     try:
         user = MregCliConfig().get("user")
         if not user:


### PR DESCRIPTION
`LoginFailedError` nows inherits from `CliError`, which causes it to be caught by `Command.parse` and not print a traceback.

Furthermore, `LoginFailedError` and `CliException` are now caught in main(), so that we can use `CliException.print_self` to print a formatted error message when caught.