### PR TITLE
Add consistent constructors for `IPAddressField`, `MACAddressField` & `NetworkOrIP`

### DIFF
--- a/mreg_cli/api/fields.py
+++ b/mreg_cli/api/fields.py
@@ -21,8 +21,6 @@ class MACAddressField(FrozenModel):
     @classmethod
     def validate(cls, value: str | MacAddress | Self) -> Self:
         """Validate a MAC address and return it as a string."""
-        if isinstance(value, MACAddressField):
-            return cls.validate(value.address)
         try:
             return cls.validate_naive(value)
         except ValueError as e:
@@ -34,7 +32,7 @@ class MACAddressField(FrozenModel):
     def validate_naive(cls, value: str | MacAddress | Self) -> Self:
         """Validate but raise built-in exceptions on failure."""
         if isinstance(value, MACAddressField):
-            return cls.validate(value.address)
+            return cls.validate_naive(value.address)
         try:
             return cls(address=value)  # pyright: ignore[reportArgumentType]
         except ValidationError as e:

--- a/mreg_cli/api/fields.py
+++ b/mreg_cli/api/fields.py
@@ -24,9 +24,21 @@ class MACAddressField(FrozenModel):
         if isinstance(value, MACAddressField):
             return cls.validate(value.address)
         try:
+            return cls.validate_naive(value)
+        except ValueError as e:
+            raise InputFailure(e) from e
+
+    # HACK: extremely hacky workaround for our custom exceptions always
+    # logging errors/warnings even when caught.
+    @classmethod
+    def validate_naive(cls, value: str | MacAddress | Self) -> Self:
+        """Validate but raise built-in exceptions on failure."""
+        if isinstance(value, MACAddressField):
+            return cls.validate(value.address)
+        try:
             return cls(address=value)  # pyright: ignore[reportArgumentType]
         except ValidationError as e:
-            raise InputFailure(f"Invalid MAC address '{value}'") from e
+            raise ValueError(f"Invalid MAC address '{value}'") from e
 
     def __str__(self) -> str:
         """Return the MAC address as a string."""

--- a/mreg_cli/api/fields.py
+++ b/mreg_cli/api/fields.py
@@ -61,6 +61,14 @@ class IPAddressField(FrozenModel):
         except ValueError as e:
             raise InputFailure(f"Invalid IP address '{value}'.") from e
 
+    def is_ipv4(self) -> bool:
+        """Check if the IP address is IPv4."""
+        return isinstance(self.address, ipaddress.IPv4Address)
+
+    def is_ipv6(self) -> bool:
+        """Check if the IP address is IPv6."""
+        return isinstance(self.address, ipaddress.IPv6Address)
+
     @staticmethod
     def is_valid(value: str) -> bool:
         """Check if the value is a valid IP address."""

--- a/mreg_cli/api/fields.py
+++ b/mreg_cli/api/fields.py
@@ -19,7 +19,7 @@ class MACAddressField(FrozenModel):
     address: MacAddress
 
     @classmethod
-    def validate_mac(cls, value: str | MacAddress) -> Self:
+    def validate(cls, value: str | MacAddress) -> Self:
         """Validate a MAC address and return it as a string."""
         try:
             return cls(address=value)  # pyright: ignore[reportArgumentType]

--- a/mreg_cli/api/fields.py
+++ b/mreg_cli/api/fields.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import ipaddress
-from typing import Annotated, Any, Literal, Self, cast, overload
+from typing import Annotated, Any, Self
 
 from pydantic import BeforeValidator, ValidationError
 from pydantic_extra_types.mac_address import MacAddress
@@ -43,9 +43,6 @@ class MACAddressField(FrozenModel):
         return str(self.address)
 
 
-IPVersion = Literal["v4", "v6"]
-
-
 class IPAddressField(FrozenModel):
     """Represents an IP address, automatically determines if it's IPv4 or IPv6."""
 
@@ -63,37 +60,6 @@ class IPAddressField(FrozenModel):
             return cls(address=value)  # pyright: ignore[reportArgumentType] # validator handles this
         except ValueError as e:
             raise InputFailure(f"Invalid IP address '{value}'.") from e
-
-    @overload
-    @classmethod
-    def parse(cls, value: str, mode: Literal["v4"]) -> ipaddress.IPv4Address: ...
-
-    @overload
-    @classmethod
-    def parse(cls, value: str, mode: Literal["v6"]) -> ipaddress.IPv6Address: ...
-
-    @classmethod
-    def parse(cls, value: str, mode: IPVersion) -> IP_AddressT:
-        """Parse a string as a specific IP version."""
-        ip = cls.validate(value)
-        if mode == "v4":
-            if not ip.is_ipv4():
-                raise InputFailure(f"Expected IPv4 address, got {ip.address!r}.")
-            return cast(ipaddress.IPv4Address, ip.address)
-        elif mode == "v6":
-            if not ip.is_ipv6():
-                raise InputFailure(f"Expected IPv6 address, got {ip.address!r}.")
-            return cast(ipaddress.IPv6Address, ip.address)
-        # This should be unreachable in type checked code. Keep it as a fallback.
-        return ip.address
-
-    def is_ipv4(self) -> bool:
-        """Check if the IP address is IPv4."""
-        return isinstance(self.address, ipaddress.IPv4Address)
-
-    def is_ipv6(self) -> bool:
-        """Check if the IP address is IPv6."""
-        return isinstance(self.address, ipaddress.IPv6Address)
 
     @staticmethod
     def is_valid(value: str) -> bool:

--- a/mreg_cli/api/fields.py
+++ b/mreg_cli/api/fields.py
@@ -19,8 +19,10 @@ class MACAddressField(FrozenModel):
     address: MacAddress
 
     @classmethod
-    def validate(cls, value: str | MacAddress) -> Self:
+    def validate(cls, value: str | MacAddress | Self) -> Self:
         """Validate a MAC address and return it as a string."""
+        if isinstance(value, MACAddressField):
+            return cls.validate(value.address)
         try:
             return cls(address=value)  # pyright: ignore[reportArgumentType]
         except ValidationError as e:
@@ -40,11 +42,13 @@ class IPAddressField(FrozenModel):
     address: IP_AddressT
 
     @classmethod
-    def validate(cls, value: str) -> IPAddressField:
+    def validate(cls, value: str | IP_AddressT | Self) -> IPAddressField:
         """Construct an IPAddressField from a string.
 
         Handles validation and exception handling for creating an IPAddressField.
         """
+        if isinstance(value, IPAddressField):
+            return cls.validate(value.address)
         try:
             return cls(address=value)  # pyright: ignore[reportArgumentType] # validator handles this
         except ValueError as e:

--- a/mreg_cli/api/fields.py
+++ b/mreg_cli/api/fields.py
@@ -34,9 +34,6 @@ class MACAddressField(FrozenModel):
 IPVersion = Literal["v4", "v6"]
 
 
-IPVersion = Literal["v4", "v6"]
-
-
 class IPAddressField(FrozenModel):
     """Represents an IP address, automatically determines if it's IPv4 or IPv6."""
 

--- a/mreg_cli/api/fields.py
+++ b/mreg_cli/api/fields.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import ipaddress
-from typing import Annotated, Any, Literal, cast, overload, Self
+from typing import Annotated, Any, Literal, Self, cast, overload
 
-from pydantic import ValidationError, field_validator
+from pydantic import BeforeValidator, ValidationError
 from pydantic_extra_types.mac_address import MacAddress
 
 from mreg_cli.api.abstracts import FrozenModel

--- a/mreg_cli/api/models.py
+++ b/mreg_cli/api/models.py
@@ -2697,7 +2697,7 @@ class Host(FrozenModelWithTimestamps, WithTTL, WithHistory, APIMixin):
             try:
                 mac = MACAddressField.validate(identifier)
                 return Host.get_by_field("ipaddresses__macaddress", mac.address)
-            except ValueError:
+            except InputFailure:
                 pass
 
             # Let us try to find the host by name...

--- a/mreg_cli/api/models.py
+++ b/mreg_cli/api/models.py
@@ -2695,9 +2695,9 @@ class Host(FrozenModelWithTimestamps, WithTTL, WithHistory, APIMixin):
                 pass
 
             try:
-                mac = MACAddressField.validate(identifier)
+                mac = MACAddressField(address=identifier)  # type: ignore
                 return Host.get_by_field("ipaddresses__macaddress", mac.address)
-            except InputFailure:
+            except ValueError:
                 pass
 
             # Let us try to find the host by name...

--- a/mreg_cli/api/models.py
+++ b/mreg_cli/api/models.py
@@ -2695,7 +2695,7 @@ class Host(FrozenModelWithTimestamps, WithTTL, WithHistory, APIMixin):
                 pass
 
             try:
-                mac = MACAddressField(address=identifier)  # type: ignore
+                mac = MACAddressField.validate_naive(identifier)
                 return Host.get_by_field("ipaddresses__macaddress", mac.address)
             except ValueError:
                 pass
@@ -2795,7 +2795,7 @@ class Host(FrozenModelWithTimestamps, WithTTL, WithHistory, APIMixin):
         :returns: The IP address object if found, None otherwise.
         """
         if not isinstance(arg_mac, MACAddressField):
-            arg_mac = MACAddressField.validate(arg_mac)
+            arg_mac = MACAddressField.validate_naive(arg_mac)
         return next((ip for ip in self.ipaddresses if ip.macaddress == arg_mac), None)
 
     def ips_with_macaddresses(self) -> list[IPAddress]:

--- a/mreg_cli/api/models.py
+++ b/mreg_cli/api/models.py
@@ -1986,7 +1986,7 @@ class IPAddress(FrozenModelWithTimestamps, WithHost, APIMixin):
         :returns: The IP address if found, None otherwise.
         """
         if isinstance(mac, str):
-            mac = MACAddressField.validate_mac(mac)
+            mac = MACAddressField.validate(mac)
         return cls.get_by_field("macaddress", mac.address)
 
     @classmethod
@@ -2029,7 +2029,7 @@ class IPAddress(FrozenModelWithTimestamps, WithHost, APIMixin):
         :returns: A new IPAddress object fetched from the API with the updated MAC address.
         """
         if isinstance(mac, str):
-            mac = MACAddressField.validate_mac(mac)
+            mac = MACAddressField.validate(mac)
 
         if self.macaddress and not force:
             raise EntityAlreadyExists(
@@ -2693,7 +2693,7 @@ class Host(FrozenModelWithTimestamps, WithTTL, WithHistory, APIMixin):
                 pass
 
             try:
-                mac = MACAddressField(address=identifier)
+                mac = MACAddressField.validate(identifier)
                 return Host.get_by_field("ipaddresses__macaddress", mac.address)
             except ValueError:
                 pass
@@ -2793,7 +2793,7 @@ class Host(FrozenModelWithTimestamps, WithTTL, WithHistory, APIMixin):
         :returns: The IP address object if found, None otherwise.
         """
         if not isinstance(arg_mac, MACAddressField):
-            arg_mac = MACAddressField(address=arg_mac)
+            arg_mac = MACAddressField.validate(arg_mac)
         return next((ip for ip in self.ipaddresses if ip.macaddress == arg_mac), None)
 
     def ips_with_macaddresses(self) -> list[IPAddress]:
@@ -2888,10 +2888,10 @@ class Host(FrozenModelWithTimestamps, WithTTL, WithHistory, APIMixin):
         :returns: A new Host object fetched from the API after updating the IP address.
         """
         if isinstance(mac, str):
-            mac = MACAddressField.validate_mac(mac)
+            mac = MACAddressField.validate(mac)
 
         if isinstance(ip, str):
-            ip = IPAddressField.from_string(ip)
+            ip = IPAddressField.validate(ip)
 
         params: QueryParams = {
             "macaddress": mac.address,

--- a/mreg_cli/commands/dhcp.py
+++ b/mreg_cli/commands/dhcp.py
@@ -37,7 +37,7 @@ def ipaddress_from_ip_arg(arg: str) -> IPAddress | None:
     if not IPAddressField.is_valid(arg):
         return None
     try:
-        addr = IPAddressField.from_string(arg)
+        addr = IPAddressField.validate(arg)
     except InputFailure:
         return None
     ipobjs = IPAddress.get_by_ip(addr.address)
@@ -82,9 +82,7 @@ def assoc(args: argparse.Namespace) -> None:
         ipaddress = host.get_associatable_ip()
 
     ipaddress.associate_mac(mac, force=force)
-    OutputManager().add_ok(
-        f"Associated mac address {mac} with ip {ipaddress.ip()}"
-    )
+    OutputManager().add_ok(f"Associated mac address {mac} with ip {ipaddress.ip()}")
 
 
 @command_registry.register_command(

--- a/mreg_cli/commands/host_submodules/a_aaaa.py
+++ b/mreg_cli/commands/host_submodules/a_aaaa.py
@@ -182,7 +182,7 @@ def _add_ip(
 
     mac = None
     if args.macaddress:
-        mac = MACAddressField.validate_mac(args.macaddress)
+        mac = MACAddressField.validate(args.macaddress)
 
     if not args.force:
         _bail_if_ip_in_use_and_not_force(ipaddr)

--- a/mreg_cli/commands/host_submodules/a_aaaa.py
+++ b/mreg_cli/commands/host_submodules/a_aaaa.py
@@ -49,9 +49,9 @@ def _ip_change(args: argparse.Namespace, ipversion: IP_Version) -> None:
     if args.old == args.new:
         raise EntityAlreadyExists("New and old IP are equal")
 
-    old_ip = NetworkOrIP(ip_or_network=args.old).as_ip()
+    old_ip = NetworkOrIP.parse(args.old, mode="ip")
 
-    new_ip = NetworkOrIP(ip_or_network=args.new)
+    new_ip = NetworkOrIP.validate(args.new)
     if new_ip.is_network():
         network = Network.get_by_network_or_raise(str(new_ip.ip_or_network))
         new_ip = network.get_first_available_ip()
@@ -88,20 +88,18 @@ def _ip_move(args: argparse.Namespace, ipversion: IP_Version) -> None:
     :param args: argparse.Namespace (ip, fromhost, tohost)
     :param ipversion: 4 or 6
     """
-    ip = NetworkOrIP(ip_or_network=args.ip)
-    if ip.is_network():
-        raise InputFailure("IP cannot be a network")
-    if ip.as_ip().version != ipversion:
+    ip = NetworkOrIP.parse(args.ip, mode="ip")
+    if ip.version != ipversion:
         raise InputFailure(
-            f"IP version {ip.as_ip().version} does not match the requested version {ipversion}"
+            f"IP version {ip.version} does not match the requested version {ipversion}"
         )
 
     from_host = Host.get_by_any_means_or_raise(args.fromhost)
     to_host = Host.get_by_any_means_or_raise(args.tohost)
 
-    host_ip = from_host.get_ip(ip.as_ip())
+    host_ip = from_host.get_ip(ip)
 
-    ptr = from_host.get_ptr_override(ip.as_ip())
+    ptr = from_host.get_ptr_override(ip)
     if not host_ip and not ptr:
         raise EntityNotFound(f"Host {from_host} has no IP or PTR with address {ip}")
 
@@ -125,15 +123,13 @@ def _ip_remove(args: argparse.Namespace, ipversion: IP_Version) -> None:
     :param args: argparse.Namespace (name, ip)
     """
     host = Host.get_by_any_means_or_raise(args.name)
-    ip = NetworkOrIP(ip_or_network=args.ip)
-    if ip.is_network():
-        raise InputFailure("IP cannot be a network")
-    if ip.as_ip().version != ipversion:
+    ip = NetworkOrIP.parse(args.ip, mode="ip")
+    if ip.version != ipversion:
         raise InputFailure(
-            f"IP version {ip.as_ip().version} does not match the requested version {ipversion}"
+            f"IP version {ip.version} does not match the requested version {ipversion}"
         )
 
-    host_ip = host.get_ip(ip.as_ip())
+    host_ip = host.get_ip(ip)
     if not host_ip:
         raise EntityNotFound(f"Host {host} does not have IP {ip}")
 
@@ -157,7 +153,7 @@ def _add_ip(
     :return: The updated host object.
     """
     host = Host.get_by_any_means_or_raise(args.name)
-    ip_or_net = NetworkOrIP(ip_or_network=args.ip)
+    ip_or_net = NetworkOrIP.validate(args.ip)
 
     if ipversion == 4 and (ip_or_net.is_ipv6() or ip_or_net.is_ipv6_network()):
         raise InputFailure("Use aaaa_add for IPv6 addresses")

--- a/mreg_cli/commands/host_submodules/core.py
+++ b/mreg_cli/commands/host_submodules/core.py
@@ -93,7 +93,7 @@ def add(args: argparse.Namespace) -> None:
     macaddress = args.macaddress
 
     if macaddress is not None:
-        macaddress = MACAddressField.validate_mac(macaddress)
+        macaddress = MACAddressField.validate(macaddress)
         ip_address = IPAddress.get_by_mac(macaddress)
 
         if ip_address:

--- a/mreg_cli/commands/host_submodules/core.py
+++ b/mreg_cli/commands/host_submodules/core.py
@@ -135,7 +135,7 @@ def add(args: argparse.Namespace) -> None:
             autodetect = True
             network_or_ip = network_or_ip.rstrip("/")
 
-        net_or_ip = NetworkOrIP(ip_or_network=network_or_ip)
+        net_or_ip = NetworkOrIP.validate(network_or_ip)
 
         if net_or_ip.is_ip() and not autodetect:
             data["ipaddress"] = str(network_or_ip)
@@ -155,10 +155,11 @@ def add(args: argparse.Namespace) -> None:
         else:
             raise EntityNotFound(f"Invalid ip or network: {network_or_ip}")
 
-        if network and network.frozen and not args.force:
-            raise ForceMissing(f"Network {network.network} is frozen, must force")
-        else:
-            net_or_ip = NetworkOrIP(ip_or_network=network.network)
+        if network:
+            if network.frozen and not args.force:
+                raise ForceMissing(f"Network {network.network} is frozen, must force")
+            else:
+                net_or_ip = NetworkOrIP.validate(network.network)
     else:
         net_or_ip = None
 

--- a/mreg_cli/commands/permission.py
+++ b/mreg_cli/commands/permission.py
@@ -56,7 +56,7 @@ def network_list(args: argparse.Namespace) -> None:
     permissions = Permission.get_by_query(query=params, ordering="range,group", limit=None)
 
     if args.range is not None:
-        argnetwork = NetworkOrIP(ip_or_network=args.range).as_network()
+        argnetwork = NetworkOrIP.parse(args.range, mode="network")
 
         for permission in permissions:
             permnet = permission.range
@@ -107,7 +107,7 @@ def network_add(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (range, group, regex)
     """
-    NetworkOrIP(ip_or_network=args.range).as_network()
+    NetworkOrIP.parse(args.range, mode="network")
 
     query = {
         "range": args.range,

--- a/mreg_cli/exceptions.py
+++ b/mreg_cli/exceptions.py
@@ -183,7 +183,7 @@ class EntityOwnershipMismatch(CliWarning):
     pass
 
 
-class InputFailure(CliWarning):
+class InputFailure(CliWarning, ValueError):
     """Warning class for input failure."""
 
     pass

--- a/tests/api/test_fields.py
+++ b/tests/api/test_fields.py
@@ -45,5 +45,5 @@ MacAddresValidationFailure = pytest.mark.xfail(raises=InputFailure, strict=True)
 )
 def test_mac_address_field(inp: str, expect: str) -> None:
     """Test the MAC address field."""
-    res = MACAddressField.validate_mac(inp)
+    res = MACAddressField.validate(inp)
     assert str(res) == expect

--- a/tests/api/test_models.py
+++ b/tests/api/test_models.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from ipaddress import IPv4Address, IPv4Network, IPv6Address, IPv6Network
+from typing import Any
+
+import pytest
+
+from mreg_cli.api.models import IPNetMode, NetworkOrIP
+from mreg_cli.exceptions import (
+    InvalidIPAddress,
+    InvalidIPv4Address,
+    InvalidIPv6Address,
+    InvalidNetwork,
+)
+
+
+@pytest.mark.parametrize(
+    "inp, mode, expect",
+    [
+        # Basic tests for each type
+        ("192.168.0.1", IPNetMode.IP, IPv4Address("192.168.0.1")),
+        ("192.168.0.1", IPNetMode.IPv4, IPv4Address("192.168.0.1")),
+        ("192.168.0.0/24", IPNetMode.NETWORK, IPv4Network("192.168.0.0/24")),
+        ("2001:db8::1", IPNetMode.IP, IPv6Address("2001:db8::1")),
+        ("2001:db8::1", IPNetMode.IPv6, IPv6Address("2001:db8::1")),
+        ("2001:db8::/64", IPNetMode.NETWORK, IPv6Network("2001:db8::/64")),
+        # No mode (auto-detect) tests for each type
+        ("192.168.0.1", None, IPv4Address("192.168.0.1")),
+        ("192.168.0.0/24", None, IPv4Network("192.168.0.0/24")),
+        ("2001:db8::1", None, IPv6Address("2001:db8::1")),
+        ("2001:db8::/64", None, IPv6Network("2001:db8::/64")),
+        # Invalid input (wrong mode)
+        pytest.param(
+            "192.168.0.1",
+            IPNetMode.IPv6,
+            None,
+            marks=pytest.mark.xfail(raises=InvalidIPv6Address, strict=True),
+        ),
+        pytest.param(
+            "192.168.0.1",
+            IPNetMode.NETWORK,
+            None,
+            marks=pytest.mark.xfail(raises=InvalidNetwork, strict=True),
+        ),
+        pytest.param(
+            "192.168.0.0/24",
+            IPNetMode.IPv4,
+            None,
+            marks=pytest.mark.xfail(raises=InvalidIPv4Address, strict=True),
+        ),
+        pytest.param(
+            "192.168.0.0/24",
+            IPNetMode.IP,
+            None,
+            marks=pytest.mark.xfail(raises=InvalidIPAddress, strict=True),
+        ),
+        pytest.param(
+            "2001:db8::1",
+            IPNetMode.IPv4,
+            None,
+            marks=pytest.mark.xfail(raises=InvalidIPv4Address, strict=True),
+        ),
+        pytest.param(
+            "2001:db8::1",
+            IPNetMode.NETWORK,
+            None,
+            marks=pytest.mark.xfail(raises=InvalidNetwork, strict=True),
+        ),
+        pytest.param(
+            "2001:db8::/64",
+            IPNetMode.IPv6,
+            None,
+            marks=pytest.mark.xfail(raises=InvalidIPv6Address, strict=True),
+        ),
+    ],
+)
+def test_network_or_ip_from_string(inp: str, mode: IPNetMode, expect: Any) -> None:
+    """Test the network or IP address from string."""
+    res = NetworkOrIP.from_string(inp, mode)
+    assert res == expect

--- a/tests/api/test_models.py
+++ b/tests/api/test_models.py
@@ -18,12 +18,14 @@ from mreg_cli.exceptions import (
     "inp, mode, expect",
     [
         # Basic tests for each type
-        ("192.168.0.1", IPNetMode.IP, IPv4Address("192.168.0.1")),
-        ("192.168.0.1", IPNetMode.IPv4, IPv4Address("192.168.0.1")),
-        ("192.168.0.0/24", IPNetMode.NETWORK, IPv4Network("192.168.0.0/24")),
-        ("2001:db8::1", IPNetMode.IP, IPv6Address("2001:db8::1")),
-        ("2001:db8::1", IPNetMode.IPv6, IPv6Address("2001:db8::1")),
-        ("2001:db8::/64", IPNetMode.NETWORK, IPv6Network("2001:db8::/64")),
+        ("192.168.0.1", "ip", IPv4Address("192.168.0.1")),
+        ("192.168.0.1", "ipv4", IPv4Address("192.168.0.1")),
+        ("192.168.0.0/24", "network", IPv4Network("192.168.0.0/24")),
+        ("192.168.0.0/24", "networkv4", IPv4Network("192.168.0.0/24")),
+        ("2001:db8::1", "ip", IPv6Address("2001:db8::1")),
+        ("2001:db8::1", "ipv6", IPv6Address("2001:db8::1")),
+        ("2001:db8::/64", "network", IPv6Network("2001:db8::/64")),
+        ("2001:db8::/64", "networkv6", IPv6Network("2001:db8::/64")),
         # No mode (auto-detect) tests for each type
         ("192.168.0.1", None, IPv4Address("192.168.0.1")),
         ("192.168.0.0/24", None, IPv4Network("192.168.0.0/24")),
@@ -32,49 +34,49 @@ from mreg_cli.exceptions import (
         # Invalid input (wrong mode)
         pytest.param(
             "192.168.0.1",
-            IPNetMode.IPv6,
+            "ipv6",
             None,
             marks=pytest.mark.xfail(raises=InvalidIPv6Address, strict=True),
         ),
         pytest.param(
             "192.168.0.1",
-            IPNetMode.NETWORK,
+            "network",
             None,
             marks=pytest.mark.xfail(raises=InvalidNetwork, strict=True),
         ),
         pytest.param(
             "192.168.0.0/24",
-            IPNetMode.IPv4,
+            "ipv4",
             None,
             marks=pytest.mark.xfail(raises=InvalidIPv4Address, strict=True),
         ),
         pytest.param(
             "192.168.0.0/24",
-            IPNetMode.IP,
+            "ip",
             None,
             marks=pytest.mark.xfail(raises=InvalidIPAddress, strict=True),
         ),
         pytest.param(
             "2001:db8::1",
-            IPNetMode.IPv4,
+            "ipv4",
             None,
             marks=pytest.mark.xfail(raises=InvalidIPv4Address, strict=True),
         ),
         pytest.param(
             "2001:db8::1",
-            IPNetMode.NETWORK,
+            "network",
             None,
             marks=pytest.mark.xfail(raises=InvalidNetwork, strict=True),
         ),
         pytest.param(
             "2001:db8::/64",
-            IPNetMode.IPv6,
+            "ipv6",
             None,
             marks=pytest.mark.xfail(raises=InvalidIPv6Address, strict=True),
         ),
     ],
 )
-def test_network_or_ip_from_string(inp: str, mode: IPNetMode, expect: Any) -> None:
+def test_network_or_ip_parse(inp: str, mode: IPNetMode, expect: Any) -> None:
     """Test the network or IP address from string."""
-    res = NetworkOrIP.from_string(inp, mode)
+    res = NetworkOrIP.parse(inp, mode)
     assert res == expect


### PR DESCRIPTION
Adds the method `validate()` for models `IPAddressField`, `MACAddressField` & `NetworkOrIP`, which takes care of validation and exception handling when instantiating these types. This removes a lot of boilerplate code used for validating IPs and MACs.

Furthermore, a new method `NetworkOrIP.parse()` has been added, which allows for validation of an argument as a specific type of IP address or network. I.e. we can instantiate `ipaddress.IPv{4,6}{Network,Address}` using a single method

```py
# Version agnostic
ip = NetworkOrIP.parse("192.168.0.1", mode="ip")
net = NetworkOrIP.parse("192.168.0.0/24", mode="network")

# v4
ipv4 = NetworkOrIP.parse("192.168.0.1", mode="ipv4")
netv4 = NetworkOrIP.parse("192.168.0.0/24", mode="networkv4")

# v6
ipv6 = NetworkOrIP.parse("2001:db8::1", mode="ipv6")
netv6 = NetworkOrIP.parse("2001:db8::/64", mode="networkv6")
```

This takes care of exception handling for us:

```py
ip = NetworkOrIP.parse("192.168.0.0/24", mode="ip")
```

```
Traceback (most recent call last):
  File "/Users/pederhan/.vscode/extensions/ms-python.python-2024.21.2024111202-darwin-arm64/python_files/python_server.py", line 130, in exec_user_input
    retval = callable_(user_input, user_globals)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<string>", line 1, in <module>
  File "/Users/pederhan/repos/mreg-cli/mreg_cli/api/models.py", line 127, in parse
    return func(ipnet)
           ^^^^^^^^^^^
  File "/Users/pederhan/repos/mreg-cli/mreg_cli/api/models.py", line 174, in as_ip
    raise InvalidIPAddress(f"{self.ip_or_network} is not an IP address.")
mreg_cli.exceptions.InvalidIPAddress: 192.168.0.0/24 is not an IP address.

```

One can also omit the `mode=` argument entirely to construct a `IP_AddressT | IP_NetworkT` directly without further type narrowing:

```py
ip = NetworkOrIP.parse("192.168.0.1")
net = NetworkOrIP.parse("192.168.0.0/24")
```


## Discussion

Since the various `validate()` and `parse()` methods raise `InputFailure` whenever they fail, we end up adding a warning every time validation fails, even if we never re-raise the error. This is a problem, because we always try to construct a MAC address from the identifier when looking up hosts in `Host.get_by_any_means` when we dont have a `HostT` hostname, id or IP.

We can either live with an increased number of warnings in the JSON records, or we will have to manually construct a `MacAddressField` in `Host.get_by_any_means` instead of using the common `validate` method, which I'm sure will come back to bite us eventually.

EDIT: this was solved by adding `MACAddressField.validate_naive`, which raises `ValueError` when failing instead of `InputError`, so we can perform these [EAFP](https://docs.python.org/3.12/glossary.html#term-EAFP) checks without logging them:

https://github.com/unioslo/mreg-cli/blob/c8e3989aa9f0eb5de887e6a558f2e763b61361c1/mreg_cli/api/fields.py#L29-L39

It's a gross hack, but it works if silencing failed mac address validation is the goal.