### PR TITLE
Improve `NameList` robustness and flexibility

### DIFF
--- a/mreg_cli/api/fields.py
+++ b/mreg_cli/api/fields.py
@@ -3,14 +3,17 @@
 from __future__ import annotations
 
 import ipaddress
+import logging
 from typing import Annotated, Any, Self
 
-from pydantic import BeforeValidator, ValidationError, AfterValidator
+from pydantic import AfterValidator, BeforeValidator, ValidationError
 from pydantic_extra_types.mac_address import MacAddress
 
 from mreg_cli.api.abstracts import FrozenModel
 from mreg_cli.exceptions import InputFailure
 from mreg_cli.types import IP_AddressT
+
+logger = logging.getLogger(__name__)
 
 
 class MACAddressField(FrozenModel):
@@ -97,6 +100,7 @@ def _extract_name(value: Any) -> str:
         try:
             return str(value["name"])  # pyright: ignore[reportUnknownArgumentType]
         except KeyError:
+            logger.error("No 'name' key in %s", value)  # pyright: ignore[reportUnknownArgumentType]
             return ""
     return value
 

--- a/mreg_cli/api/fields.py
+++ b/mreg_cli/api/fields.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import ipaddress
 from typing import Annotated, Any, Self
 
-from pydantic import BeforeValidator, ValidationError
+from pydantic import BeforeValidator, ValidationError, AfterValidator
 from pydantic_extra_types.mac_address import MacAddress
 
 from mreg_cli.api.abstracts import FrozenModel
@@ -87,13 +87,32 @@ class IPAddressField(FrozenModel):
         return hash(self.address)
 
 
-def _extract_name(value: dict[str, Any]) -> str:
-    """Extract the name from the dictionary.
+def _extract_name(value: Any) -> str:
+    """Extract the "name" value from a dictionary.
 
     :param v: Dictionary containing the name.
     :returns: Extracted name as a string.
     """
-    return value["name"]
+    if isinstance(value, dict):
+        try:
+            return str(value["name"])  # pyright: ignore[reportUnknownArgumentType]
+        except KeyError:
+            return ""
+    return value
 
 
-NameList = list[Annotated[str, BeforeValidator(_extract_name)]]
+def _remove_falsy_list_items(value: Any) -> Any:
+    """Remove falsy items from a list.
+
+    For use in validators only.
+    """
+    if isinstance(value, list):
+        return [i for i in value if i]  # pyright: ignore[reportUnknownVariableType]
+    return value
+
+
+NameList = Annotated[
+    list[Annotated[str, BeforeValidator(_extract_name)]],
+    AfterValidator(_remove_falsy_list_items),
+]
+"""List of names extracted from a list of dicts."""

--- a/tests/api/test_fields.py
+++ b/tests/api/test_fields.py
@@ -135,4 +135,4 @@ def test_name_list_with_empty_name() -> None:
     # just like with the list of dictionaries. Whether or not this is
     # desirable is up for debate.
     # This test ensures that any change to that behavior is caught.
-    assert m.model_dump(mode="json") == snapshot({"hosts": ["test1", "tests2", "test3"]})
+    assert m.model_dump(mode="json") == snapshot({"hosts": ["test1", "test2", "test3"]})

--- a/tests/api/test_fields.py
+++ b/tests/api/test_fields.py
@@ -69,8 +69,10 @@ def test_name_list_basic():
     assert m.model_dump(mode="json") == snapshot({"hosts": ["test1", "test2", "test3"]})
 
 
-def test_name_list_with_invalid_item():
-    """Test NameList field with an item without a name."""
+def test_name_list_with_invalid_item(caplog: pytest.LogCaptureFixture):
+    """Test NameList field with an item without a name.
+
+    Should log an error and skip the item."""
     inp = {
         "hosts": [
             {"name": "test1", "value": 1},
@@ -85,6 +87,10 @@ def test_name_list_with_invalid_item():
     m = TestModel.model_validate(inp)
 
     assert m.model_dump(mode="json") == snapshot({"hosts": ["test1", "test3"]})
+
+    assert caplog.record_tuples == snapshot(
+        [("mreg_cli.api.fields", 40, "No 'name' key in {'value': 2}")]
+    )
 
 
 def test_name_list_invalid_type():


### PR DESCRIPTION
This PR makes the custom `NameList` type less brittle by not breaking when receiving values without a `"name"` key. The validator instead opts to filter out these dicts and log an error when it happens. 

Tests have been added for a small variety of different inputs to the field.