### PR TITLE
Add `Network.ip_network` property

### DIFF
--- a/mreg_cli/exceptions.py
+++ b/mreg_cli/exceptions.py
@@ -195,31 +195,37 @@ class ForceMissing(CliWarning):
     pass
 
 
-class InvalidIPAddress(CliWarning):
+class IPNetworkWarning(CliWarning):
+    """Warning class for IP network/address warnings."""
+
+    pass
+
+
+class InvalidIPAddress(IPNetworkWarning):
     """Warning class for an entity that is not an IP address."""
 
     pass
 
 
-class InvalidIPv4Address(CliWarning):
+class InvalidIPv4Address(IPNetworkWarning):
     """Warning class for an entity that is not an IPv4 address."""
 
     pass
 
 
-class InvalidIPv6Address(CliWarning):
+class InvalidIPv6Address(IPNetworkWarning):
     """Warning class for an entity that is not an IPv6 address."""
 
     pass
 
 
-class InvalidNetwork(CliWarning):
+class InvalidNetwork(IPNetworkWarning):
     """Warning class for an entity that is not a network."""
 
     pass
 
 
-class NetworkOverlap(CliWarning):
+class NetworkOverlap(IPNetworkWarning):
     """Warning class for a networkthat overlaps with another network."""
 
     pass

--- a/tests/api/test_models.py
+++ b/tests/api/test_models.py
@@ -1,17 +1,19 @@
 from __future__ import annotations
 
+from datetime import datetime
 from ipaddress import IPv4Address, IPv4Network, IPv6Address, IPv6Network
 from typing import Any
 
 import pytest
 
-from mreg_cli.api.models import IPNetMode, NetworkOrIP
+from mreg_cli.api.models import IPNetMode, Network, NetworkOrIP
 from mreg_cli.exceptions import (
     InvalidIPAddress,
     InvalidIPv4Address,
     InvalidIPv6Address,
     InvalidNetwork,
 )
+from mreg_cli.types import IP_NetworkT
 
 
 @pytest.mark.parametrize(
@@ -80,3 +82,32 @@ def test_network_or_ip_parse(inp: str, mode: IPNetMode, expect: Any) -> None:
     """Test the network or IP address from string."""
     res = NetworkOrIP.parse(inp, mode)
     assert res == expect
+
+
+@pytest.mark.parametrize(
+    "inp, expect",
+    [
+        ("192.168.0.0/24", IPv4Network("192.168.0.0/24")),
+        ("2001:db8::/64", IPv6Network("2001:db8::/64")),
+    ],
+)
+def test_network_ip_network(inp: str, expect: IP_NetworkT) -> None:
+    """Test the network or IP address from string."""
+    network = Network(
+        id=123,
+        excluded_ranges=[],
+        network=inp,
+        description="testnet",
+        vlan=123,
+        dns_delegated=False,
+        category="test",
+        location="testnet",
+        frozen=False,
+        reserved=0,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+
+    assert network.ip_network == expect
+    assert network.broadcast_address == expect.broadcast_address
+    assert network.network_address == expect.network_address

--- a/tests/api/test_models.py
+++ b/tests/api/test_models.py
@@ -92,7 +92,7 @@ def test_network_or_ip_parse(inp: str, mode: IPNetMode, expect: Any) -> None:
     ],
 )
 def test_network_ip_network(inp: str, expect: IP_NetworkT) -> None:
-    """Test the network or IP address from string."""
+    """Test usage of `Network.ip_network` and related properties."""
     network = Network(
         id=123,
         excluded_ranges=[],


### PR DESCRIPTION
Adds a new cached property `Network.ip_network` which handles calling `NetworkOrIP.parse` and logs the ID of the network if, for any reason, the network is invalid.

The 2 new properties `Network.network_address` and `Network.broadcast_address` introduced in #326  now use `Network.ip_network` under the hood.

Furthermore, all IP address/network exceptions now have a common base class `IPNetworkWarning` so it's easier to catch that category of exceptions.