### PR TITLE
Add version number in user agent header

### DIFF
--- a/mreg_cli/utilities/api.py
+++ b/mreg_cli/utilities/api.py
@@ -20,6 +20,7 @@ from prompt_toolkit import prompt
 from pydantic import BaseModel, TypeAdapter, field_validator
 from requests import Response
 
+from mreg_cli.__about__ import __version__
 from mreg_cli.config import MregCliConfig
 from mreg_cli.exceptions import (
     APINotOk,
@@ -34,7 +35,7 @@ from mreg_cli.tokenfile import TokenFile
 from mreg_cli.types import Json, JsonMapping, QueryParams
 
 session = requests.Session()
-session.headers.update({"User-Agent": "mreg-cli"})
+session.headers.update({"User-Agent": f"mreg-cli-{__version__}"})
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Adds mreg-cli version number in the user agent header for each request. 

So instead of `mreg-cli` we now send `mreg-cli-x.y.z` in the user agent field.