### PR TITLE
Require successful PyPI publishing before creating release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -130,8 +130,8 @@ jobs:
   publish_github:
     name: Publish GitHub release
     needs:
-      - build_pypi
       - build_pyinstaller
+      - publish_pypi
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Since we include PyPI installation instructions in the release notes, we should make sure the PyPI release actually, you know, exists.