### PR TITLE
Re-add command completion descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Fixed
+
+- REPL command completion not showing descriptions for commands.
 
 ## [1.1.0](https://github.com/unioslo/mreg-cli/releases/tag/1.1.0) - 2024-11-19
 

--- a/mreg_cli/cli.py
+++ b/mreg_cli/cli.py
@@ -222,6 +222,7 @@ class Command(Completer):
                     yield Completion(
                         name,
                         start_position=-len(cur),
+                        display_meta=self.children[name].short_desc,
                     )
 
         # if the line starts with one of the sub commands, pass it along


### PR DESCRIPTION
This reverts the "fix" applied in #309 . I have no idea how to make the `host` and `help` completions render vertically, when `permission` and `policy` already do so by default.