### PR TITLE
Handle failed token file write operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - REPL command completion not showing descriptions for commands.
 - `host info` with MAC address argument not working for hosts with multiple IPs associated with the same MAC address.
+- Failed token file write causing the application to crash.
 
 ## [1.1.0](https://github.com/unioslo/mreg-cli/releases/tag/1.1.0) - 2024-11-19
 

--- a/mreg_cli/tokenfile.py
+++ b/mreg_cli/tokenfile.py
@@ -83,6 +83,13 @@ class TokenFile(BaseModel):
     @classmethod
     def set_entry(cls, username: str, url: str, new_token: str) -> None:
         """Update or add a token based on the URL and username."""
+        try:
+            cls._do_set_entry(username, url, new_token)
+        except OSError as e:
+            logger.error("Failed to set token: %r", e)
+
+    @classmethod
+    def _do_set_entry(cls, username: str, url: str, new_token: str) -> None:
         tokens_file = cls.load()
         for token in tokens_file.tokens:
             if token.url == url and token.username == username:


### PR DESCRIPTION
Fixes #340

Now logs whenever we are unable to write a token file. Could consider printing this to stderr too?