### PR TITLE
Fix underline in errors for commands with regex as final arg

### DIFF
--- a/mreg_cli/errorbuilder.py
+++ b/mreg_cli/errorbuilder.py
@@ -137,21 +137,23 @@ class FilterErrorBuilder(ErrorBuilder):
             if "'" in part or '"' in part:
                 continue
 
-            if char in part:
-                try:
-                    start, end = command.index(part), command.index(part) + len(part)
-                    if start > end or start >= len(command) or end >= len(command):
-                        raise ValueError(f"Invalid start and end values: {start}, {end}")
-                except ValueError as e:
-                    logger.error(
-                        "Failed to get index of char '%s' in part '%s' of command %s: %s",
-                        char,
-                        part,
-                        command,
-                        e,
-                    )
-                else:
-                    return start, end
+            if char not in part:
+                continue
+
+            try:
+                start, end = command.index(part), command.index(part) + len(part) - 1
+                if start > end or start >= len(command) or end >= len(command):
+                    raise ValueError(f"Invalid start and end values: {start}, {end}")
+            except ValueError as e:
+                logger.error(
+                    "Failed to get index of char '%s' in part '%s' of command %s: %s",
+                    char,
+                    part,
+                    command,
+                    e,
+                )
+            else:
+                return start, end
         return -1, -1
 
     def get_offset(self) -> tuple[int, int]:  # noqa: D102 (missing docstring [inherit it from parent])

--- a/mreg_cli/errorbuilder.py
+++ b/mreg_cli/errorbuilder.py
@@ -141,8 +141,8 @@ class FilterErrorBuilder(ErrorBuilder):
                 continue
 
             try:
-                start, end = command.index(part), command.index(part) + len(part) - 1
-                if start > end or start >= len(command) or end >= len(command):
+                start, end = command.index(part), command.index(part) + len(part)
+                if start > end or start >= len(command) or end > len(command):
                     raise ValueError(f"Invalid start and end values: {start}, {end}")
             except ValueError as e:
                 logger.error(

--- a/tests/test_errorbuilder.py
+++ b/tests/test_errorbuilder.py
@@ -43,7 +43,7 @@ def test_build_error_message() -> None:
     ) == snapshot("""\
 Unable to compile regex 'cman)ora.*\\.example\\.com$ oracle'
 permission label_add 192.168.0.0/24 oracle-group ^(db|cman)ora.*\\.example\\.com$ oracle
-                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                                                  └ Consider enclosing this part in quotes.\
 """)
 
@@ -54,7 +54,7 @@ permission label_add 192.168.0.0/24 oracle-group ^(db|cman)ora.*\\.example\\.com
     ) == snapshot("""\
 Unable to compile regex 'db(pg|my).*\\.example\\.com$'
 permission network_add 192.168.0.0/24 pg-group ^db(pg|my).*\\.example\\.com$
-                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
                                                └ Consider enclosing this part in quotes.\
 """)
 


### PR DESCRIPTION
The `>=` check for the `end` offset was wrong. It should have been `>`. This caused the underline for those commands to be considered invalid, and defaulted to `(-1, -1)`, which meant no underline was rendered.

Also rewrote tests as snapshot tests so we don't have to write the expected results by hand.