### PR TITLE
Fix parsing of http://localhost:8000 for the prompt.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - REPL command completion not showing descriptions for commands.
 - `host info` with MAC address argument not working for hosts with multiple IPs associated with the same MAC address.
 - Failed token file write causing the application to crash.
+- Connection strings without domains and with ports are now parsed properly for prompt interpolation.
 
 ### Added
 

--- a/mreg_cli/prompt.py
+++ b/mreg_cli/prompt.py
@@ -37,10 +37,7 @@ def parse_connection_string(
     """
     # Regular expression to match the protocol (http or https), host/IP (v4/v6), and port
     regex = (
-        r"^(?P<protocol>https?)://"
-        r"(?P<host>(?:(?:[a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}|"
-        r"(?:\d{1,3}\.){3}\d{1,3}|\[.*?\]))"
-        r"(?::(?P<port>\d+))?$"
+        r"^(?P<protocol>https?)://" r"(?P<host>(?:[a-zA-Z0-9.-]+|\[.*?\]))" r"(?::(?P<port>\d+))?$"
     )
 
     match = re.match(regex, connection_string)
@@ -61,7 +58,8 @@ def parse_connection_string(
         return ConnectionInfo(protocol, host, None, port)
 
     # Otherwise, it's a domain
-    return ConnectionInfo(protocol, host, host.split(".")[-1], port)
+    domain = host.split(".")[-1] if "." in host else None
+    return ConnectionInfo(protocol, host, domain, port)
 
 
 def get_prompt_message(args: argparse.Namespace, config: MregCliConfig) -> HTML:

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -77,6 +77,24 @@ PROMPT_TEST_CASES = [
         "admin@https://fe80::5074:f2ff:feb1:a87f:8000",
         id="URL w/ IPv6 (Link-local) & port (custom prompt)",
     ),
+    pytest.param(
+        {
+            "url": "http://localhost:8000",
+            "user": "admin",
+            "prompt": "{user}@{proto}://{host}:{port}",
+        },
+        "admin@http://localhost:8000",
+        id="URL w/ localhost & port (custom prompt)",
+    ),
+    pytest.param(
+        {
+            "url": "http://localhost.localdomain:8000",
+            "user": "admin",
+            "prompt": "{user}@{host}:{port}",
+        },
+        "admin@localhost.localdomain:8000",
+        id="URL w/ localhost.localdomain & port (custom prompt)",
+    ),
 ]
 
 


### PR DESCRIPTION
  - Simplifies the regex.
  - Cleanly allows empty domain.
  - Added tests.