### PR TITLE
Fix IPv6 host lookup raising `ValidationError` when not found

### DIFF
--- a/mreg_cli/api/fields.py
+++ b/mreg_cli/api/fields.py
@@ -41,6 +41,29 @@ class MACAddressField(FrozenModel):
         except ValidationError as e:
             raise ValueError(f"Invalid MAC address '{value}'") from e
 
+    @classmethod
+    def parse(cls, obj: Any) -> MacAddress:
+        """Parse a MAC address from a string. Returns the MAC address as a string.
+
+        :param obj: The object to parse.
+        :returns: The MAC address as a string.
+        :raises ValueError: If the object is not a valid MAC address.
+        """
+        # Match interface of NetworkOrIP.parse
+        return cls.validate(obj).address
+
+    @classmethod
+    def parse_optional(cls, obj: Any) -> MacAddress | None:
+        """Parse a MAC address from a string. Returns None if the MAC address is invalid.
+
+        :param obj: The object to parse.
+        :returns: The MAC address as a string or None if it is invalid.
+        """
+        try:
+            return cls.parse(obj)
+        except ValueError:
+            return None
+
     def __str__(self) -> str:
         """Return the MAC address as a string."""
         return str(self.address)


### PR DESCRIPTION
This PR fixes #348 by treating a failed lookup in `Host.get_by_any_means_or_raise` for IP/MAC with a _valid_ IP/MAC as "host not found", rather than proceeding by interpreting the argument as a hostname. This _does_ break support for hosts with valid IPs/MACs used as hostnames, but that should probably not be supported anyway (?)


## Problems

This is a draft PR, because it causes a bunch of new warnings to be added to the test suite results. Every time we check if a IP or MAC is valid, and it's not, we add a warning to the log. This happens because our helper functions raise `CliWarning` or `CliError`, and it's not possible to use them to check if something is valid, then catch the exception silently. Those exception types _always_ log when they are instantiated.

If this is fine, then sure, we can just merge the PR with the extra warnings in the result log, but if not, we need to consider a new scheme for logging exceptions.

I think automatic recording of every exception can cause a lot of test suite result churn, and we should take a look at it.