### PR TITLE
Only log exceptions when caught

### DIFF
--- a/ci/testsuite-result.json
+++ b/ci/testsuite-result.json
@@ -6,7 +6,6 @@
     "command_issued": "zone create example.org hostmaster@example.org ns1.example.org  # should require force because ns1 is unknown",
     "ok": [],
     "warning": [
-      "Host ns1.example.org not found.",
       "ns1.example.org is not in mreg, must force"
     ],
     "error": [],
@@ -41,9 +40,7 @@
     "ok": [
       "Created zone example.org"
     ],
-    "warning": [
-      "Host ns1.example.org not found."
-    ],
+    "warning": [],
     "error": [],
     "output": [],
     "api_requests": [
@@ -210,10 +207,9 @@
     "command": "zone set_ns example.org ns2.example.org",
     "command_filter": null,
     "command_filter_negate": false,
-    "command_issued": "zone set_ns example.org ns2.example.org # requires force because ns2 is unknown",
+    "command_issued": "zone set_ns example.org ns2.example.org  #  requires force because ns2 is unknown",
     "ok": [],
     "warning": [
-      "Host ns2.example.org not found.",
       "ns2.example.org is not in mreg, must force"
     ],
     "error": [],
@@ -271,9 +267,7 @@
     "ok": [
       "Updated nameservers for example.org"
     ],
-    "warning": [
-      "Host ns2.example.org not found."
-    ],
+    "warning": [],
     "error": [],
     "output": [],
     "api_requests": [
@@ -15283,9 +15277,7 @@
     "ok": [
       "Created zone delegation wut.example.org"
     ],
-    "warning": [
-      "Host ns2.example.org not found."
-    ],
+    "warning": [],
     "error": [],
     "output": [],
     "api_requests": [

--- a/mreg_cli/cli.py
+++ b/mreg_cli/cli.py
@@ -167,7 +167,7 @@ class Command(Completer):
             self.last_errno = e.code
 
         except (CliWarning, CliError) as exc:
-            exc.print_self()
+            exc.print_and_log()
 
         except CliExit:
             # If we have active recordings going on, save them before exiting
@@ -263,7 +263,7 @@ class Command(Completer):
         try:
             cmd = output.from_command(line)
         except (CliWarning, CliError) as exc:
-            exc.print_self()
+            exc.print_and_log()
             return
         # Create and set the corrolation id, using the cleaned command
         # as the suffix. This is used to track the command in the logs

--- a/mreg_cli/main.py
+++ b/mreg_cli/main.py
@@ -154,7 +154,7 @@ def main():
         )
     except (EOFError, KeyboardInterrupt, LoginFailedError) as e:
         if isinstance(e, LoginFailedError):
-            e.print_self()
+            e.print_and_log()
         else:
             print(e)
         raise SystemExit() from None
@@ -204,7 +204,7 @@ def main():
         except EOFError:
             raise SystemExit() from None
         except CliException as e:
-            e.print_self()
+            e.print_and_log()
             raise SystemExit() from None
         else:
             try:

--- a/mreg_cli/utilities/api.py
+++ b/mreg_cli/utilities/api.py
@@ -145,7 +145,7 @@ def prompt_for_password_and_login(user: str, url: str, catch_exception: bool = T
         auth_and_update_token(user, password)
     except CliError as e:
         if catch_exception:
-            e.print_self()
+            e.print_and_log()
         else:
             raise LoginFailedError("Updating token failed.") from e
 
@@ -169,7 +169,7 @@ def prompt_for_password_and_try_update_token() -> None:
             raise LoginFailedError("Unable to determine username.")
         auth_and_update_token(user, password)
     except CliError as e:
-        e.print_self()
+        e.print_and_log()
 
 
 def auth_and_update_token(username: str, password: str) -> None:


### PR DESCRIPTION
This PR refactors logging of exceptions by adding the new methods `log()` and `print_and_log()` to `CliException`, and removing the logging + `OutputManager.add_{warning,error}` calls in the constructor. 

All logging is moved to the new `log()` method, which can be overridden in subclasses to control how a given exception type is logged. The new `print_and_log()` method simply calls `log()`and `print_self()`.