### PR TITLE
Refactor `parse()` methods to conform with naming conventions

### DIFF
--- a/mreg_cli/commands/host_submodules/a_aaaa.py
+++ b/mreg_cli/commands/host_submodules/a_aaaa.py
@@ -49,7 +49,7 @@ def _ip_change(args: argparse.Namespace, ipversion: IP_Version) -> None:
     if args.old == args.new:
         raise EntityAlreadyExists("New and old IP are equal")
 
-    old_ip = NetworkOrIP.parse(args.old, mode="ip")
+    old_ip = NetworkOrIP.parse_or_raise(args.old, mode="ip")
 
     new_ip = NetworkOrIP.validate(args.new)
     if new_ip.is_network():
@@ -88,7 +88,7 @@ def _ip_move(args: argparse.Namespace, ipversion: IP_Version) -> None:
     :param args: argparse.Namespace (ip, fromhost, tohost)
     :param ipversion: 4 or 6
     """
-    ip = NetworkOrIP.parse(args.ip, mode="ip")
+    ip = NetworkOrIP.parse_or_raise(args.ip, mode="ip")
     if ip.version != ipversion:
         raise InputFailure(
             f"IP version {ip.version} does not match the requested version {ipversion}"
@@ -123,7 +123,7 @@ def _ip_remove(args: argparse.Namespace, ipversion: IP_Version) -> None:
     :param args: argparse.Namespace (name, ip)
     """
     host = Host.get_by_any_means_or_raise(args.name)
-    ip = NetworkOrIP.parse(args.ip, mode="ip")
+    ip = NetworkOrIP.parse_or_raise(args.ip, mode="ip")
     if ip.version != ipversion:
         raise InputFailure(
             f"IP version {ip.version} does not match the requested version {ipversion}"

--- a/mreg_cli/commands/host_submodules/rr.py
+++ b/mreg_cli/commands/host_submodules/rr.py
@@ -474,7 +474,7 @@ def ptr_change(args: argparse.Namespace) -> None:
     if not old_host.ptr_overrides:
         raise EntityNotFound(f"No PTR records for {old_host}")
 
-    ip = NetworkOrIP.parse(args.ip, mode="ip")
+    ip = NetworkOrIP.parse_or_raise(args.ip, mode="ip")
     ptr_override = old_host.get_ptr_override(ip)
     if not ptr_override:
         raise EntityNotFound(f"No PTR record for {old_host} with IP {ip}")
@@ -503,7 +503,7 @@ def ptr_remove(args: argparse.Namespace) -> None:
     :param args: argparse.Namespace (ip, name)
     """
     host = Host.get_by_any_means_or_raise(args.name)
-    ip = NetworkOrIP.parse(args.ip, mode="ip")
+    ip = NetworkOrIP.parse_or_raise(args.ip, mode="ip")
     ptr_override = host.get_ptr_override(ip)
     if not ptr_override:
         raise EntityNotFound(f"No PTR record for {host} with IP {ip}")
@@ -529,7 +529,7 @@ def ptr_add(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (ip, name, force)
     """
-    ip = NetworkOrIP.parse(args.ip, mode="ip")
+    ip = NetworkOrIP.parse_or_raise(args.ip, mode="ip")
 
     host = Host.get_by_any_means_or_raise(args.name)
     existing_ptrs = PTR_override.get_list_by_field("ipaddress", str(ip))
@@ -563,7 +563,7 @@ def ptr_show(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (ip)
     """
-    ip = NetworkOrIP.parse(args.ip, mode="ip")
+    ip = NetworkOrIP.parse_or_raise(args.ip, mode="ip")
     host = Host.get_by_any_means_or_raise(str(ip), inform_as_ptr=False)
     if not host.ptr_overrides:
         OutputManager().add_line(f"No PTR records for {host.name.hostname}")

--- a/mreg_cli/commands/network.py
+++ b/mreg_cli/commands/network.py
@@ -67,7 +67,7 @@ def create(args: argparse.Namespace) -> None:
     if args.location and not is_valid_location_tag(args.location):
         raise InputFailure("Not a valid location tag")
 
-    arg_network = NetworkOrIP.parse(args.network, mode="network")
+    arg_network = NetworkOrIP.parse_or_raise(args.network, mode="network")
     networks = Network.get_list()
     for network in networks:
         if network.overlaps(arg_network):

--- a/mreg_cli/commands/permission.py
+++ b/mreg_cli/commands/permission.py
@@ -56,7 +56,7 @@ def network_list(args: argparse.Namespace) -> None:
     permissions = Permission.get_by_query(query=params, ordering="range,group", limit=None)
 
     if args.range is not None:
-        argnetwork = NetworkOrIP.parse(args.range, mode="network")
+        argnetwork = NetworkOrIP.parse_or_raise(args.range, mode="network")
 
         for permission in permissions:
             permnet = permission.range
@@ -107,7 +107,7 @@ def network_add(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (range, group, regex)
     """
-    NetworkOrIP.parse(args.range, mode="network")
+    NetworkOrIP.parse_or_raise(args.range, mode="network")
 
     query = {
         "range": args.range,

--- a/tests/api/test_models.py
+++ b/tests/api/test_models.py
@@ -86,7 +86,7 @@ def test_network_or_ip_parse(inp: str, mode: IPNetMode, expect: Any) -> None:
 
 
 @pytest.mark.parametrize(
-    "inp, expect_type",
+    "inp, expect_type_call",
     [
         ("192.168.0.1", NetworkOrIP.is_ipv4),
         ("192.168.0.0/24", NetworkOrIP.is_ipv4_network),
@@ -101,11 +101,11 @@ def test_network_or_ip_parse(inp: str, mode: IPNetMode, expect: Any) -> None:
         ),
     ],
 )
-def test_network_or_ip_validate(inp: Any, expect_type: Callable[[NetworkOrIP], bool]) -> None:
+def test_network_or_ip_validate(inp: Any, expect_type_call: Callable[[NetworkOrIP], bool]) -> None:
     """Test the validation of network or IP address."""
     res = NetworkOrIP.validate(inp)
     # Ensure it's validated as the correct type
-    assert expect_type(res)
+    assert expect_type_call(res)
 
 
 @pytest.mark.parametrize(

--- a/tests/api/test_models.py
+++ b/tests/api/test_models.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 from datetime import datetime
 from ipaddress import IPv4Address, IPv4Network, IPv6Address, IPv6Network
-from typing import Any
+from typing import Any, Callable
 
 import pytest
 
 from mreg_cli.api.models import IPNetMode, Network, NetworkOrIP
 from mreg_cli.exceptions import (
+    InputFailure,
     InvalidIPAddress,
     InvalidIPv4Address,
     InvalidIPv6Address,
@@ -80,8 +81,31 @@ from mreg_cli.types import IP_NetworkT
 )
 def test_network_or_ip_parse(inp: str, mode: IPNetMode, expect: Any) -> None:
     """Test the network or IP address from string."""
-    res = NetworkOrIP.parse(inp, mode)
+    res = NetworkOrIP.parse_or_raise(inp, mode)
     assert res == expect
+
+
+@pytest.mark.parametrize(
+    "inp, expect_type",
+    [
+        ("192.168.0.1", NetworkOrIP.is_ipv4),
+        ("192.168.0.0/24", NetworkOrIP.is_ipv4_network),
+        ("2001:db8::1", NetworkOrIP.is_ipv6),
+        ("2001:db8::/64", NetworkOrIP.is_ipv6_network),
+        ("2001:db8::/", NetworkOrIP.is_ipv6),  # valid address because validator removes suffix
+        pytest.param(
+            "192.168.0.0/33", None, marks=pytest.mark.xfail(raises=InputFailure, strict=True)
+        ),
+        pytest.param(
+            "2001:db8::/129", None, marks=pytest.mark.xfail(raises=InputFailure, strict=True)
+        ),
+    ],
+)
+def test_network_or_ip_validate(inp: Any, expect_type: Callable[[NetworkOrIP], bool]) -> None:
+    """Test the validation of network or IP address."""
+    res = NetworkOrIP.validate(inp)
+    # Ensure it's validated as the correct type
+    assert expect_type(res)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Renames the following methods:

-  `MACAddressField.parse()` -> `MACAddressField.parse_or_raise()`
-  `MACAddressField.parse_optional()` -> `MACAddressField.parse()`
-  `NetworkOrIP.parse()` -> `NetworkOrIP.parse_or_raise()`
-  `NetworkOrIP.parse_optional()` -> `NetworkOrIP.parse()`

Also fixes a bug where `NetworkOrIP.validate()` could raise a `pydantic.ValidationError` on failed validation instead of `InputFailure` because we caught our own `ValidationError` type instead of Pydantic's.