### PR TITLE
Containerize setup for testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,20 +14,15 @@ jobs:
         python-version:
           - '3.11'
           - '3.12'
+          - '3.13'
     env:
       # Disable colors and formatting in Rich console output
       TERM: dumb
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install uv
-        uses: astral-sh/setup-uv@v2
-      - name: Set up Python ${{ matrix.python-version }}
-        run: uv python install ${{ matrix.python-version }}
-      - name: Install mreg-cli
-        run: uv sync
       - name: Test and compare api calls
-        run: uv run ci/run_testsuite_and_record.sh
+        run: ci/run_testsuite_and_record_V2.sh ${{ matrix.python-version }}
 
   tox:
     name: tox
@@ -68,6 +63,7 @@ jobs:
         python-version:
           - "3.11"
           - "3.12"
+          - '3.13'
     steps:
       - uses: actions/checkout@v4
       - name: Install uv

--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -9,6 +9,10 @@ If you would like to contribute to this project, please follow these steps:
 5. Push to the branch (`git push origin feature/branch-name`)
 6. Create a Pull Request
 
+## Testing
+
+To run tests locally, just run the script `ci/run_testsuite_and_record_V2.sh` from anywhere. The only prerequisite is a working installation of docker or podman.
+
 ## Publishing
 
 Publishing new versions is automatically handled by GitHub actions for versions tagged with `x.y.z[.prerelease]` (`1.2.3`, `1.2.3.rc1`, etc.). If you are a maintainer, you can create a new release by following these steps:

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -2,13 +2,12 @@
 FROM ubuntu:latest
 ARG python_version=3.12
 
-SHELL ["/bin/bash", "-c"]
-RUN apt update
-RUN apt install -y curl git
+RUN apt-get -qq update
+RUN apt-get -y install curl git >/dev/null
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh
-RUN /root/.local/bin/uv self update
+RUN /root/.local/bin/uv self update -q
 RUN /root/.local/bin/uv python install ${python_version}
 COPY . /build
-RUN cd /build; /root/.local/bin/uv sync
+RUN cd /build; /root/.local/bin/uv sync -q
 
 CMD cd /build/ci; /root/.local/bin/uv run bash -c 'echo "test" | mreg-cli -u test -d example.org --url http://127.0.0.1:8000 --source testsuite --record new_testsuite_log.json --record-without-timestamps -v ERROR >/dev/null'

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,0 +1,14 @@
+# This container image is only used temporarily for testing during a CI process.
+FROM ubuntu:latest
+ARG python_version=3.12
+
+SHELL ["/bin/bash", "-c"]
+RUN apt update
+RUN apt install -y curl git
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+RUN /root/.local/bin/uv self update
+RUN /root/.local/bin/uv python install ${python_version}
+COPY . /build
+RUN cd /build; /root/.local/bin/uv sync
+
+CMD cd /build/ci; /root/.local/bin/uv run bash -c 'echo "test" | mreg-cli -u test -d example.org --url http://127.0.0.1:8000 --source testsuite --record new_testsuite_log.json --record-without-timestamps -v ERROR >/dev/null'

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -4,7 +4,7 @@ ARG python_version=3.12
 
 RUN apt-get -qq update
 RUN apt-get -y install curl git >/dev/null
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+RUN curl -LsSf https://astral.sh/uv/0.5.6/install.sh | sh
 RUN /root/.local/bin/uv self update -q
 RUN /root/.local/bin/uv python install ${python_version}
 COPY . /build

--- a/ci/run_testsuite_and_record_V2.sh
+++ b/ci/run_testsuite_and_record_V2.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# exit immediately on error
+set -e
+
+# clean up on exit, even if something fails
+function cleanup {
+	set +e
+	if [[ -n "$GITHUB_ACTIONS" ]]; then
+    	docker compose --ansi=never down
+	else
+		docker compose down
+	fi
+	docker ps -a | grep "mreg-" | awk '{print $1}' | xargs -r docker stop
+	docker ps -a | grep "mreg-" | awk '{print $1}' | xargs -r docker rm
+	docker images | grep "mreg-" | awk '{print $1}' | xargs -r docker rmi
+	rm -f new_testsuite_log.json
+	echo "cleanup done."
+}
+trap cleanup EXIT
+
+# chdir to where this script is
+cd `dirname $0`
+
+# get Python version from argument
+PYTHON_VERSION=3.12
+if [ ! -z "$1" ]; then
+	PYTHON_VERSION=$1
+fi
+echo "Python version $PYTHON_VERSION"
+
+# build a container image for mreg-cli
+docker build -f Dockerfile -t mreg-cli --build-arg python_version=$PYTHON_VERSION ..
+
+# start mreg+postgres in containers
+if [[ -n "$GITHUB_ACTIONS" ]]; then
+    docker compose --ansi=never pull --quiet
+    docker compose --ansi=never up -d
+else
+    docker compose up -d
+fi
+
+# give mreg some time to create the database schema and start up
+sleep 5s
+
+# create a superuser
+docker exec -t mreg /app/manage.py create_mreg_superuser --username test --password test
+
+# test connectivity
+#docker run --rm --tty --network host --entrypoint curl mreg-cli --head http://127.0.0.1:8000/admin/login/
+
+# start the mreg-cli container, which will automatically run the test suite
+echo "Running the tests..."
+docker run --name mreg-cli --network host --tty mreg-cli
+docker commit mreg-cli finished-mreg-tests # because inside is the file new_testsuite_log.json which we want to look at
+
+# show a detailed diff (and review if running locally)
+if [[ -n "$GITHUB_ACTIONS" ]]; then
+	docker run --rm --tty --entrypoint bash finished-mreg-tests -c 'cd /build/ci; /root/.local/bin/uv run diff.py testsuite-result.json new_testsuite_log.json'
+	exit $?
+else
+	docker run -it --name finished-mreg-tests --entrypoint bash finished-mreg-tests -c 'cd /build/ci; /root/.local/bin/uv run diff.py testsuite-result.json new_testsuite_log.json --review'
+	EXITCODE=$?
+	docker cp finished-mreg-tests:/build/ci/testsuite-result.json .
+	exit $EXITCODE
+fi


### PR DESCRIPTION
This PR moves UV and Python setup/installation from the workflow and into a Dockerfile. A new test script is added that builds a container for mreg-cli with all the dependencies.
The purpose is to make it easier to run the testsuite. Now you just have to clone the repo and run the script, as long as you have docker or podman installed. This is great for other workflows that need to do this when building mreg.

This PR also adds Python version 3.13 to the matrix for unit- and integration tests. Tried it with tox, but it didn't work.