### PR TITLE
Do not resolve CNAME hosts in `host info`

### DIFF
--- a/ci/testsuite-result.json
+++ b/ci/testsuite-result.json
@@ -23730,57 +23730,6 @@
           "comment": "This is the comment",
           "zone": 1
         }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hosts/?id=14",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
-            {
-              "ipaddresses": [
-                {
-                  "macaddress": "",
-                  "ipaddress": "10.0.0.14",
-                  "host": 14
-                },
-                {
-                  "macaddress": "11:22:33:44:55:66",
-                  "ipaddress": "10.0.0.15",
-                  "host": 14
-                }
-              ],
-              "cnames": [
-                {
-                  "name": "fubar.example.org",
-                  "ttl": null,
-                  "zone": 1,
-                  "host": 14
-                }
-              ],
-              "mxs": [],
-              "txts": [
-                {
-                  "txt": "v=spf1 -all",
-                  "host": 14
-                }
-              ],
-              "ptr_overrides": [],
-              "hinfo": null,
-              "loc": null,
-              "bacnetid": null,
-              "name": "bar.example.org",
-              "contact": "me@example.org",
-              "ttl": null,
-              "comment": "This is the comment",
-              "zone": 1
-            }
-          ]
-        }
       }
     ],
     "time": null

--- a/mreg_cli/api/models.py
+++ b/mreg_cli/api/models.py
@@ -268,6 +268,14 @@ class HostT(BaseModel):
 
     hostname: str
 
+    @field_validator("hostname", mode="before")
+    @classmethod
+    def extract_hostname(cls, value: Any) -> Any:
+        """Extract the hostname from a HostT input value."""
+        if isinstance(value, HostT):
+            return value.hostname
+        return value
+
     @field_validator("hostname")
     @classmethod
     def validate_hostname(cls, value: str) -> str:
@@ -2179,6 +2187,31 @@ class CNAME(FrozenModelWithTimestamps, WithHost, WithZone, WithTTL, APIMixin):
     name: HostT
     ttl: int | None = None
 
+    canonical_name: HostT | None = Field(default=None, exclude=True)
+    """Custom field to store the canonical hostname of the CNAME record.
+
+    Only used when instantiated from a host's CNAME record.
+    """
+
+    @classmethod
+    def from_host_cname(cls, host: HostT, cname: CNAME) -> CNAME:
+        """Create a CNAME record from a host and a CNAME record.
+
+        :param host: The host to use.
+        :param record: The CNAME record to use.
+        :returns: The new CNAME record.
+        """
+        return cls(
+            id=cname.id,
+            name=cname.name,
+            ttl=cname.ttl,
+            created_at=cname.created_at,
+            updated_at=cname.updated_at,
+            canonical_name=host,
+            host=cname.host,
+            zone=cname.zone,
+        )
+
     @field_validator("name", mode="before")
     @classmethod
     def validate_name(cls, value: Any) -> HostT:
@@ -2234,25 +2267,28 @@ class CNAME(FrozenModelWithTimestamps, WithHost, WithZone, WithTTL, APIMixin):
 
         return results[0]
 
-    def output(self, padding: int = 14) -> None:
+    def output(self, padding: int = 14, resolve: bool = True) -> None:
         """Output the CNAME record to the console.
 
         :param padding: Number of spaces for left-padding the output.
         """
-        actual_host = self.resolve_host()
-        host = actual_host.name if actual_host else "<Not found>"
-
+        if resolve and (actual_host := self.resolve_host()):
+            host = actual_host.name.hostname
+        elif self.canonical_name:
+            host = self.canonical_name.hostname
+        else:
+            host = "<Not found>"
         OutputManager().add_line(f"{'Cname:':<{padding}}{self.name} -> {host}")
 
     @classmethod
-    def output_multiple(cls, cnames: list[CNAME], padding: int = 14) -> None:
+    def output_multiple(cls, cnames: list[CNAME], resolve: bool = True, padding: int = 14) -> None:
         """Output multiple CNAME records to the console.
 
         :param cnames: List of CNAME records to output.
         :param padding: Number of spaces for left-padding the output.
         """
         for cname in cnames:
-            cname.output(padding=padding)
+            cname.output(resolve=resolve, padding=padding)
 
 
 class TXT(FrozenModelWithTimestamps, WithHost, APIMixin):
@@ -3232,8 +3268,8 @@ class Host(FrozenModelWithTimestamps, WithTTL, WithHistory, APIMixin):
         """Output the CNAME records for the host."""
         if not self.cnames:
             return
-
-        CNAME.output_multiple(self.cnames, padding=padding)
+        cnames = [CNAME.from_host_cname(self.name, cname) for cname in self.cnames]
+        CNAME.output_multiple(cnames, resolve=False, padding=padding)
 
     def output_roles(self, _padding: int = 14) -> None:
         """Output the roles for the host."""

--- a/mreg_cli/api/models.py
+++ b/mreg_cli/api/models.py
@@ -2248,10 +2248,10 @@ class CNAME(FrozenModelWithTimestamps, WithHost, WithZone, WithTTL, APIMixin):
         :param host: Host CNAME points to. Attempts to resolve the host if not provided.
         :param padding: Number of spaces for left-padding the output.
         """
-        if not host and (actual_host := self.resolve_host()):
-            hostname = actual_host.name.hostname
-        elif host:
+        if host:
             hostname = host.name.hostname
+        elif not host and (actual_host := self.resolve_host()):
+            hostname = actual_host.name.hostname
         else:
             hostname = "<Not found>"
         OutputManager().add_line(f"{'Cname:':<{padding}}{self.name} -> {hostname}")


### PR DESCRIPTION
`host info` is _very_ slow for hosts with a large number of CNAME records because we resolve every single record before printing them. As I understand it, that is unnecessary in the case of `host info` because we already have the host they point to, so we can just inject the host into the output method so we can skip resolving (what should be) the same host for each CNAME record the host has.

## Alternatives considered

There are multiple ways to solve this problem. Below are some other approaches that were considered.

### Sending multiple requests with a thread pool

If we really _needed_ to perform the additional API lookups, using a thread pool to send multiple requests concurrently could speed things up massively. However, as I understand it, seeing as we already have the host that the CNAME records point to, there is no need to perform this lookup for each individual record.


### Injecting hostname via `CNAME.output()` and `CNAME.output_multiple()` methods

Edit: ended up taking this approach instead