### PR TITLE
Use original test suite result when writing diffs

### DIFF
--- a/ci/diff.py
+++ b/ci/diff.py
@@ -290,8 +290,8 @@ class CommandDiffer:
                     new_testsuite_results.append(expected.original)
                     self.diff_unresolved += 1
             else:
-                # No diff, keep new line
-                new_testsuite_results.append(result.original)
+                # No diff, keep old line
+                new_testsuite_results.append(expected.original)
 
         # Only write back changes if we are in review mode and there are changes
         if self.review and self.diff_resolved > 0:


### PR DESCRIPTION
I guess when I originally wrote the new diff.py I wanted to be on the safe side and use the new result rather than the original one, but that leads to a lot of unnecessary changes to the test suite results file.

This PR selects the old result when writing the diff file, so that we only modify the lines pertaining to the commands that have differences, instead of updating a bunch of lines that are replaced by placeholders anyway. 

Tested when writing #354 