### PR TITLE
Replace field models with custom types

### DIFF
--- a/ci/testsuite-result.json
+++ b/ci/testsuite-result.json
@@ -17441,7 +17441,7 @@
     "command_filter_negate": false,
     "command_issued": "policy host_remove fruit foo",
     "ok": [
-      "Removed host foo.example.org from role 'fruit'"
+      "Removed host 'foo.example.org' from role 'fruit'"
     ],
     "warning": [],
     "error": [],

--- a/mreg_cli/api/fields.py
+++ b/mreg_cli/api/fields.py
@@ -3,6 +3,11 @@
 The types validate to basic types like str, int, etc., but with additional
 validation added to them. The types are used in Pydantic models for consistent
 validation of common fields such as hostnames, MAC addresses, etc.
+
+Warning:
+Values constructed from these types should NOT be checked at runtime with isinstance()!
+Pydantic will always coerce these types to their schema types (str, int, etc.).
+
 """
 
 from __future__ import annotations

--- a/mreg_cli/api/fields.py
+++ b/mreg_cli/api/fields.py
@@ -32,10 +32,10 @@ class HostName(str):
 
     @classmethod
     def parse(cls, obj: Any) -> HostName | None:
-        """Parse a MAC address from a string. Returns None if the MAC address is invalid.
+        """Parse a hostname from a string. Returns None if the hostname is invalid.
 
         :param obj: The object to parse.
-        :returns: The MAC address as a string or None if it is invalid.
+        :returns: The hostname as a string or None if it is invalid.
         """
         try:
             return cls.parse_or_raise(obj)
@@ -44,7 +44,7 @@ class HostName(str):
 
     @classmethod
     def parse_or_raise(cls, obj: Any) -> HostName:
-        """Parse a hostname from a string. Returns the MAC address as a string.
+        """Parse a hostname from a string. Returns the hostname as a string.
 
         :param obj: The object to parse.
         :returns: The hostname as a string.
@@ -54,7 +54,7 @@ class HostName(str):
             adapter = get_type_adapter(cls)
             return cls(adapter.validate_python(obj))
         except ValueError as e:
-            raise InputFailure(f"Invalid MAC address '{obj}'") from e
+            raise InputFailure(f"Invalid hostname '{obj}'") from e
 
     @staticmethod
     def validate_hostname(value: str) -> str:

--- a/mreg_cli/api/fields.py
+++ b/mreg_cli/api/fields.py
@@ -1,4 +1,9 @@
-"""Fields for models of the API."""
+"""Custom field types for Pydantic models.
+
+The types validate to basic types like str, int, etc., but with additional
+validation added to them. The types are used in Pydantic models for consistent
+validation of common fields such as hostnames, MAC addresses, etc.
+"""
 
 from __future__ import annotations
 
@@ -53,11 +58,6 @@ class HostName(str):
 
         if re.search(r"^(\*\.)?([a-z0-9_][a-z0-9\-]*\.?)+$", value) is None:
             raise InputFailure(f"Invalid input for hostname: {value}")
-            # raise PydanticCustomError(
-            #     "hostname_format",
-            #     "Invalid input for hostname: {value}",
-            #     {"value": value},
-            # )
 
         # Assume user is happy with domain, but strip the dot.
         if value.endswith("."):
@@ -130,11 +130,6 @@ class MacAddress(PydanticMacAddress):
         """
         try:
             adapter = get_type_adapter(cls)
-            # Convert regular string to MacAddress string after validation.
-            # The pydantic validator returns a regular string even though the
-            # Pydantic MacAddress type is a distinct type that subclasses str.
-            # By converting the string to a MacAddress string, we can distinguish
-            # between a valid MAC address and a valid string at runtime if needed.
             return cls(adapter.validate_python(obj))
         except ValueError as e:
             raise InputFailure(f"Invalid MAC address '{obj}'") from e

--- a/mreg_cli/api/fields.py
+++ b/mreg_cli/api/fields.py
@@ -39,7 +39,12 @@ class MacAddress(PydanticMacAddress):
         """
         try:
             adapter = get_type_adapter(cls)
-            return adapter.validate_python(obj)
+            # Convert regular string to MacAddress string after validation.
+            # The pydantic validator returns a regular string even though the
+            # Pydantic MacAddress type is a distinct type that subclasses str.
+            # By converting the string to a MacAddress string, we can distinguish
+            # between a valid MAC address and a valid string at runtime if needed.
+            return cls(adapter.validate_python(obj))
         except ValueError as e:
             raise InputFailure(f"Invalid MAC address '{obj}'") from e
 

--- a/mreg_cli/api/fields.py
+++ b/mreg_cli/api/fields.py
@@ -2,47 +2,20 @@
 
 from __future__ import annotations
 
-import ipaddress
 import logging
-from typing import Annotated, Any, Self
+from typing import Annotated, Any
 
-from pydantic import AfterValidator, BeforeValidator, ValidationError
-from pydantic_extra_types.mac_address import MacAddress
+from pydantic import AfterValidator, BeforeValidator
+from pydantic_extra_types.mac_address import MacAddress as PydanticMacAddress
 
-from mreg_cli.api.abstracts import FrozenModel
 from mreg_cli.exceptions import InputFailure
-from mreg_cli.types import IP_AddressT
+from mreg_cli.types import get_type_adapter
 
 logger = logging.getLogger(__name__)
 
 
-class MACAddressField(FrozenModel):
-    """Represents a MAC address."""
-
-    address: MacAddress
-
-    # HACK: extremely hacky workaround for our custom exceptions always
-    # logging errors/warnings even when caught.
-    @classmethod
-    def validate(cls, value: str | MacAddress | Self) -> Self:
-        """Validate but raise built-in exceptions on failure."""
-        if isinstance(value, MACAddressField):
-            return cls.validate(value.address)
-        try:
-            return cls(address=value)  # pyright: ignore[reportArgumentType]
-        except ValidationError as e:
-            raise InputFailure(f"Invalid MAC address '{value}'") from e
-
-    @classmethod
-    def parse_or_raise(cls, obj: Any) -> MacAddress:
-        """Parse a MAC address from a string. Returns the MAC address as a string.
-
-        :param obj: The object to parse.
-        :returns: The MAC address as a string.
-        :raises ValueError: If the object is not a valid MAC address.
-        """
-        # Match interface of NetworkOrIP.parse_or_raise
-        return cls.validate(obj).address
+class MacAddress(PydanticMacAddress):
+    """MAC address string type used in Pydantic models."""
 
     @classmethod
     def parse(cls, obj: Any) -> MacAddress | None:
@@ -53,56 +26,22 @@ class MACAddressField(FrozenModel):
         """
         try:
             return cls.parse_or_raise(obj)
-        except ValueError:
+        except InputFailure:
             return None
 
-    def __str__(self) -> str:
-        """Return the MAC address as a string."""
-        return str(self.address)
-
-
-class IPAddressField(FrozenModel):
-    """Represents an IP address, automatically determines if it's IPv4 or IPv6."""
-
-    address: IP_AddressT
-
     @classmethod
-    def validate(cls, value: str | IP_AddressT | Self) -> IPAddressField:
-        """Construct an IPAddressField from a string.
+    def parse_or_raise(cls, obj: Any) -> MacAddress:
+        """Parse a MAC address from a string. Returns the MAC address as a string.
 
-        Handles validation and exception handling for creating an IPAddressField.
+        :param obj: The object to parse.
+        :returns: The MAC address as a string.
+        :raises ValueError: If the object is not a valid MAC address.
         """
-        if isinstance(value, IPAddressField):
-            return cls.validate(value.address)
         try:
-            return cls(address=value)  # pyright: ignore[reportArgumentType] # validator handles this
+            adapter = get_type_adapter(cls)
+            return adapter.validate_python(obj)
         except ValueError as e:
-            raise InputFailure(f"Invalid IP address '{value}'.") from e
-
-    def is_ipv4(self) -> bool:
-        """Check if the IP address is IPv4."""
-        return isinstance(self.address, ipaddress.IPv4Address)
-
-    def is_ipv6(self) -> bool:
-        """Check if the IP address is IPv6."""
-        return isinstance(self.address, ipaddress.IPv6Address)
-
-    @staticmethod
-    def is_valid(value: str) -> bool:
-        """Check if the value is a valid IP address."""
-        try:
-            ipaddress.ip_address(value)
-            return True
-        except ValueError:
-            return False
-
-    def __str__(self) -> str:
-        """Return the IP address as a string."""
-        return str(self.address)
-
-    def __hash__(self):
-        """Return a hash of the IP address."""
-        return hash(self.address)
+            raise InputFailure(f"Invalid MAC address '{obj}'") from e
 
 
 def _extract_name(value: Any) -> str:

--- a/mreg_cli/api/models.py
+++ b/mreg_cli/api/models.py
@@ -297,7 +297,7 @@ class HostName(str):
         """
         try:
             adapter = get_type_adapter(cls)
-            return adapter.validate_python(obj)
+            return cls(adapter.validate_python(obj))
         except ValueError as e:
             raise InputFailure(f"Invalid MAC address '{obj}'") from e
 
@@ -335,12 +335,9 @@ class HostName(str):
     ) -> core_schema.CoreSchema:
         """Return a Pydantic CoreSchema with the hostname validation.
 
-        Args:
-            source: The source type to be converted.
-            handler: The handler to get the CoreSchema.
-
-        Returns:
-            A Pydantic CoreSchema with the hostname validation.
+        :param source: The source type to be converted.
+        :param handler: The handler to get the CoreSchema.
+        :returns: A Pydantic CoreSchema with the hostname validation.
 
         """
         return core_schema.with_info_before_validator_function(

--- a/mreg_cli/api/models.py
+++ b/mreg_cli/api/models.py
@@ -13,7 +13,6 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
-    IPvAnyAddress,
     computed_field,
     field_validator,
 )
@@ -1557,8 +1556,8 @@ class ExcludedRange(FrozenModelWithTimestamps):
 
     id: int  # noqa: A003
     network: int
-    start_ip: IPvAnyAddress
-    end_ip: IPvAnyAddress
+    start_ip: IP_AddressT
+    end_ip: IP_AddressT
 
     def excluded_ips(self) -> int:
         """Return the number of IP addresses in the excluded range."""
@@ -1965,7 +1964,7 @@ class IPAddress(FrozenModelWithTimestamps, WithHost, APIMixin):
 
     id: int  # noqa: A003
     macaddress: MacAddress | None = None
-    ipaddress: IPvAnyAddress
+    ipaddress: IP_AddressT
 
     @field_validator("macaddress", mode="before")
     @classmethod
@@ -1973,7 +1972,7 @@ class IPAddress(FrozenModelWithTimestamps, WithHost, APIMixin):
         """Create macaddress or convert empty strings to None.
 
         The API can return an empty string for this field, which fails to validate
-        as a MAC address.
+        as a MAC address. Therefore, treat empty strings as None.
         """
         if v:
             return v

--- a/mreg_cli/api/models.py
+++ b/mreg_cli/api/models.py
@@ -2178,9 +2178,9 @@ class CNAME(FrozenModelWithTimestamps, WithHost, WithZone, WithTTL, APIMixin):
         :param padding: Number of spaces for left-padding the output.
         """
         if host:
-            hostname = host.name.hostname
+            hostname = host.name
         elif not host and (actual_host := self.resolve_host()):
-            hostname = actual_host.name.hostname
+            hostname = actual_host.name
         else:
             hostname = "<Not found>"
         OutputManager().add_line(f"{'Cname:':<{padding}}{self.name} -> {hostname}")

--- a/mreg_cli/api/models.py
+++ b/mreg_cli/api/models.py
@@ -2675,7 +2675,7 @@ class Host(FrozenModelWithTimestamps, WithTTL, WithHistory, APIMixin):
 
     @classmethod
     def get_by_any_means(
-        cls, identifier: HostName | str, inform_as_cname: bool = True, inform_as_ptr: bool = True
+        cls, identifier: str, inform_as_cname: bool = True, inform_as_ptr: bool = True
     ) -> Host | None:
         """Get a host by the given identifier.
 
@@ -2710,19 +2710,18 @@ class Host(FrozenModelWithTimestamps, WithTTL, WithHistory, APIMixin):
 
         :returns: A Host object if the host was found, otherwise None.
         """
-        if not isinstance(identifier, HostName):
-            if identifier.isdigit():
-                return Host.get_by_id(int(identifier))
+        if identifier.isdigit():
+            return Host.get_by_id(int(identifier))
 
-            if ip := NetworkOrIP.parse(identifier, mode="ip"):
-                host = cls.get_by_ip_or_raise(ip, inform_as_ptr=inform_as_ptr)
-                return host
+        if ip := NetworkOrIP.parse(identifier, mode="ip"):
+            host = cls.get_by_ip_or_raise(ip, inform_as_ptr=inform_as_ptr)
+            return host
 
-            if mac := MacAddress.parse(identifier):
-                return cls.get_by_mac_or_raise(mac)
+        if mac := MacAddress.parse(identifier):
+            return cls.get_by_mac_or_raise(mac)
 
-            # Let us try to find the host by name...
-            identifier = HostName.parse_or_raise(identifier)
+        # Let us try to find the host by name...
+        identifier = HostName.parse_or_raise(identifier)
 
         if host := cls.get_by_field("name", identifier):
             return host

--- a/mreg_cli/api/models.py
+++ b/mreg_cli/api/models.py
@@ -2148,7 +2148,7 @@ class CNAME(FrozenModelWithTimestamps, WithHost, WithZone, WithTTL, APIMixin):
         :returns: The CNAME record if found, None otherwise.
         """
         target_hostname = None
-        if isinstance(host, HostName):
+        if isinstance(host, str):
             hostobj = Host.get_by_any_means(host, inform_as_cname=False)
             if not hostobj:
                 raise EntityNotFound(f"Host with name {host} not found.")

--- a/mreg_cli/commands/dhcp.py
+++ b/mreg_cli/commands/dhcp.py
@@ -106,10 +106,8 @@ def disassoc(args: argparse.Namespace) -> None:
     ipaddress = ipaddress_from_ip_arg(name)
     if not ipaddress:
         host = Host.get_by_any_means_or_raise(name)
-        try:
-            ipaddress = host.has_ip_with_mac(name)
-        except ValueError:
-            pass
+        if mac := MacAddress.parse(name):
+            ipaddress = host.has_ip_with_mac(mac)
 
         if not ipaddress:
             ips_with_mac = host.ips_with_macaddresses()

--- a/mreg_cli/commands/group.py
+++ b/mreg_cli/commands/group.py
@@ -189,7 +189,7 @@ def host_add(args: argparse.Namespace) -> None:
 
     for name in args.hosts:
         host = Host.get_by_any_means_or_raise(name)
-        fqname = host.name.hostname
+        fqname = host.name
         hostgroup.add_host(fqname)
         OutputManager().add_ok(f"Added host {fqname!r} to {args.group!r}")
 
@@ -213,7 +213,7 @@ def host_remove(args: argparse.Namespace) -> None:
     to_remove: set[str] = set()
     for name in args.hosts:
         host = Host.get_by_any_means_or_raise(name)
-        fqname = host.name.hostname
+        fqname = host.name
         if not hostgroup.has_host(fqname):
             raise EntityNotFound(f"Host {name!r} ({fqname}) not a member in {args.group!r}")
         to_remove.add(fqname)

--- a/mreg_cli/commands/group.py
+++ b/mreg_cli/commands/group.py
@@ -215,7 +215,7 @@ def host_remove(args: argparse.Namespace) -> None:
         host = Host.get_by_any_means_or_raise(name)
         fqname = host.name
         if not hostgroup.has_host(fqname):
-            raise EntityNotFound(f"Host {name!r} ({fqname}) not a member in {args.group!r}")
+            raise EntityNotFound(f"Host {name!r} ({fqname!r}) not a member in {args.group!r}")
         to_remove.add(fqname)
 
     for name in to_remove:

--- a/mreg_cli/commands/help.py
+++ b/mreg_cli/commands/help.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import argparse
-import logging
 from typing import Any
 
 from mreg_cli.__about__ import __version__ as mreg_cli_version

--- a/mreg_cli/commands/host_submodules/a_aaaa.py
+++ b/mreg_cli/commands/host_submodules/a_aaaa.py
@@ -183,8 +183,7 @@ def _add_ip(
 
     mac = None
     if args.macaddress:
-        # FIXME: should this raise exception if validation fails? Surely?
-        mac = MacAddress.parse(args.macaddress)
+        mac = MacAddress.parse_or_raise(args.macaddress)
 
     if not args.force:
         _bail_if_ip_in_use_and_not_force(ipaddr)

--- a/mreg_cli/commands/host_submodules/a_aaaa.py
+++ b/mreg_cli/commands/host_submodules/a_aaaa.py
@@ -17,7 +17,8 @@ from __future__ import annotations
 
 import argparse
 
-from mreg_cli.api.models import Host, HostList, IPAddress, MACAddressField, Network, NetworkOrIP
+from mreg_cli.api.fields import MacAddress
+from mreg_cli.api.models import Host, HostList, IPAddress, Network, NetworkOrIP
 from mreg_cli.commands.host import registry as command_registry
 from mreg_cli.exceptions import (
     DeleteError,
@@ -182,7 +183,8 @@ def _add_ip(
 
     mac = None
     if args.macaddress:
-        mac = MACAddressField.validate(args.macaddress)
+        # FIXME: should this raise exception if validation fails? Surely?
+        mac = MacAddress.parse(args.macaddress)
 
     if not args.force:
         _bail_if_ip_in_use_and_not_force(ipaddr)

--- a/mreg_cli/commands/host_submodules/bacnet.py
+++ b/mreg_cli/commands/host_submodules/bacnet.py
@@ -50,13 +50,13 @@ def bacnetid_add(args: argparse.Namespace) -> None:
             f"BACnet ID {existing.id} is already in use by {existing.hostname}."
         )
 
-    BacnetID.create(params={"hostname": host.name.hostname, "id": args.id})
+    BacnetID.create(params={"hostname": host.name, "id": args.id})
 
     validator = BacnetID.get(args.id)
-    if validator and validator.hostname == host.name.hostname:
+    if validator and validator.hostname == host.name:
         OutputManager().add_ok(f"Assigned BACnet ID {validator.id} to {validator.hostname}.")
     else:
-        raise CreateError(f"Failed to assign BACnet ID {args.id} to {host.name.hostname}.")
+        raise CreateError(f"Failed to assign BACnet ID {args.id} to {host.name}.")
 
 
 @command_registry.register_command(

--- a/mreg_cli/commands/host_submodules/cname.py
+++ b/mreg_cli/commands/host_submodules/cname.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import argparse
 
-from mreg_cli.api.models import CNAME, ForwardZone, Host, HostName
+from mreg_cli.api.fields import HostName
+from mreg_cli.api.models import CNAME, ForwardZone, Host
 from mreg_cli.commands.host import registry as command_registry
 from mreg_cli.exceptions import (
     CreateError,

--- a/mreg_cli/commands/host_submodules/core.py
+++ b/mreg_cli/commands/host_submodules/core.py
@@ -16,12 +16,11 @@ from __future__ import annotations
 import argparse
 import re
 
-from mreg_cli.api.fields import MacAddress
+from mreg_cli.api.fields import HostName, MacAddress
 from mreg_cli.api.models import (
     ForwardZone,
     Host,
     HostList,
-    HostName,
     IPAddress,
     Network,
     NetworkOrIP,

--- a/mreg_cli/commands/host_submodules/rr.py
+++ b/mreg_cli/commands/host_submodules/rr.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 
 import argparse
 
+from mreg_cli.api.fields import HostName
 from mreg_cli.api.models import (
     MX,
     NAPTR,
@@ -49,7 +50,6 @@ from mreg_cli.api.models import (
     ForwardZone,
     HInfo,
     Host,
-    HostName,
     Location,
     Network,
     NetworkOrIP,

--- a/mreg_cli/commands/network.py
+++ b/mreg_cli/commands/network.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import argparse
 from typing import Any
 
-from mreg_cli.api.fields import IPAddressField
 from mreg_cli.api.models import Network, NetworkOrIP
 from mreg_cli.commands.base import BaseCommand
 from mreg_cli.commands.registry import CommandRegistry
@@ -188,8 +187,8 @@ def find(args: argparse.Namespace) -> None:
     args_dict = vars(args)
 
     if ip_arg := args_dict.get("ip"):
-        addr = IPAddressField(address=ip_arg)
-        networks = [Network.get_by_ip_or_raise(addr.address)]
+        addr = NetworkOrIP.parse_or_raise(ip_arg, mode="ip")
+        networks = [Network.get_by_ip_or_raise(addr)]
     else:
         params: QueryParams = {}
         param_names = [

--- a/mreg_cli/commands/policy.py
+++ b/mreg_cli/commands/policy.py
@@ -307,8 +307,8 @@ def host_add(args: argparse.Namespace) -> None:
     hosts = [Host.get_by_any_means_or_raise(host) for host in host_names]
 
     for host in hosts:
-        role.add_host(host.name.hostname)
-        OutputManager().add_ok(f"Added host {host.name!r} to role {role_name!r}")
+        role.add_host(host.name)
+        OutputManager().add_ok(f"Added host {host.name} to role {role_name!r}")
 
 
 @command_registry.register_command(
@@ -340,7 +340,7 @@ def host_copy(args: argparse.Namespace) -> None:
 
         # Check what roles need to be added
         for role in source_roles - destination_roles:
-            role.add_host(destination.name.hostname)
+            role.add_host(destination.name)
             OutputManager().add_line(f"    + {role.name}")
 
 
@@ -385,7 +385,7 @@ def host_remove(args: argparse.Namespace) -> None:
     hosts = [Host.get_by_any_means_or_raise(host) for host in host_names]
 
     for host in hosts:
-        role.remove_host(host.name.hostname)
+        role.remove_host(host.name)
         OutputManager().add_ok(f"Removed host {host.name!r} from role {role_name!r}")
 
 

--- a/mreg_cli/exceptions.py
+++ b/mreg_cli/exceptions.py
@@ -9,12 +9,10 @@ from __future__ import annotations
 
 import logging
 import sys
-from typing import Any
 
 from prompt_toolkit import print_formatted_text
 from prompt_toolkit.formatted_text import HTML
 from prompt_toolkit.formatted_text.html import html_escape
-
 
 logger = logging.getLogger(__name__)
 

--- a/mreg_cli/types.py
+++ b/mreg_cli/types.py
@@ -6,6 +6,7 @@ import argparse
 import ipaddress
 from collections.abc import Callable
 from enum import StrEnum
+from functools import lru_cache
 from typing import (
     Annotated,
     Any,
@@ -21,6 +22,7 @@ from typing import (
 )
 
 from pydantic import (
+    TypeAdapter,
     ValidationError,
     ValidationInfo,
     ValidatorFunctionWrapHandler,
@@ -158,3 +160,17 @@ class LogLevel(StrEnum):
     def choices(cls) -> list[str]:
         """Return a list of all log levels as strings."""
         return [str(c) for c in list(cls)]
+
+
+T = TypeVar("T")
+
+
+@lru_cache(maxsize=100)
+def get_type_adapter(t: type[T]) -> TypeAdapter[T]:
+    """Get the type adapter for a given type.
+
+    :param t: The type to get the adapter for.
+    :returns: The type adapter.
+
+    """
+    return TypeAdapter(t)

--- a/tests/api/test_fields.py
+++ b/tests/api/test_fields.py
@@ -4,7 +4,7 @@ import pytest
 from inline_snapshot import snapshot
 from pydantic import BaseModel, ValidationError
 
-from mreg_cli.api.fields import MACAddressField, NameList
+from mreg_cli.api.fields import MacAddress, NameList
 from mreg_cli.exceptions import InputFailure
 
 MacAddresValidationFailure = pytest.mark.xfail(raises=InputFailure, strict=True)
@@ -45,10 +45,13 @@ MacAddresValidationFailure = pytest.mark.xfail(raises=InputFailure, strict=True)
         pytest.param("abcd.ef12.34", "", marks=MacAddresValidationFailure),
     ],
 )
-def test_mac_address_field(inp: str, expect: str) -> None:
+def test_mac_address_type(inp: str, expect: str) -> None:
     """Test the MAC address field."""
-    res = MACAddressField.validate(inp)
+    res = MacAddress.parse_or_raise(inp)
     assert str(res) == expect
+    # Narrow and broad type
+    assert isinstance(res, MacAddress)
+    assert isinstance(res, str)
 
 
 def test_name_list_basic():

--- a/tests/api/test_fields.py
+++ b/tests/api/test_fields.py
@@ -4,10 +4,114 @@ import pytest
 from inline_snapshot import snapshot
 from pydantic import BaseModel, ValidationError
 
-from mreg_cli.api.fields import MacAddress, NameList
+from mreg_cli.api.fields import HostName, MacAddress, NameList
 from mreg_cli.exceptions import InputFailure
 
-MacAddresValidationFailure = pytest.mark.xfail(raises=InputFailure, strict=True)
+
+@pytest.mark.parametrize(
+    "hostname",
+    [
+        "example.com",
+        "sub.domain.com",
+        "localhost",
+        "my-host-123.com",
+        "123-start-with-number.com",
+        "singlelabel",
+        "sub.sub2.sub3.domain.com",
+        "_underscore.hostname.com",
+        "host-name-with-dashes.com",
+        "multi.label.domain.co.uk",
+        "*.example.com",
+        "*.sub.domain.com",
+        "*.localhost",
+        "*.my-host-123.com",
+        "*.123-start-with-number.com",
+        "*.singlelabel",
+        "*.sub.sub2.sub3.domain.com",
+        "*.underscore.hostname.com",
+        "*.host-name-with-dashes.com",
+        "*.multi.label.domain.co.uk",
+    ],
+)
+def test_valid_hostname(hostname: str) -> None:
+    assert HostName.parse_or_raise(hostname) == hostname
+
+
+@pytest.mark.parametrize(
+    "hostname",
+    [
+        "-example.com",
+        "sub..domain.com",
+        ".singlelabel",
+        "multi..label.domain.co.uk",
+        "*.sub.-domain.com",
+        "localhost*",
+        "host name with spaces.com",
+        "example.com/net",
+        "*.sub..domain.com",
+        "host>name.com",
+        "example.com#section",
+        "123&456.com",
+        # TODO: Make these invalid names fail validation:
+        pytest.param(
+            "example-.com",
+            marks=pytest.mark.xfail(
+                reason="ends with '-'",
+                strict=True,
+            ),
+        ),
+        pytest.param(
+            "*.example-.com",
+            marks=pytest.mark.xfail(
+                reason="ends with '-'",
+                strict=True,
+            ),
+        ),
+        pytest.param(
+            "localhost.",
+            marks=pytest.mark.xfail(
+                reason="ends with '.'",
+                strict=True,
+            ),
+        ),
+        pytest.param(
+            "host--name-with-dashes.com",
+            marks=pytest.mark.xfail(
+                reason="double '-'",
+                strict=True,
+            ),
+        ),
+        pytest.param(
+            "_underscore_.hostname.com",
+            marks=pytest.mark.xfail(
+                reason="Ends with '_'",
+                strict=True,
+            ),
+        ),
+        pytest.param(
+            "my_host_123.com",
+            marks=pytest.mark.xfail(
+                reason="Underscores between words",
+                strict=True,
+            ),
+        ),
+        pytest.param(
+            "123.start-with-number.com",
+            marks=pytest.mark.xfail(
+                reason="Starts with number",
+                strict=True,
+            ),
+        ),
+    ],
+)
+def test_invalid_hostname(hostname: str) -> None:
+    with pytest.raises(InputFailure):
+        HostName.parse_or_raise(hostname)
+
+    assert HostName.parse(hostname) is None
+
+
+MacAddressValidationFailure = pytest.mark.xfail(raises=InputFailure, strict=True)
 
 
 @pytest.mark.parametrize(
@@ -32,17 +136,17 @@ MacAddresValidationFailure = pytest.mark.xfail(raises=InputFailure, strict=True)
         ("a1b2.c3d4.e5f6", "a1:b2:c3:d4:e5:f6"),
         ("Ab12.cD34.eF56", "ab:12:cd:34:ef:56"),
         # Invalid mac addresses
-        pytest.param("00:00:00:00:00:00:00", "", marks=MacAddresValidationFailure),
-        pytest.param("00:00:00:00:00", "", marks=MacAddresValidationFailure),
-        pytest.param("00:00:00:00:00:0", "", marks=MacAddresValidationFailure),
-        pytest.param("00:00:00:00:00:0g", "", marks=MacAddresValidationFailure),
-        pytest.param("00-00-00-00-00-00:00", "", marks=MacAddresValidationFailure),
-        pytest.param("00-00-00-00-00", "", marks=MacAddresValidationFailure),
-        pytest.param("00-00-00-00-00-0", "", marks=MacAddresValidationFailure),
-        pytest.param("00-00-00-00-00-0g", "", marks=MacAddresValidationFailure),
-        pytest.param("ab:cd:ef:12:34", "", marks=MacAddresValidationFailure),
-        pytest.param("ab-cd-ef-12-34", "", marks=MacAddresValidationFailure),
-        pytest.param("abcd.ef12.34", "", marks=MacAddresValidationFailure),
+        pytest.param("00:00:00:00:00:00:00", "", marks=MacAddressValidationFailure),
+        pytest.param("00:00:00:00:00", "", marks=MacAddressValidationFailure),
+        pytest.param("00:00:00:00:00:0", "", marks=MacAddressValidationFailure),
+        pytest.param("00:00:00:00:00:0g", "", marks=MacAddressValidationFailure),
+        pytest.param("00-00-00-00-00-00:00", "", marks=MacAddressValidationFailure),
+        pytest.param("00-00-00-00-00", "", marks=MacAddressValidationFailure),
+        pytest.param("00-00-00-00-00-0", "", marks=MacAddressValidationFailure),
+        pytest.param("00-00-00-00-00-0g", "", marks=MacAddressValidationFailure),
+        pytest.param("ab:cd:ef:12:34", "", marks=MacAddressValidationFailure),
+        pytest.param("ab-cd-ef-12-34", "", marks=MacAddressValidationFailure),
+        pytest.param("abcd.ef12.34", "", marks=MacAddressValidationFailure),
     ],
 )
 def test_mac_address_type(inp: str, expect: str) -> None:


### PR DESCRIPTION
Replaces models such as `HostT`, `IPAddressField` and `MacAddressField` with simpler custom types that Pydantic understands how to validate and serialize. It also makes them easier to use in the application, since we don't have to access the internal field of the model i.e. `HostT.hostname`, `IPAddressField.address`, etc. whenever we want to use it.

At runtime, the new `HostName` and `MacAddress` types are just string subclasses, while `IP_AddressT`, which we already use throughout the application, is a union of `ipaddress.IPv4Address` and `ipaddress.IPv6Address`. We can differentiate between the two IP types with the `.version` property.

## String types

New types:

- `mreg_cli.api.fields.MacAddress`
- `mreg_cli.api.fields.HostName`

These new types allow us to define functions that take in `HostName`, `MacAddress`, etc. instead of strings, so that we know we are operating on a valid value, while still having the ease of use of working with strings directly instead of through a proxy class.

## IP types

As mentioned in the introduction, we now operate on `IPv{4,6}Address` types directly, which we validate through `NetworkOrIP.parse(..., mode="ip")`, instead of having parallel interface for _just_ IP validation in the former `IPAddressField`.

## Benefits of this PR

By using the correct types directly in the model definitions, the models will serialize more cleanly. This is important want to tackle JSON output, since the new types serialize to basic types such as `str` instead of a nested dict containing a single key (`address`, `hostname`, etc.). It also removes a lot of custom field validators that were necessary to make these models work previously.

It also improves the ergonomics of these types in development, since, as mentioned, hostnames and mac addresses are just strings now (but with the benefit of being different from regular strings from the type checker's perspective).