### PR TITLE
Validation error handling

### DIFF
--- a/mreg_cli/exceptions.py
+++ b/mreg_cli/exceptions.py
@@ -178,6 +178,13 @@ class ValidationError(CliError):
         err_msg = f"{msg}\n  Input: {inp}\n  Errors:\n" + "\n\n".join(errors)
         return cls(err_msg, e)
 
+    def log(self):
+        """Log the exception with traceback."""
+        from mreg_cli.outputmanager import OutputManager
+
+        logger.exception(str(self), stack_info=True, exc_info=self)
+        OutputManager().add_error(str(self))
+
 
 class FileError(CliError):
     """Error class for file errors."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ import pytest
 from pytest_httpserver import HTTPServer
 
 from mreg_cli.config import MregCliConfig
+from mreg_cli.utilities.api import last_request_method, last_request_url
 
 
 @pytest.fixture(autouse=True)
@@ -53,3 +54,12 @@ def empty_config() -> Iterator[MregCliConfig]:
     conf._config_env = {}
     conf._config_file = {}
     yield conf
+
+
+@pytest.fixture(autouse=True)
+def reset_context_vars() -> Iterator[None]:
+    """Reset all context variables after each test."""
+    yield
+
+    last_request_method.set(None)
+    last_request_url.set(None)

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,115 @@
+from inline_snapshot import snapshot
+from pydantic import ValidationError as PydanticValidationError
+import pytest
+
+from mreg_cli.api.models import Host
+from mreg_cli.config import MregCliConfig
+from mreg_cli.exceptions import ValidationError
+
+
+from pytest_httpserver import HTTPServer
+
+from mreg_cli.utilities.api import get
+
+
+def test_validation_error_get_host(httpserver: HTTPServer) -> None:
+    """Test a validation error stemming from a GET request."""
+    MregCliConfig()._config_cmd["url"] = httpserver.url_for("/")
+
+    httpserver.expect_oneshot_request("/hosts/foobar").respond_with_json(
+        {
+            "created_at": "2022-06-16T09:15:40.775601+02:00",
+            "updated_at": "2024-01-26T10:23:06.631486+01:00",
+            "id": 76036,
+            "name": "_.--host123_example.com",  # invalid name
+            "ipaddresses": [
+                {
+                    "host": 76036,
+                    "created_at": "2022-06-16T09:47:43.761478+02:00",
+                    "updated_at": "2022-06-16T12:20:40.722808+02:00",
+                    "id": 78492,
+                    "macaddress": "e4:54:e8:80:73:73",
+                    "ipaddress": "192.168.0.1",
+                }
+            ],
+            "cnames": [],
+            "mxs": [],
+            "txts": [],
+            "ptr_overrides": [],
+            "hinfo": None,
+            "loc": None,
+            "bacnetid": None,
+            "contact": "user@example.com",
+            "ttl": None,
+            "comment": "",
+            "zone": 5,
+        }
+    )
+    resp = get("/hosts/foobar")
+    with pytest.raises(PydanticValidationError) as exc_info:
+        Host.model_validate_json(resp.text)
+
+    assert exc_info.value.error_count() == snapshot(1)
+    assert [repr(err) for err in exc_info.value.errors(include_url=False)] == snapshot(
+        [
+            "{'type': 'value_error', 'loc': ('name', 'hostname'), 'msg': 'Value error, Invalid input for hostname: _.--host123_example.com', 'input': '_.--host123_example.com', 'ctx': {'error': InputFailure('Invalid input for hostname: _.--host123_example.com')}}"
+        ]
+    )
+
+    validationerror = ValidationError.from_pydantic(exc_info.value)
+
+    # port-number is non-determinstic, so we need to replace that before comparing
+    err = validationerror.args[0].replace(f":{httpserver.port}", ":12345")
+    assert err == snapshot(
+        """\
+Failed to validate Host response from GET http://localhost:12345/hosts/foobar
+  Input: _.--host123_example.com
+  Errors:
+    Field: name, hostname
+    Reason: Value error, Invalid input for hostname: _.--host123_example.com\
+"""
+    )
+
+
+def test_validation_error_no_request() -> None:
+    """Test a validation error that did not originate from an API request."""
+    with pytest.raises(PydanticValidationError) as exc_info:
+        Host.model_validate({"name": "test"})  # Missing required fields
+
+    assert exc_info.value.error_count() == snapshot(6)
+    assert [repr(err) for err in exc_info.value.errors(include_url=False)] == snapshot(
+        [
+            "{'type': 'missing', 'loc': ('created_at',), 'msg': 'Field required', 'input': {'name': 'test'}}",
+            "{'type': 'missing', 'loc': ('updated_at',), 'msg': 'Field required', 'input': {'name': 'test'}}",
+            "{'type': 'missing', 'loc': ('id',), 'msg': 'Field required', 'input': {'name': 'test'}}",
+            "{'type': 'missing', 'loc': ('ipaddresses',), 'msg': 'Field required', 'input': {'name': 'test'}}",
+            "{'type': 'missing', 'loc': ('contact',), 'msg': 'Field required', 'input': {'name': 'test'}}",
+            "{'type': 'missing', 'loc': ('comment',), 'msg': 'Field required', 'input': {'name': 'test'}}",
+        ]
+    )
+
+    validationerror = ValidationError.from_pydantic(exc_info.value)
+    assert validationerror.args[0] == snapshot(
+        """\
+Failed to validate Host
+  Input: {'name': 'test'}
+  Errors:
+    Field: created_at
+    Reason: Field required
+
+    Field: updated_at
+    Reason: Field required
+
+    Field: id
+    Reason: Field required
+
+    Field: ipaddresses
+    Reason: Field required
+
+    Field: contact
+    Reason: Field required
+
+    Field: comment
+    Reason: Field required\
+"""
+    )

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -71,7 +71,7 @@ Failed to validate Host response from GET http://localhost:12345/hosts/foobar
     )
 
 
-def test_validation_error_no_request() -> None:
+def test_validation_error_no_request(caplog, capsys) -> None:
     """Test a validation error that did not originate from an API request."""
     with pytest.raises(PydanticValidationError) as exc_info:
         Host.model_validate({"name": "test"})  # Missing required fields
@@ -111,5 +111,65 @@ Failed to validate Host
 
     Field: comment
     Reason: Field required\
+"""
+    )
+
+    # Call method and check output
+    validationerror.print_and_log()
+
+    assert caplog.record_tuples == snapshot(
+        [
+            (
+                "mreg_cli.exceptions",
+                40,
+                """\
+Failed to validate Host
+  Input: {'name': 'test'}
+  Errors:
+    Field: created_at
+    Reason: Field required
+
+    Field: updated_at
+    Reason: Field required
+
+    Field: id
+    Reason: Field required
+
+    Field: ipaddresses
+    Reason: Field required
+
+    Field: contact
+    Reason: Field required
+
+    Field: comment
+    Reason: Field required\
+""",
+            )
+        ]
+    )
+
+    out, err = capsys.readouterr()
+    assert out == snapshot(
+        """\
+ERROR: Failed to validate Host\r
+  Input: {'name': 'test'}\r
+  Errors:\r
+    Field: created_at\r
+    Reason: Field required\r
+\r
+    Field: updated_at\r
+    Reason: Field required\r
+\r
+    Field: id\r
+    Reason: Field required\r
+\r
+    Field: ipaddresses\r
+    Reason: Field required\r
+\r
+    Field: contact\r
+    Reason: Field required\r
+\r
+    Field: comment\r
+    Reason: Field required\r
 """
     )

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -52,7 +52,7 @@ def test_validation_error_get_host(httpserver: HTTPServer) -> None:
     assert exc_info.value.error_count() == snapshot(1)
     assert [repr(err) for err in exc_info.value.errors(include_url=False)] == snapshot(
         [
-            "{'type': 'value_error', 'loc': ('name', 'hostname'), 'msg': 'Value error, Invalid input for hostname: _.--host123_example.com', 'input': '_.--host123_example.com', 'ctx': {'error': InputFailure('Invalid input for hostname: _.--host123_example.com')}}"
+            "{'type': 'value_error', 'loc': ('name',), 'msg': 'Value error, Invalid input for hostname: _.--host123_example.com', 'input': '_.--host123_example.com', 'ctx': {'error': InputFailure('Invalid input for hostname: _.--host123_example.com')}}"
         ]
     )
 
@@ -65,7 +65,7 @@ def test_validation_error_get_host(httpserver: HTTPServer) -> None:
 Failed to validate Host response from GET http://localhost:12345/hosts/foobar
   Input: _.--host123_example.com
   Errors:
-    Field: name, hostname
+    Field: name
     Reason: Value error, Invalid input for hostname: _.--host123_example.com\
 """
     )


### PR DESCRIPTION
This PR adds handling of Pydantic validation errors to the application, ensuring that such errors are printed and logged, and also prevents the application from crashing when such an exception is raised.

## Custom error messages

Instead of displaying the default verbose Pydantic validation error, we construct our own more concise version.

### With URL

When we have a validation error that happens as a result of failed validation of an API response, we show the request method and URL in the error message:

```
super@mreg-dev.uio.no> host info auspex
ERROR: Failed to validate Host response from GET https://mreg-dev.uio.no/api/v1/hosts/auspex.uio.no
  Input: foo
  Errors:
    Field: id
    Reason: Input should be a valid integer, unable to parse string as an integer
```

In this example, I simply patched the value of `"id"` in the response JSON to trigger the error:

```py
data["id"] = "foo"
```

### Without URL

If a validation error happens before we have made any requests in the current command invocation context, we omit the method and URL:

```
super@mreg-dev.uio.no> host info auspex
ERROR: Failed to validate Host
  Input: {'name': 'foo'}
  Errors:
    Field: created_at
    Reason: Field required

    Field: updated_at
    Reason: Field required

    Field: id
    Reason: Field required

    Field: ipaddresses
    Reason: Field required

    Field: contact
    Reason: Field required

    Field: comment
    Reason: Field required
```

In this example, I tried to construct a Host missing a number of required fields before sending any requests:

```py
    Host(name="foo") # exception is raised here
    for host in args.hosts:
        Host.get_by_any_means_or_raise(host, inform_as_cname=True).output(
            traverse_hostgroups=args.traverse_hostgroups
        )
```


## Context vars

To keep track of the last request method + url, this PR introduces 2 [`ContextVar`](https://docs.python.org/3.12/library/contextvars.html#contextvars.ContextVar) objects in `mreg_cli.utilities.api` named `last_request_url` and `last_request_method`.

The benefit of `ContextVar` over globals is that they are thread-safe and asyncio-compatible. If we introduce some sort of concurrency via threads or asyncio, we can be confident that threads or tasks cannot clobber each other's `last_request_url` and `last_request_method`.