### PR TITLE
Disable uniqueness check by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- `dhcp assoc` command displaying unique constraint error instead of a proper error message when a MAC is already associated with an IP.
+
+### Changed
+
+- Disabled uniqueness check for various commands that fetch from endpoints with a key-value query parameter. This was overly strict and caused cryptic errors to be printed when it failed.
 
 ## [1.2.1](https://github.com/unioslo/mreg-cli/releases/tag/1.2.1) - 2024-12-02
 


### PR DESCRIPTION
This PR disables the uniqueness check in `get_list_unique` and just returns the first result by default. The old behavior can be enabled with the new `expect_one_result` parameter for `get_list_unique`.