### PR TITLE
Refactor MAC to IP association checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+- `dhcp assoc` and `host add` commands displaying unique constraint error instead of a proper error message when a MAC is already associated with an IP.
 
 ## [1.2.1](https://github.com/unioslo/mreg-cli/releases/tag/1.2.1) - 2024-12-02
 

--- a/ci/testsuite-result.json
+++ b/ci/testsuite-result.json
@@ -27485,7 +27485,7 @@
     "command_issued": "host add -ip 10.0.0.0/24 -macaddress aa:bb:cc:cc:bb:aa directfail",
     "ok": [],
     "warning": [
-      "MAC address aa:bb:cc:cc:bb:aa is already associated with 10.0.0.4"
+      "MAC address aa:bb:cc:cc:bb:aa is already associated with IP address 10.0.0.184, must force."
     ],
     "error": [],
     "output": [],
@@ -27502,7 +27502,7 @@
           "results": [
             {
               "macaddress": "aa:bb:cc:cc:bb:aa",
-              "ipaddress": "10.0.0.4",
+              "ipaddress": "10.0.0.184",
               "host": 18
             }
           ]

--- a/mreg_cli/api/models.py
+++ b/mreg_cli/api/models.py
@@ -1992,9 +1992,9 @@ class IPAddress(FrozenModelWithTimestamps, WithHost, APIMixin):
 
     @classmethod
     def ensure_associable(cls, mac: MacAddress, force: bool) -> None:
-        """Check if a MAC address can be associated with this IP address.
+        """Check if a MAC address is available to be associated with an IP address.
 
-        Raise an exception if the MAC address is already associated with another IP address,
+        Raise an exception if the MAC address is already associated with an IP address,
         and force is not set.
 
         :param mac: The MAC address to check.

--- a/mreg_cli/api/models.py
+++ b/mreg_cli/api/models.py
@@ -1992,11 +1992,15 @@ class IPAddress(FrozenModelWithTimestamps, WithHost, APIMixin):
 
     @classmethod
     def ensure_associable(cls, mac: MacAddress, force: bool) -> None:
-        """Check if the MAC address can be associated with this IP address.
+        """Check if a MAC address can be associated with this IP address.
+
+        Raise an exception if the MAC address is already associated with another IP address,
+        and force is not set.
 
         :param mac: The MAC address to check.
         :param force: Force is active. If True, the check is skipped.
-        :raises EntityAlreadyExists: If the MAC address is already associated with one or more IPs.
+        :raises EntityAlreadyExists: If the MAC address is already associated with one IP.
+        :raises MultipleEntitiesFound: If the MAC address is already associated multiple IPs.
         """
         if force:
             return

--- a/mreg_cli/api/models.py
+++ b/mreg_cli/api/models.py
@@ -1996,7 +1996,7 @@ class IPAddress(FrozenModelWithTimestamps, WithHost, APIMixin):
 
         :param mac: The MAC address to check.
         :param force: Force is active. If True, the check is skipped.
-        :raises EntityAlreadyExists: If the MAC address is already associated with an IP address.
+        :raises EntityAlreadyExists: If the MAC address is already associated with one or more IPs.
         """
         if force:
             return
@@ -2073,7 +2073,10 @@ class IPAddress(FrozenModelWithTimestamps, WithHost, APIMixin):
 
         :returns: A new IPAddress object fetched from the API with the updated MAC address.
         """
-        self.ensure_associable(mac, force=force)
+        if self.macaddress and not force:
+            raise EntityAlreadyExists(
+                f"IP address {self.ipaddress} already has MAC address {self.macaddress}."
+            )
         return self.patch(fields={"macaddress": mac})
 
     def disassociate_mac(self) -> IPAddress:

--- a/mreg_cli/commands/dhcp.py
+++ b/mreg_cli/commands/dhcp.py
@@ -70,6 +70,7 @@ def assoc(args: argparse.Namespace) -> None:
     force: bool = args.force
 
     mac = MacAddress.parse_or_raise(mac)
+    IPAddress.ensure_associable(mac, force=force)
 
     ipaddress = ipaddress_from_ip_arg(name)
     if not ipaddress:

--- a/mreg_cli/commands/dhcp.py
+++ b/mreg_cli/commands/dhcp.py
@@ -70,9 +70,6 @@ def assoc(args: argparse.Namespace) -> None:
     force: bool = args.force
 
     mac = MacAddress.parse_or_raise(mac)
-    in_use = IPAddress.get_by_mac(mac)
-    if in_use:
-        raise InputFailure(f"MAC {mac} is already in use by {in_use.ipaddress}.")
 
     ipaddress = ipaddress_from_ip_arg(name)
     if not ipaddress:

--- a/mreg_cli/commands/host_submodules/core.py
+++ b/mreg_cli/commands/host_submodules/core.py
@@ -96,6 +96,7 @@ def add(args: argparse.Namespace) -> None:
 
     if macaddress is not None:
         macaddress = MacAddress.parse_or_raise(macaddress)
+        IPAddress.ensure_associable(macaddress, force=force)
 
     host = Host.get_by_any_means(hname)
     if host:


### PR DESCRIPTION
Alternative to #360 to fix MAC to IP association checks.

This solves the same issue by fetching mac addresses via `get_list_by_field`, so we can inform the user about _all_ the IP addresses associated with the MAC address.

However, I would still say this is just a band-aid fix, and sets us up for similar bugs in the future.