### PR TITLE
Accept changes to test results

### DIFF
--- a/ci/diff.py
+++ b/ci/diff.py
@@ -126,7 +126,7 @@ def preprocess_json(s: str) -> str:
 
     # Replace all non-deterministic values with placeholders
     s = timestamp_pattern.sub("<TIME>", s)
-    s = datetime_str_pattern.sub("<TIME>", s)
+    s = datetime_str_pattern.sub("<DATETIME>", s)
     s = serial_pattern.sub("Serial: <NUMBER>", s)
     s = mac_pattern.sub("<macaddress>", s)
     s = ipv4_pattern.sub("<IPv4>", s)

--- a/ci/testsuite-result.json
+++ b/ci/testsuite-result.json
@@ -91,13 +91,18 @@
         "response": {
           "nameservers": [
             {
+              "created_at": "2024-12-11T16:44:39.714536+01:00",
+              "updated_at": "2024-12-11T16:44:39.714557+01:00",
               "name": "ns1.example.org",
               "ttl": null
             }
           ],
+          "created_at": "2024-12-11T16:44:39.701254+01:00",
+          "updated_at": "2024-12-11T16:44:39.734053+01:00",
           "updated": true,
           "primary_ns": "ns1.example.org",
           "email": "hostmaster@example.org",
+          "serialno_updated_at": "2024-12-11T16:44:39.700924+01:00",
           "refresh": 10800,
           "retry": 3600,
           "expire": 1814400,
@@ -118,17 +123,17 @@
     "warning": [],
     "error": [],
     "output": [
-      "Name: example.org",
-      " Nameservers: hostname TTL",
-      " ns1.example.org <not set>",
-      "Primary NS: ns1.example.org",
-      "Email: hostmaster@example.org",
-      "Serial: <NUMBER>",
-      "Refresh: 10800",
-      "Retry: 3600",
-      "Expire: 1814400",
-      "SOA TTL: 43200",
-      "Default TTL: 43200"
+      "Name:               example.org",
+      "        Nameservers:        hostname            TTL",
+      "                            ns1.example.org     <not set>",
+      "Primary NS:         ns1.example.org",
+      "Email:              hostmaster@example.org",
+      "Serial:             3241211000",
+      "Refresh:            10800",
+      "Retry:              3600",
+      "Expire:             1814400",
+      "SOA TTL:            43200",
+      "Default TTL:        43200"
     ],
     "api_requests": [
       {
@@ -139,13 +144,18 @@
         "response": {
           "nameservers": [
             {
+              "created_at": "2024-12-11T16:44:39.714536+01:00",
+              "updated_at": "2024-12-11T16:44:39.714557+01:00",
               "name": "ns1.example.org",
               "ttl": null
             }
           ],
+          "created_at": "2024-12-11T16:44:39.701254+01:00",
+          "updated_at": "2024-12-11T16:44:39.734053+01:00",
           "updated": true,
           "primary_ns": "ns1.example.org",
           "email": "hostmaster@example.org",
+          "serialno_updated_at": "2024-12-11T16:44:39.700924+01:00",
           "refresh": 10800,
           "retry": 3600,
           "expire": 1814400,
@@ -183,13 +193,18 @@
             {
               "nameservers": [
                 {
+                  "created_at": "2024-12-11T16:44:39.714536+01:00",
+                  "updated_at": "2024-12-11T16:44:39.714557+01:00",
                   "name": "ns1.example.org",
                   "ttl": null
                 }
               ],
+              "created_at": "2024-12-11T16:44:39.701254+01:00",
+              "updated_at": "2024-12-11T16:44:39.734053+01:00",
               "updated": true,
               "primary_ns": "ns1.example.org",
               "email": "hostmaster@example.org",
+              "serialno_updated_at": "2024-12-11T16:44:39.700924+01:00",
               "refresh": 10800,
               "retry": 3600,
               "expire": 1814400,
@@ -223,13 +238,18 @@
         "response": {
           "nameservers": [
             {
+              "created_at": "2024-12-11T16:44:39.714536+01:00",
+              "updated_at": "2024-12-11T16:44:39.714557+01:00",
               "name": "ns1.example.org",
               "ttl": null
             }
           ],
+          "created_at": "2024-12-11T16:44:39.701254+01:00",
+          "updated_at": "2024-12-11T16:44:39.734053+01:00",
           "updated": true,
           "primary_ns": "ns1.example.org",
           "email": "hostmaster@example.org",
+          "serialno_updated_at": "2024-12-11T16:44:39.700924+01:00",
           "refresh": 10800,
           "retry": 3600,
           "expire": 1814400,
@@ -279,13 +299,18 @@
         "response": {
           "nameservers": [
             {
+              "created_at": "2024-12-11T16:44:39.714536+01:00",
+              "updated_at": "2024-12-11T16:44:39.714557+01:00",
               "name": "ns1.example.org",
               "ttl": null
             }
           ],
+          "created_at": "2024-12-11T16:44:39.701254+01:00",
+          "updated_at": "2024-12-11T16:44:39.734053+01:00",
           "updated": true,
           "primary_ns": "ns1.example.org",
           "email": "hostmaster@example.org",
+          "serialno_updated_at": "2024-12-11T16:44:39.700924+01:00",
           "refresh": 10800,
           "retry": 3600,
           "expire": 1814400,
@@ -345,13 +370,18 @@
         "response": {
           "nameservers": [
             {
+              "created_at": "2024-12-11T16:44:40.356452+01:00",
+              "updated_at": "2024-12-11T16:44:40.356481+01:00",
               "name": "ns2.example.org",
               "ttl": null
             }
           ],
+          "created_at": "2024-12-11T16:44:39.701254+01:00",
+          "updated_at": "2024-12-11T16:44:40.381405+01:00",
           "updated": true,
           "primary_ns": "ns2.example.org",
           "email": "hostmaster@example.org",
+          "serialno_updated_at": "2024-12-11T16:44:39.700924+01:00",
           "refresh": 10800,
           "retry": 3600,
           "expire": 1814400,
@@ -386,13 +416,18 @@
             {
               "nameservers": [
                 {
+                  "created_at": "2024-12-11T16:44:40.356452+01:00",
+                  "updated_at": "2024-12-11T16:44:40.356481+01:00",
                   "name": "ns2.example.org",
                   "ttl": null
                 }
               ],
+              "created_at": "2024-12-11T16:44:39.701254+01:00",
+              "updated_at": "2024-12-11T16:44:40.481572+01:00",
               "updated": true,
               "primary_ns": "ns2.example.org",
               "email": "hostperson@example.org",
+              "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
               "refresh": 360,
               "retry": 1800,
               "expire": 2400,
@@ -426,13 +461,18 @@
         "response": {
           "nameservers": [
             {
+              "created_at": "2024-12-11T16:44:40.356452+01:00",
+              "updated_at": "2024-12-11T16:44:40.356481+01:00",
               "name": "ns2.example.org",
               "ttl": null
             }
           ],
+          "created_at": "2024-12-11T16:44:39.701254+01:00",
+          "updated_at": "2024-12-11T16:44:40.481572+01:00",
           "updated": true,
           "primary_ns": "ns2.example.org",
           "email": "hostperson@example.org",
+          "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
           "refresh": 360,
           "retry": 1800,
           "expire": 2400,
@@ -464,13 +504,18 @@
         "response": {
           "nameservers": [
             {
+              "created_at": "2024-12-11T16:44:40.356452+01:00",
+              "updated_at": "2024-12-11T16:44:40.356481+01:00",
               "name": "ns2.example.org",
               "ttl": null
             }
           ],
+          "created_at": "2024-12-11T16:44:39.701254+01:00",
+          "updated_at": "2024-12-11T16:44:40.481572+01:00",
           "updated": true,
           "primary_ns": "ns2.example.org",
           "email": "hostperson@example.org",
+          "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
           "refresh": 360,
           "retry": 1800,
           "expire": 2400,
@@ -500,13 +545,18 @@
             {
               "nameservers": [
                 {
+                  "created_at": "2024-12-11T16:44:40.356452+01:00",
+                  "updated_at": "2024-12-11T16:44:40.356481+01:00",
                   "name": "ns2.example.org",
                   "ttl": null
                 }
               ],
+              "created_at": "2024-12-11T16:44:39.701254+01:00",
+              "updated_at": "2024-12-11T16:44:40.710848+01:00",
               "updated": true,
               "primary_ns": "ns2.example.org",
               "email": "hostperson@example.org",
+              "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
               "refresh": 360,
               "retry": 1800,
               "expire": 2400,
@@ -561,6 +611,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:44:40.886409+01:00",
+          "updated_at": "2024-12-11T16:44:40.886433+01:00",
           "network": "10.0.2.0/28",
           "description": "TinyNet",
           "vlan": null,
@@ -593,6 +645,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:44:40.886409+01:00",
+          "updated_at": "2024-12-11T16:44:40.886433+01:00",
           "network": "10.0.2.0/28",
           "description": "TinyNet",
           "vlan": null,
@@ -649,6 +703,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:44:40.886409+01:00",
+          "updated_at": "2024-12-11T16:44:40.886433+01:00",
           "network": "10.0.2.0/28",
           "description": "TinyNet",
           "vlan": null,
@@ -700,6 +756,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:44:40.886409+01:00",
+          "updated_at": "2024-12-11T16:44:40.886433+01:00",
           "network": "10.0.2.0/28",
           "description": "TinyNet",
           "vlan": null,
@@ -730,6 +788,8 @@
           "results": [
             {
               "excluded_ranges": [],
+              "created_at": "2024-12-11T16:44:40.886409+01:00",
+              "updated_at": "2024-12-11T16:44:41.314670+01:00",
               "network": "10.0.2.0/28",
               "description": "TinyNet",
               "vlan": null,
@@ -762,8 +822,8 @@
       "              10.0.2.9      <not set>",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Tue Oct  8 15:31:14 2024",
-      "Updated:      Tue Oct  8 15:31:14 2024"
+      "Created:      Wed Dec 11 16:44:41 2024",
+      "Updated:      Wed Dec 11 16:44:41 2024"
     ],
     "api_requests": [
       {
@@ -793,13 +853,18 @@
           "zone": {
             "nameservers": [
               {
+                "created_at": "2024-12-11T16:44:40.356452+01:00",
+                "updated_at": "2024-12-11T16:44:40.356481+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
+            "created_at": "2024-12-11T16:44:39.701254+01:00",
+            "updated_at": "2024-12-11T16:44:40.710848+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
+            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -816,6 +881,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:44:40.886409+01:00",
+          "updated_at": "2024-12-11T16:44:41.314670+01:00",
           "network": "10.0.2.0/28",
           "description": "TinyNet",
           "vlan": null,
@@ -845,6 +912,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:44:41.709138+01:00",
+              "updated_at": "2024-12-11T16:44:41.709149+01:00",
               "ipaddress": "10.0.2.9",
               "host": 1
             }
@@ -853,6 +922,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:44:41.688378+01:00",
+              "updated_at": "2024-12-11T16:44:41.688391+01:00",
               "txt": "v=spf1 -all",
               "host": 1
             }
@@ -861,6 +932,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:44:41.683671+01:00",
+          "updated_at": "2024-12-11T16:44:41.683683+01:00",
           "name": "tinyhost.example.org",
           "contact": "tinyhost@example.org",
           "ttl": null,
@@ -950,6 +1023,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:44:40.886409+01:00",
+          "updated_at": "2024-12-11T16:44:41.314670+01:00",
           "network": "10.0.2.0/28",
           "description": "TinyNet",
           "vlan": null,
@@ -1004,6 +1079,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:44:40.886409+01:00",
+          "updated_at": "2024-12-11T16:44:41.314670+01:00",
           "network": "10.0.2.0/28",
           "description": "TinyNet",
           "vlan": null,
@@ -1051,6 +1128,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:44:41.709138+01:00",
+              "updated_at": "2024-12-11T16:44:41.709149+01:00",
               "ipaddress": "10.0.2.9",
               "host": 1
             }
@@ -1059,6 +1138,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:44:41.688378+01:00",
+              "updated_at": "2024-12-11T16:44:41.688391+01:00",
               "txt": "v=spf1 -all",
               "host": 1
             }
@@ -1067,6 +1148,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:44:41.683671+01:00",
+          "updated_at": "2024-12-11T16:44:41.683683+01:00",
           "name": "tinyhost.example.org",
           "contact": "tinyhost@example.org",
           "ttl": null,
@@ -1126,6 +1209,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:44:40.886409+01:00",
+          "updated_at": "2024-12-11T16:44:41.314670+01:00",
           "network": "10.0.2.0/28",
           "description": "TinyNet",
           "vlan": null,
@@ -1193,6 +1278,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:44:42.899068+01:00",
+          "updated_at": "2024-12-11T16:44:42.899085+01:00",
           "network": "2001:db8::/64",
           "description": "Lorem ipsum dolor sit amet",
           "vlan": null,
@@ -1225,6 +1312,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:44:42.899068+01:00",
+          "updated_at": "2024-12-11T16:44:42.899085+01:00",
           "network": "2001:db8::/64",
           "description": "Lorem ipsum dolor sit amet",
           "vlan": null,
@@ -5366,6 +5455,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:44:42.899068+01:00",
+          "updated_at": "2024-12-11T16:44:42.899085+01:00",
           "network": "2001:db8::/64",
           "description": "Lorem ipsum dolor sit amet",
           "vlan": null,
@@ -9502,6 +9593,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:44:42.899068+01:00",
+          "updated_at": "2024-12-11T16:44:42.899085+01:00",
           "network": "2001:db8::/64",
           "description": "Lorem ipsum dolor sit amet",
           "vlan": null,
@@ -9532,6 +9625,8 @@
           "results": [
             {
               "excluded_ranges": [],
+              "created_at": "2024-12-11T16:44:42.899068+01:00",
+              "updated_at": "2024-12-11T16:44:43.431469+01:00",
               "network": "2001:db8::/64",
               "description": "Lorem ipsum dolor sit amet",
               "vlan": null,
@@ -9564,8 +9659,8 @@
       "              2001:db8::33  <not set>",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Tue Oct  8 15:31:14 2024",
-      "Updated:      Tue Oct  8 15:31:14 2024"
+      "Created:      Wed Dec 11 16:44:43 2024",
+      "Updated:      Wed Dec 11 16:44:43 2024"
     ],
     "api_requests": [
       {
@@ -9595,13 +9690,18 @@
           "zone": {
             "nameservers": [
               {
+                "created_at": "2024-12-11T16:44:40.356452+01:00",
+                "updated_at": "2024-12-11T16:44:40.356481+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
+            "created_at": "2024-12-11T16:44:39.701254+01:00",
+            "updated_at": "2024-12-11T16:44:42.599830+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
+            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -9618,6 +9718,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:44:42.899068+01:00",
+          "updated_at": "2024-12-11T16:44:43.431469+01:00",
           "network": "2001:db8::/64",
           "description": "Lorem ipsum dolor sit amet",
           "vlan": null,
@@ -9647,6 +9749,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:44:43.799845+01:00",
+              "updated_at": "2024-12-11T16:44:43.799865+01:00",
               "ipaddress": "2001:db8::33",
               "host": 2
             }
@@ -9655,6 +9759,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:44:43.765364+01:00",
+              "updated_at": "2024-12-11T16:44:43.765383+01:00",
               "txt": "v=spf1 -all",
               "host": 2
             }
@@ -9663,6 +9769,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:44:43.759890+01:00",
+          "updated_at": "2024-12-11T16:44:43.759911+01:00",
           "name": "tinyhost.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -9754,6 +9862,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:44:43.799845+01:00",
+              "updated_at": "2024-12-11T16:44:43.799865+01:00",
               "ipaddress": "2001:db8::33",
               "host": 2
             }
@@ -9762,6 +9872,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:44:43.765364+01:00",
+              "updated_at": "2024-12-11T16:44:43.765383+01:00",
               "txt": "v=spf1 -all",
               "host": 2
             }
@@ -9770,6 +9882,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:44:43.759890+01:00",
+          "updated_at": "2024-12-11T16:44:43.759911+01:00",
           "name": "tinyhost.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -9853,8 +9967,8 @@
       "              2001:db8::33  <not set>",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Tue Oct  8 15:31:14 2024",
-      "Updated:      Tue Oct  8 15:31:14 2024"
+      "Created:      Wed Dec 11 16:44:43 2024",
+      "Updated:      Wed Dec 11 16:44:43 2024"
     ],
     "api_requests": [
       {
@@ -9866,6 +9980,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:44:43.799845+01:00",
+              "updated_at": "2024-12-11T16:44:43.799865+01:00",
               "ipaddress": "2001:db8::33",
               "host": 2
             }
@@ -9874,6 +9990,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:44:43.765364+01:00",
+              "updated_at": "2024-12-11T16:44:43.765383+01:00",
               "txt": "v=spf1 -all",
               "host": 2
             }
@@ -9882,6 +10000,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:44:43.759890+01:00",
+          "updated_at": "2024-12-11T16:44:43.759911+01:00",
           "name": "tinyhost.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -9973,6 +10093,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:44:43.799845+01:00",
+              "updated_at": "2024-12-11T16:44:43.799865+01:00",
               "ipaddress": "2001:db8::33",
               "host": 2
             }
@@ -9981,6 +10103,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:44:43.765364+01:00",
+              "updated_at": "2024-12-11T16:44:43.765383+01:00",
               "txt": "v=spf1 -all",
               "host": 2
             }
@@ -9989,6 +10113,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:44:43.759890+01:00",
+          "updated_at": "2024-12-11T16:44:43.759911+01:00",
           "name": "tinyhost.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -10048,6 +10174,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:44:42.899068+01:00",
+          "updated_at": "2024-12-11T16:44:43.431469+01:00",
           "network": "2001:db8::/64",
           "description": "Lorem ipsum dolor sit amet",
           "vlan": null,
@@ -10115,6 +10243,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:44:45.393437+01:00",
+          "updated_at": "2024-12-11T16:44:45.393462+01:00",
           "network": "10.0.1.0/24",
           "description": "Frozzzen",
           "vlan": null,
@@ -10147,6 +10277,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:44:45.393437+01:00",
+          "updated_at": "2024-12-11T16:44:45.393462+01:00",
           "network": "10.0.1.0/24",
           "description": "Frozzzen",
           "vlan": null,
@@ -10177,6 +10309,8 @@
           "results": [
             {
               "excluded_ranges": [],
+              "created_at": "2024-12-11T16:44:45.393437+01:00",
+              "updated_at": "2024-12-11T16:44:45.582957+01:00",
               "network": "10.0.1.0/24",
               "description": "Frozzzen",
               "vlan": null,
@@ -10231,13 +10365,18 @@
           "zone": {
             "nameservers": [
               {
+                "created_at": "2024-12-11T16:44:40.356452+01:00",
+                "updated_at": "2024-12-11T16:44:40.356481+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
+            "created_at": "2024-12-11T16:44:39.701254+01:00",
+            "updated_at": "2024-12-11T16:44:45.067149+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
+            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -10254,6 +10393,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:44:45.393437+01:00",
+          "updated_at": "2024-12-11T16:44:45.582957+01:00",
           "network": "10.0.1.0/24",
           "description": "Frozzzen",
           "vlan": null,
@@ -10286,6 +10427,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:44:45.393437+01:00",
+          "updated_at": "2024-12-11T16:44:45.582957+01:00",
           "network": "10.0.1.0/24",
           "description": "Frozzzen",
           "vlan": null,
@@ -10348,13 +10491,18 @@
           "zone": {
             "nameservers": [
               {
+                "created_at": "2024-12-11T16:44:40.356452+01:00",
+                "updated_at": "2024-12-11T16:44:40.356481+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
+            "created_at": "2024-12-11T16:44:39.701254+01:00",
+            "updated_at": "2024-12-11T16:44:45.067149+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
+            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -10372,11 +10520,15 @@
         "response": {
           "excluded_ranges": [
             {
+              "created_at": "2024-12-11T16:44:45.955630+01:00",
+              "updated_at": "2024-12-11T16:44:45.955656+01:00",
               "start_ip": "10.0.1.20",
               "end_ip": "10.0.1.30",
               "network": 3
             }
           ],
+          "created_at": "2024-12-11T16:44:45.393437+01:00",
+          "updated_at": "2024-12-11T16:44:45.582957+01:00",
           "network": "10.0.1.0/24",
           "description": "Frozzzen",
           "vlan": null,
@@ -10422,8 +10574,8 @@
       "              10.0.1.4      <not set>",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Tue Oct  8 15:31:15 2024",
-      "Updated:      Tue Oct  8 15:31:15 2024"
+      "Created:      Wed Dec 11 16:44:46 2024",
+      "Updated:      Wed Dec 11 16:44:46 2024"
     ],
     "api_requests": [
       {
@@ -10453,13 +10605,18 @@
           "zone": {
             "nameservers": [
               {
+                "created_at": "2024-12-11T16:44:40.356452+01:00",
+                "updated_at": "2024-12-11T16:44:40.356481+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
+            "created_at": "2024-12-11T16:44:39.701254+01:00",
+            "updated_at": "2024-12-11T16:44:45.067149+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
+            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -10477,11 +10634,15 @@
         "response": {
           "excluded_ranges": [
             {
+              "created_at": "2024-12-11T16:44:45.955630+01:00",
+              "updated_at": "2024-12-11T16:44:45.955656+01:00",
               "start_ip": "10.0.1.20",
               "end_ip": "10.0.1.30",
               "network": 3
             }
           ],
+          "created_at": "2024-12-11T16:44:45.393437+01:00",
+          "updated_at": "2024-12-11T16:44:45.582957+01:00",
           "network": "10.0.1.0/24",
           "description": "Frozzzen",
           "vlan": null,
@@ -10511,6 +10672,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:44:46.560426+01:00",
+              "updated_at": "2024-12-11T16:44:46.560441+01:00",
               "ipaddress": "10.0.1.4",
               "host": 4
             }
@@ -10519,6 +10682,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:44:46.533402+01:00",
+              "updated_at": "2024-12-11T16:44:46.533419+01:00",
               "txt": "v=spf1 -all",
               "host": 4
             }
@@ -10527,6 +10692,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:44:46.528383+01:00",
+          "updated_at": "2024-12-11T16:44:46.528401+01:00",
           "name": "somehost.example.org",
           "contact": "support@example.org",
           "ttl": null,
@@ -10617,11 +10784,15 @@
         "response": {
           "excluded_ranges": [
             {
+              "created_at": "2024-12-11T16:44:45.955630+01:00",
+              "updated_at": "2024-12-11T16:44:45.955656+01:00",
               "start_ip": "10.0.1.20",
               "end_ip": "10.0.1.30",
               "network": 3
             }
           ],
+          "created_at": "2024-12-11T16:44:45.393437+01:00",
+          "updated_at": "2024-12-11T16:44:45.582957+01:00",
           "network": "10.0.1.0/24",
           "description": "Frozzzen",
           "vlan": null,
@@ -10673,11 +10844,15 @@
         "response": {
           "excluded_ranges": [
             {
+              "created_at": "2024-12-11T16:44:45.955630+01:00",
+              "updated_at": "2024-12-11T16:44:45.955656+01:00",
               "start_ip": "10.0.1.20",
               "end_ip": "10.0.1.30",
               "network": 3
             }
           ],
+          "created_at": "2024-12-11T16:44:45.393437+01:00",
+          "updated_at": "2024-12-11T16:44:45.582957+01:00",
           "network": "10.0.1.0/24",
           "description": "Frozzzen",
           "vlan": null,
@@ -10709,11 +10884,15 @@
             {
               "excluded_ranges": [
                 {
+                  "created_at": "2024-12-11T16:44:45.955630+01:00",
+                  "updated_at": "2024-12-11T16:44:45.955656+01:00",
                   "start_ip": "10.0.1.20",
                   "end_ip": "10.0.1.30",
                   "network": 3
                 }
               ],
+              "created_at": "2024-12-11T16:44:45.393437+01:00",
+              "updated_at": "2024-12-11T16:44:47.108747+01:00",
               "network": "10.0.1.0/24",
               "description": "Frozen but has one host",
               "vlan": null,
@@ -10749,11 +10928,15 @@
         "response": {
           "excluded_ranges": [
             {
+              "created_at": "2024-12-11T16:44:45.955630+01:00",
+              "updated_at": "2024-12-11T16:44:45.955656+01:00",
               "start_ip": "10.0.1.20",
               "end_ip": "10.0.1.30",
               "network": 3
             }
           ],
+          "created_at": "2024-12-11T16:44:45.393437+01:00",
+          "updated_at": "2024-12-11T16:44:47.108747+01:00",
           "network": "10.0.1.0/24",
           "description": "Frozen but has one host",
           "vlan": null,
@@ -10785,11 +10968,15 @@
             {
               "excluded_ranges": [
                 {
+                  "created_at": "2024-12-11T16:44:45.955630+01:00",
+                  "updated_at": "2024-12-11T16:44:45.955656+01:00",
                   "start_ip": "10.0.1.20",
                   "end_ip": "10.0.1.30",
                   "network": 3
                 }
               ],
+              "created_at": "2024-12-11T16:44:45.393437+01:00",
+              "updated_at": "2024-12-11T16:44:47.307856+01:00",
               "network": "10.0.1.0/24",
               "description": "Frozen but has one host",
               "vlan": null,
@@ -10825,11 +11012,15 @@
         "response": {
           "excluded_ranges": [
             {
+              "created_at": "2024-12-11T16:44:45.955630+01:00",
+              "updated_at": "2024-12-11T16:44:45.955656+01:00",
               "start_ip": "10.0.1.20",
               "end_ip": "10.0.1.30",
               "network": 3
             }
           ],
+          "created_at": "2024-12-11T16:44:45.393437+01:00",
+          "updated_at": "2024-12-11T16:44:47.307856+01:00",
           "network": "10.0.1.0/24",
           "description": "Frozen but has one host",
           "vlan": null,
@@ -10861,11 +11052,15 @@
             {
               "excluded_ranges": [
                 {
+                  "created_at": "2024-12-11T16:44:45.955630+01:00",
+                  "updated_at": "2024-12-11T16:44:45.955656+01:00",
                   "start_ip": "10.0.1.20",
                   "end_ip": "10.0.1.30",
                   "network": 3
                 }
               ],
+              "created_at": "2024-12-11T16:44:45.393437+01:00",
+              "updated_at": "2024-12-11T16:44:47.505945+01:00",
               "network": "10.0.1.0/24",
               "description": "Frozen but has one host",
               "vlan": null,
@@ -10901,11 +11096,15 @@
         "response": {
           "excluded_ranges": [
             {
+              "created_at": "2024-12-11T16:44:45.955630+01:00",
+              "updated_at": "2024-12-11T16:44:45.955656+01:00",
               "start_ip": "10.0.1.20",
               "end_ip": "10.0.1.30",
               "network": 3
             }
           ],
+          "created_at": "2024-12-11T16:44:45.393437+01:00",
+          "updated_at": "2024-12-11T16:44:47.505945+01:00",
           "network": "10.0.1.0/24",
           "description": "Frozen but has one host",
           "vlan": null,
@@ -10937,11 +11136,15 @@
             {
               "excluded_ranges": [
                 {
+                  "created_at": "2024-12-11T16:44:45.955630+01:00",
+                  "updated_at": "2024-12-11T16:44:45.955656+01:00",
                   "start_ip": "10.0.1.20",
                   "end_ip": "10.0.1.30",
                   "network": 3
                 }
               ],
+              "created_at": "2024-12-11T16:44:45.393437+01:00",
+              "updated_at": "2024-12-11T16:44:47.698742+01:00",
               "network": "10.0.1.0/24",
               "description": "Frozen but has one host",
               "vlan": 1234,
@@ -10995,11 +11198,15 @@
         "response": {
           "excluded_ranges": [
             {
+              "created_at": "2024-12-11T16:44:45.955630+01:00",
+              "updated_at": "2024-12-11T16:44:45.955656+01:00",
               "start_ip": "10.0.1.20",
               "end_ip": "10.0.1.30",
               "network": 3
             }
           ],
+          "created_at": "2024-12-11T16:44:45.393437+01:00",
+          "updated_at": "2024-12-11T16:44:47.698742+01:00",
           "network": "10.0.1.0/24",
           "description": "Frozen but has one host",
           "vlan": 1234,
@@ -11088,6 +11295,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:44:46.560426+01:00",
+              "updated_at": "2024-12-11T16:44:46.560441+01:00",
               "ipaddress": "10.0.1.4",
               "host": 4
             }
@@ -11096,6 +11305,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:44:46.533402+01:00",
+              "updated_at": "2024-12-11T16:44:46.533419+01:00",
               "txt": "v=spf1 -all",
               "host": 4
             }
@@ -11104,6 +11315,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:44:46.528383+01:00",
+          "updated_at": "2024-12-11T16:44:46.528401+01:00",
           "name": "somehost.example.org",
           "contact": "support@example.org",
           "ttl": null,
@@ -11133,6 +11346,8 @@
               "ipaddresses": [
                 {
                   "macaddress": "",
+                  "created_at": "2024-12-11T16:44:46.560426+01:00",
+                  "updated_at": "2024-12-11T16:44:46.560441+01:00",
                   "ipaddress": "10.0.1.4",
                   "host": 4
                 }
@@ -11141,6 +11356,8 @@
               "mxs": [],
               "txts": [
                 {
+                  "created_at": "2024-12-11T16:44:46.533402+01:00",
+                  "updated_at": "2024-12-11T16:44:46.533419+01:00",
                   "txt": "v=spf1 -all",
                   "host": 4
                 }
@@ -11149,6 +11366,8 @@
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
+              "created_at": "2024-12-11T16:44:46.528383+01:00",
+              "updated_at": "2024-12-11T16:44:48.169499+01:00",
               "name": "somehost.example.org",
               "contact": "new-support@example.org",
               "ttl": null,
@@ -11322,6 +11541,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:44:46.560426+01:00",
+              "updated_at": "2024-12-11T16:44:46.560441+01:00",
               "ipaddress": "10.0.1.4",
               "host": 4
             }
@@ -11330,6 +11551,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:44:46.533402+01:00",
+              "updated_at": "2024-12-11T16:44:46.533419+01:00",
               "txt": "v=spf1 -all",
               "host": 4
             }
@@ -11338,6 +11561,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:44:46.528383+01:00",
+          "updated_at": "2024-12-11T16:44:48.169499+01:00",
           "name": "somehost.example.org",
           "contact": "new-support@example.org",
           "ttl": null,
@@ -11353,11 +11578,15 @@
         "response": {
           "excluded_ranges": [
             {
+              "created_at": "2024-12-11T16:44:45.955630+01:00",
+              "updated_at": "2024-12-11T16:44:45.955656+01:00",
               "start_ip": "10.0.1.20",
               "end_ip": "10.0.1.30",
               "network": 3
             }
           ],
+          "created_at": "2024-12-11T16:44:45.393437+01:00",
+          "updated_at": "2024-12-11T16:44:47.698742+01:00",
           "network": "10.0.1.0/24",
           "description": "Frozen but has one host",
           "vlan": 1234,
@@ -11399,6 +11628,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:44:46.560426+01:00",
+              "updated_at": "2024-12-11T16:44:46.560441+01:00",
               "ipaddress": "10.0.1.4",
               "host": 4
             }
@@ -11407,6 +11638,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:44:46.533402+01:00",
+              "updated_at": "2024-12-11T16:44:46.533419+01:00",
               "txt": "v=spf1 -all",
               "host": 4
             }
@@ -11415,6 +11648,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:44:46.528383+01:00",
+          "updated_at": "2024-12-11T16:44:48.169499+01:00",
           "name": "somehost.example.org",
           "contact": "new-support@example.org",
           "ttl": null,
@@ -11430,11 +11665,15 @@
         "response": {
           "excluded_ranges": [
             {
+              "created_at": "2024-12-11T16:44:45.955630+01:00",
+              "updated_at": "2024-12-11T16:44:45.955656+01:00",
               "start_ip": "10.0.1.20",
               "end_ip": "10.0.1.30",
               "network": 3
             }
           ],
+          "created_at": "2024-12-11T16:44:45.393437+01:00",
+          "updated_at": "2024-12-11T16:44:47.698742+01:00",
           "network": "10.0.1.0/24",
           "description": "Frozen but has one host",
           "vlan": 1234,
@@ -11462,6 +11701,8 @@
         "status": 201,
         "response": {
           "macaddress": "",
+          "created_at": "2024-12-11T16:44:48.833137+01:00",
+          "updated_at": "2024-12-11T16:44:48.833158+01:00",
           "ipaddress": "10.0.1.5",
           "host": 4
         }
@@ -11480,11 +11721,15 @@
               "ipaddresses": [
                 {
                   "macaddress": "",
+                  "created_at": "2024-12-11T16:44:46.560426+01:00",
+                  "updated_at": "2024-12-11T16:44:46.560441+01:00",
                   "ipaddress": "10.0.1.4",
                   "host": 4
                 },
                 {
                   "macaddress": "",
+                  "created_at": "2024-12-11T16:44:48.833137+01:00",
+                  "updated_at": "2024-12-11T16:44:48.833158+01:00",
                   "ipaddress": "10.0.1.5",
                   "host": 4
                 }
@@ -11493,6 +11738,8 @@
               "mxs": [],
               "txts": [
                 {
+                  "created_at": "2024-12-11T16:44:46.533402+01:00",
+                  "updated_at": "2024-12-11T16:44:46.533419+01:00",
                   "txt": "v=spf1 -all",
                   "host": 4
                 }
@@ -11501,6 +11748,8 @@
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
+              "created_at": "2024-12-11T16:44:46.528383+01:00",
+              "updated_at": "2024-12-11T16:44:48.169499+01:00",
               "name": "somehost.example.org",
               "contact": "new-support@example.org",
               "ttl": null,
@@ -11534,11 +11783,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:44:46.560426+01:00",
+              "updated_at": "2024-12-11T16:44:46.560441+01:00",
               "ipaddress": "10.0.1.4",
               "host": 4
             },
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:44:48.833137+01:00",
+              "updated_at": "2024-12-11T16:44:48.833158+01:00",
               "ipaddress": "10.0.1.5",
               "host": 4
             }
@@ -11547,6 +11800,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:44:46.533402+01:00",
+              "updated_at": "2024-12-11T16:44:46.533419+01:00",
               "txt": "v=spf1 -all",
               "host": 4
             }
@@ -11555,6 +11810,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:44:46.528383+01:00",
+          "updated_at": "2024-12-11T16:44:48.169499+01:00",
           "name": "somehost.example.org",
           "contact": "new-support@example.org",
           "ttl": null,
@@ -11570,11 +11827,15 @@
         "response": {
           "excluded_ranges": [
             {
+              "created_at": "2024-12-11T16:44:45.955630+01:00",
+              "updated_at": "2024-12-11T16:44:45.955656+01:00",
               "start_ip": "10.0.1.20",
               "end_ip": "10.0.1.30",
               "network": 3
             }
           ],
+          "created_at": "2024-12-11T16:44:45.393437+01:00",
+          "updated_at": "2024-12-11T16:44:47.698742+01:00",
           "network": "10.0.1.0/24",
           "description": "Frozen but has one host",
           "vlan": 1234,
@@ -11593,11 +11854,15 @@
         "response": {
           "excluded_ranges": [
             {
+              "created_at": "2024-12-11T16:44:45.955630+01:00",
+              "updated_at": "2024-12-11T16:44:45.955656+01:00",
               "start_ip": "10.0.1.20",
               "end_ip": "10.0.1.30",
               "network": 3
             }
           ],
+          "created_at": "2024-12-11T16:44:45.393437+01:00",
+          "updated_at": "2024-12-11T16:44:47.698742+01:00",
           "network": "10.0.1.0/24",
           "description": "Frozen but has one host",
           "vlan": 1234,
@@ -11656,11 +11921,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:44:46.560426+01:00",
+              "updated_at": "2024-12-11T16:44:46.560441+01:00",
               "ipaddress": "10.0.1.4",
               "host": 4
             },
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:44:48.833137+01:00",
+              "updated_at": "2024-12-11T16:44:48.833158+01:00",
               "ipaddress": "10.0.1.5",
               "host": 4
             }
@@ -11669,6 +11938,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:44:46.533402+01:00",
+              "updated_at": "2024-12-11T16:44:46.533419+01:00",
               "txt": "v=spf1 -all",
               "host": 4
             }
@@ -11677,6 +11948,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:44:46.528383+01:00",
+          "updated_at": "2024-12-11T16:44:48.169499+01:00",
           "name": "somehost.example.org",
           "contact": "new-support@example.org",
           "ttl": null,
@@ -11692,11 +11965,15 @@
         "response": {
           "excluded_ranges": [
             {
+              "created_at": "2024-12-11T16:44:45.955630+01:00",
+              "updated_at": "2024-12-11T16:44:45.955656+01:00",
               "start_ip": "10.0.1.20",
               "end_ip": "10.0.1.30",
               "network": 3
             }
           ],
+          "created_at": "2024-12-11T16:44:45.393437+01:00",
+          "updated_at": "2024-12-11T16:44:47.698742+01:00",
           "network": "10.0.1.0/24",
           "description": "Frozen but has one host",
           "vlan": 1234,
@@ -11715,11 +11992,15 @@
         "response": {
           "excluded_ranges": [
             {
+              "created_at": "2024-12-11T16:44:45.955630+01:00",
+              "updated_at": "2024-12-11T16:44:45.955656+01:00",
               "start_ip": "10.0.1.20",
               "end_ip": "10.0.1.30",
               "network": 3
             }
           ],
+          "created_at": "2024-12-11T16:44:45.393437+01:00",
+          "updated_at": "2024-12-11T16:44:47.698742+01:00",
           "network": "10.0.1.0/24",
           "description": "Frozen but has one host",
           "vlan": 1234,
@@ -11783,11 +12064,15 @@
         "response": {
           "excluded_ranges": [
             {
+              "created_at": "2024-12-11T16:44:45.955630+01:00",
+              "updated_at": "2024-12-11T16:44:45.955656+01:00",
               "start_ip": "10.0.1.20",
               "end_ip": "10.0.1.30",
               "network": 3
             }
           ],
+          "created_at": "2024-12-11T16:44:45.393437+01:00",
+          "updated_at": "2024-12-11T16:44:47.698742+01:00",
           "network": "10.0.1.0/24",
           "description": "Frozen but has one host",
           "vlan": 1234,
@@ -11819,11 +12104,15 @@
             {
               "excluded_ranges": [
                 {
+                  "created_at": "2024-12-11T16:44:45.955630+01:00",
+                  "updated_at": "2024-12-11T16:44:45.955656+01:00",
                   "start_ip": "10.0.1.20",
                   "end_ip": "10.0.1.30",
                   "network": 3
                 }
               ],
+              "created_at": "2024-12-11T16:44:45.393437+01:00",
+              "updated_at": "2024-12-11T16:44:49.759182+01:00",
               "network": "10.0.1.0/24",
               "description": "Frozen but has one host",
               "vlan": 1234,
@@ -11878,13 +12167,18 @@
           "zone": {
             "nameservers": [
               {
+                "created_at": "2024-12-11T16:44:40.356452+01:00",
+                "updated_at": "2024-12-11T16:44:40.356481+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
+            "created_at": "2024-12-11T16:44:39.701254+01:00",
+            "updated_at": "2024-12-11T16:44:49.630468+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
+            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -11902,11 +12196,15 @@
         "response": {
           "excluded_ranges": [
             {
+              "created_at": "2024-12-11T16:44:45.955630+01:00",
+              "updated_at": "2024-12-11T16:44:45.955656+01:00",
               "start_ip": "10.0.1.20",
               "end_ip": "10.0.1.30",
               "network": 3
             }
           ],
+          "created_at": "2024-12-11T16:44:45.393437+01:00",
+          "updated_at": "2024-12-11T16:44:49.759182+01:00",
           "network": "10.0.1.0/24",
           "description": "Frozen but has one host",
           "vlan": 1234,
@@ -11955,11 +12253,15 @@
         "response": {
           "excluded_ranges": [
             {
+              "created_at": "2024-12-11T16:44:45.955630+01:00",
+              "updated_at": "2024-12-11T16:44:45.955656+01:00",
               "start_ip": "10.0.1.20",
               "end_ip": "10.0.1.30",
               "network": 3
             }
           ],
+          "created_at": "2024-12-11T16:44:45.393437+01:00",
+          "updated_at": "2024-12-11T16:44:49.759182+01:00",
           "network": "10.0.1.0/24",
           "description": "Frozen but has one host",
           "vlan": 1234,
@@ -11996,8 +12298,8 @@
       "              10.0.1.20     <not set>",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Tue Oct  8 15:31:16 2024",
-      "Updated:      Tue Oct  8 15:31:16 2024"
+      "Created:      Wed Dec 11 16:44:50 2024",
+      "Updated:      Wed Dec 11 16:44:50 2024"
     ],
     "api_requests": [
       {
@@ -12027,13 +12329,18 @@
           "zone": {
             "nameservers": [
               {
+                "created_at": "2024-12-11T16:44:40.356452+01:00",
+                "updated_at": "2024-12-11T16:44:40.356481+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
+            "created_at": "2024-12-11T16:44:39.701254+01:00",
+            "updated_at": "2024-12-11T16:44:49.630468+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
+            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -12050,6 +12357,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:44:45.393437+01:00",
+          "updated_at": "2024-12-11T16:44:49.759182+01:00",
           "network": "10.0.1.0/24",
           "description": "Frozen but has one host",
           "vlan": 1234,
@@ -12079,6 +12388,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:44:50.481015+01:00",
+              "updated_at": "2024-12-11T16:44:50.481025+01:00",
               "ipaddress": "10.0.1.20",
               "host": 6
             }
@@ -12087,6 +12398,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:44:50.463021+01:00",
+              "updated_at": "2024-12-11T16:44:50.463029+01:00",
               "txt": "v=spf1 -all",
               "host": 6
             }
@@ -12095,6 +12408,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:44:50.460417+01:00",
+          "updated_at": "2024-12-11T16:44:50.460427+01:00",
           "name": "otherhost.example.org",
           "contact": "support@example.org",
           "ttl": null,
@@ -12186,6 +12501,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:44:50.481015+01:00",
+              "updated_at": "2024-12-11T16:44:50.481025+01:00",
               "ipaddress": "10.0.1.20",
               "host": 6
             }
@@ -12194,6 +12511,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:44:50.463021+01:00",
+              "updated_at": "2024-12-11T16:44:50.463029+01:00",
               "txt": "v=spf1 -all",
               "host": 6
             }
@@ -12202,6 +12521,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:44:50.460417+01:00",
+          "updated_at": "2024-12-11T16:44:50.460427+01:00",
           "name": "otherhost.example.org",
           "contact": "support@example.org",
           "ttl": null,
@@ -12261,6 +12582,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:44:45.393437+01:00",
+          "updated_at": "2024-12-11T16:44:49.759182+01:00",
           "network": "10.0.1.0/24",
           "description": "Frozen but has one host",
           "vlan": 1234,
@@ -12328,6 +12651,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:44:51.283232+01:00",
+          "updated_at": "2024-12-11T16:44:51.283253+01:00",
           "network": "2001:db8::/64",
           "description": "Lorem ipsum dolor sit amet",
           "vlan": null,
@@ -12360,6 +12685,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:44:51.283232+01:00",
+          "updated_at": "2024-12-11T16:44:51.283253+01:00",
           "network": "2001:db8::/64",
           "description": "Lorem ipsum dolor sit amet",
           "vlan": null,
@@ -12390,6 +12717,8 @@
           "results": [
             {
               "excluded_ranges": [],
+              "created_at": "2024-12-11T16:44:51.283232+01:00",
+              "updated_at": "2024-12-11T16:44:51.463783+01:00",
               "network": "2001:db8::/64",
               "description": "Lorem ipsum dolor sit amet",
               "vlan": null,
@@ -12444,13 +12773,18 @@
           "zone": {
             "nameservers": [
               {
+                "created_at": "2024-12-11T16:44:40.356452+01:00",
+                "updated_at": "2024-12-11T16:44:40.356481+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
+            "created_at": "2024-12-11T16:44:39.701254+01:00",
+            "updated_at": "2024-12-11T16:44:51.003885+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
+            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -12467,6 +12801,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:44:51.283232+01:00",
+          "updated_at": "2024-12-11T16:44:51.463783+01:00",
           "network": "2001:db8::/64",
           "description": "Lorem ipsum dolor sit amet",
           "vlan": null,
@@ -12499,6 +12835,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:44:51.283232+01:00",
+          "updated_at": "2024-12-11T16:44:51.463783+01:00",
           "network": "2001:db8::/64",
           "description": "Lorem ipsum dolor sit amet",
           "vlan": null,
@@ -12561,13 +12899,18 @@
           "zone": {
             "nameservers": [
               {
+                "created_at": "2024-12-11T16:44:40.356452+01:00",
+                "updated_at": "2024-12-11T16:44:40.356481+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
+            "created_at": "2024-12-11T16:44:39.701254+01:00",
+            "updated_at": "2024-12-11T16:44:51.003885+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
+            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -12585,11 +12928,15 @@
         "response": {
           "excluded_ranges": [
             {
+              "created_at": "2024-12-11T16:44:51.818052+01:00",
+              "updated_at": "2024-12-11T16:44:51.818069+01:00",
               "start_ip": "2001:db8::20",
               "end_ip": "2001:db8::30",
               "network": 4
             }
           ],
+          "created_at": "2024-12-11T16:44:51.283232+01:00",
+          "updated_at": "2024-12-11T16:44:51.463783+01:00",
           "network": "2001:db8::/64",
           "description": "Lorem ipsum dolor sit amet",
           "vlan": null,
@@ -12635,8 +12982,8 @@
       "              2001:db8::4   <not set>",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Tue Oct  8 15:31:16 2024",
-      "Updated:      Tue Oct  8 15:31:16 2024"
+      "Created:      Wed Dec 11 16:44:52 2024",
+      "Updated:      Wed Dec 11 16:44:52 2024"
     ],
     "api_requests": [
       {
@@ -12666,13 +13013,18 @@
           "zone": {
             "nameservers": [
               {
+                "created_at": "2024-12-11T16:44:40.356452+01:00",
+                "updated_at": "2024-12-11T16:44:40.356481+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
+            "created_at": "2024-12-11T16:44:39.701254+01:00",
+            "updated_at": "2024-12-11T16:44:51.003885+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
+            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -12690,11 +13042,15 @@
         "response": {
           "excluded_ranges": [
             {
+              "created_at": "2024-12-11T16:44:51.818052+01:00",
+              "updated_at": "2024-12-11T16:44:51.818069+01:00",
               "start_ip": "2001:db8::20",
               "end_ip": "2001:db8::30",
               "network": 4
             }
           ],
+          "created_at": "2024-12-11T16:44:51.283232+01:00",
+          "updated_at": "2024-12-11T16:44:51.463783+01:00",
           "network": "2001:db8::/64",
           "description": "Lorem ipsum dolor sit amet",
           "vlan": null,
@@ -12724,6 +13080,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:44:52.291402+01:00",
+              "updated_at": "2024-12-11T16:44:52.291419+01:00",
               "ipaddress": "2001:db8::4",
               "host": 8
             }
@@ -12732,6 +13090,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:44:52.260029+01:00",
+              "updated_at": "2024-12-11T16:44:52.260048+01:00",
               "txt": "v=spf1 -all",
               "host": 8
             }
@@ -12740,6 +13100,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:44:52.254284+01:00",
+          "updated_at": "2024-12-11T16:44:52.254305+01:00",
           "name": "somehost.example.org",
           "contact": "support@example.org",
           "ttl": null,
@@ -12830,11 +13192,15 @@
         "response": {
           "excluded_ranges": [
             {
+              "created_at": "2024-12-11T16:44:51.818052+01:00",
+              "updated_at": "2024-12-11T16:44:51.818069+01:00",
               "start_ip": "2001:db8::20",
               "end_ip": "2001:db8::30",
               "network": 4
             }
           ],
+          "created_at": "2024-12-11T16:44:51.283232+01:00",
+          "updated_at": "2024-12-11T16:44:51.463783+01:00",
           "network": "2001:db8::/64",
           "description": "Lorem ipsum dolor sit amet",
           "vlan": null,
@@ -12866,11 +13232,15 @@
             {
               "excluded_ranges": [
                 {
+                  "created_at": "2024-12-11T16:44:51.818052+01:00",
+                  "updated_at": "2024-12-11T16:44:51.818069+01:00",
                   "start_ip": "2001:db8::20",
                   "end_ip": "2001:db8::30",
                   "network": 4
                 }
               ],
+              "created_at": "2024-12-11T16:44:51.283232+01:00",
+              "updated_at": "2024-12-11T16:44:52.806494+01:00",
               "network": "2001:db8::/64",
               "description": "Frozen but has one host",
               "vlan": null,
@@ -12923,11 +13293,15 @@
         "response": {
           "excluded_ranges": [
             {
+              "created_at": "2024-12-11T16:44:51.818052+01:00",
+              "updated_at": "2024-12-11T16:44:51.818069+01:00",
               "start_ip": "2001:db8::20",
               "end_ip": "2001:db8::30",
               "network": 4
             }
           ],
+          "created_at": "2024-12-11T16:44:51.283232+01:00",
+          "updated_at": "2024-12-11T16:44:52.806494+01:00",
           "network": "2001:db8::/64",
           "description": "Frozen but has one host",
           "vlan": null,
@@ -12988,6 +13362,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:44:52.291402+01:00",
+              "updated_at": "2024-12-11T16:44:52.291419+01:00",
               "ipaddress": "2001:db8::4",
               "host": 8
             }
@@ -12996,6 +13372,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:44:52.260029+01:00",
+              "updated_at": "2024-12-11T16:44:52.260048+01:00",
               "txt": "v=spf1 -all",
               "host": 8
             }
@@ -13004,6 +13382,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:44:52.254284+01:00",
+          "updated_at": "2024-12-11T16:44:52.254305+01:00",
           "name": "somehost.example.org",
           "contact": "support@example.org",
           "ttl": null,
@@ -13019,11 +13399,15 @@
         "response": {
           "excluded_ranges": [
             {
+              "created_at": "2024-12-11T16:44:51.818052+01:00",
+              "updated_at": "2024-12-11T16:44:51.818069+01:00",
               "start_ip": "2001:db8::20",
               "end_ip": "2001:db8::30",
               "network": 4
             }
           ],
+          "created_at": "2024-12-11T16:44:51.283232+01:00",
+          "updated_at": "2024-12-11T16:44:52.806494+01:00",
           "network": "2001:db8::/64",
           "description": "Frozen but has one host",
           "vlan": null,
@@ -13065,6 +13449,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:44:52.291402+01:00",
+              "updated_at": "2024-12-11T16:44:52.291419+01:00",
               "ipaddress": "2001:db8::4",
               "host": 8
             }
@@ -13073,6 +13459,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:44:52.260029+01:00",
+              "updated_at": "2024-12-11T16:44:52.260048+01:00",
               "txt": "v=spf1 -all",
               "host": 8
             }
@@ -13081,6 +13469,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:44:52.254284+01:00",
+          "updated_at": "2024-12-11T16:44:52.254305+01:00",
           "name": "somehost.example.org",
           "contact": "support@example.org",
           "ttl": null,
@@ -13096,11 +13486,15 @@
         "response": {
           "excluded_ranges": [
             {
+              "created_at": "2024-12-11T16:44:51.818052+01:00",
+              "updated_at": "2024-12-11T16:44:51.818069+01:00",
               "start_ip": "2001:db8::20",
               "end_ip": "2001:db8::30",
               "network": 4
             }
           ],
+          "created_at": "2024-12-11T16:44:51.283232+01:00",
+          "updated_at": "2024-12-11T16:44:52.806494+01:00",
           "network": "2001:db8::/64",
           "description": "Frozen but has one host",
           "vlan": null,
@@ -13128,6 +13522,8 @@
         "status": 201,
         "response": {
           "macaddress": "",
+          "created_at": "2024-12-11T16:44:53.390254+01:00",
+          "updated_at": "2024-12-11T16:44:53.390276+01:00",
           "ipaddress": "2001:db8::5",
           "host": 8
         }
@@ -13146,11 +13542,15 @@
               "ipaddresses": [
                 {
                   "macaddress": "",
+                  "created_at": "2024-12-11T16:44:52.291402+01:00",
+                  "updated_at": "2024-12-11T16:44:52.291419+01:00",
                   "ipaddress": "2001:db8::4",
                   "host": 8
                 },
                 {
                   "macaddress": "",
+                  "created_at": "2024-12-11T16:44:53.390254+01:00",
+                  "updated_at": "2024-12-11T16:44:53.390276+01:00",
                   "ipaddress": "2001:db8::5",
                   "host": 8
                 }
@@ -13159,6 +13559,8 @@
               "mxs": [],
               "txts": [
                 {
+                  "created_at": "2024-12-11T16:44:52.260029+01:00",
+                  "updated_at": "2024-12-11T16:44:52.260048+01:00",
                   "txt": "v=spf1 -all",
                   "host": 8
                 }
@@ -13167,6 +13569,8 @@
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
+              "created_at": "2024-12-11T16:44:52.254284+01:00",
+              "updated_at": "2024-12-11T16:44:52.254305+01:00",
               "name": "somehost.example.org",
               "contact": "support@example.org",
               "ttl": null,
@@ -13200,11 +13604,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:44:52.291402+01:00",
+              "updated_at": "2024-12-11T16:44:52.291419+01:00",
               "ipaddress": "2001:db8::4",
               "host": 8
             },
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:44:53.390254+01:00",
+              "updated_at": "2024-12-11T16:44:53.390276+01:00",
               "ipaddress": "2001:db8::5",
               "host": 8
             }
@@ -13213,6 +13621,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:44:52.260029+01:00",
+              "updated_at": "2024-12-11T16:44:52.260048+01:00",
               "txt": "v=spf1 -all",
               "host": 8
             }
@@ -13221,6 +13631,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:44:52.254284+01:00",
+          "updated_at": "2024-12-11T16:44:52.254305+01:00",
           "name": "somehost.example.org",
           "contact": "support@example.org",
           "ttl": null,
@@ -13236,11 +13648,15 @@
         "response": {
           "excluded_ranges": [
             {
+              "created_at": "2024-12-11T16:44:51.818052+01:00",
+              "updated_at": "2024-12-11T16:44:51.818069+01:00",
               "start_ip": "2001:db8::20",
               "end_ip": "2001:db8::30",
               "network": 4
             }
           ],
+          "created_at": "2024-12-11T16:44:51.283232+01:00",
+          "updated_at": "2024-12-11T16:44:52.806494+01:00",
           "network": "2001:db8::/64",
           "description": "Frozen but has one host",
           "vlan": null,
@@ -13259,11 +13675,15 @@
         "response": {
           "excluded_ranges": [
             {
+              "created_at": "2024-12-11T16:44:51.818052+01:00",
+              "updated_at": "2024-12-11T16:44:51.818069+01:00",
               "start_ip": "2001:db8::20",
               "end_ip": "2001:db8::30",
               "network": 4
             }
           ],
+          "created_at": "2024-12-11T16:44:51.283232+01:00",
+          "updated_at": "2024-12-11T16:44:52.806494+01:00",
           "network": "2001:db8::/64",
           "description": "Frozen but has one host",
           "vlan": null,
@@ -13327,11 +13747,15 @@
         "response": {
           "excluded_ranges": [
             {
+              "created_at": "2024-12-11T16:44:51.818052+01:00",
+              "updated_at": "2024-12-11T16:44:51.818069+01:00",
               "start_ip": "2001:db8::20",
               "end_ip": "2001:db8::30",
               "network": 4
             }
           ],
+          "created_at": "2024-12-11T16:44:51.283232+01:00",
+          "updated_at": "2024-12-11T16:44:52.806494+01:00",
           "network": "2001:db8::/64",
           "description": "Frozen but has one host",
           "vlan": null,
@@ -13398,6 +13822,8 @@
           "groups": [],
           "hosts": [],
           "owners": [],
+          "created_at": "2024-12-11T16:44:54.078203+01:00",
+          "updated_at": "2024-12-11T16:44:54.078229+01:00",
           "name": "mygroup",
           "description": "This describes the group"
         }
@@ -13420,8 +13846,8 @@
       "Contact:      ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Tue Oct  8 15:31:16 2024",
-      "Updated:      Tue Oct  8 15:31:16 2024"
+      "Created:      Wed Dec 11 16:44:54 2024",
+      "Updated:      Wed Dec 11 16:44:54 2024"
     ],
     "api_requests": [
       {
@@ -13451,13 +13877,18 @@
           "zone": {
             "nameservers": [
               {
+                "created_at": "2024-12-11T16:44:40.356452+01:00",
+                "updated_at": "2024-12-11T16:44:40.356481+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
+            "created_at": "2024-12-11T16:44:39.701254+01:00",
+            "updated_at": "2024-12-11T16:44:53.798307+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
+            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -13486,6 +13917,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:44:54.399698+01:00",
+              "updated_at": "2024-12-11T16:44:54.399718+01:00",
               "txt": "v=spf1 -all",
               "host": 9
             }
@@ -13494,6 +13927,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:44:54.385177+01:00",
+          "updated_at": "2024-12-11T16:44:54.385200+01:00",
           "name": "testhost1.example.org",
           "contact": "",
           "ttl": null,
@@ -13579,8 +14014,8 @@
       "Contact:      ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Tue Oct  8 15:31:17 2024",
-      "Updated:      Tue Oct  8 15:31:17 2024"
+      "Created:      Wed Dec 11 16:44:54 2024",
+      "Updated:      Wed Dec 11 16:44:54 2024"
     ],
     "api_requests": [
       {
@@ -13610,13 +14045,18 @@
           "zone": {
             "nameservers": [
               {
+                "created_at": "2024-12-11T16:44:40.356452+01:00",
+                "updated_at": "2024-12-11T16:44:40.356481+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
+            "created_at": "2024-12-11T16:44:39.701254+01:00",
+            "updated_at": "2024-12-11T16:44:54.393800+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
+            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -13645,6 +14085,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:44:54.968112+01:00",
+              "updated_at": "2024-12-11T16:44:54.968130+01:00",
               "txt": "v=spf1 -all",
               "host": 10
             }
@@ -13653,6 +14095,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:44:54.954097+01:00",
+          "updated_at": "2024-12-11T16:44:54.954110+01:00",
           "name": "testhost2.example.org",
           "contact": "",
           "ttl": null,
@@ -13745,6 +14189,8 @@
           "groups": [],
           "hosts": [],
           "owners": [],
+          "created_at": "2024-12-11T16:44:54.078203+01:00",
+          "updated_at": "2024-12-11T16:44:54.078229+01:00",
           "name": "mygroup",
           "description": "This describes the group"
         }
@@ -13760,6 +14206,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:44:54.399698+01:00",
+              "updated_at": "2024-12-11T16:44:54.399718+01:00",
               "txt": "v=spf1 -all",
               "host": 9
             }
@@ -13768,6 +14216,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:44:54.385177+01:00",
+          "updated_at": "2024-12-11T16:44:54.385200+01:00",
           "name": "testhost1.example.org",
           "contact": "",
           "ttl": null,
@@ -13802,6 +14252,8 @@
                 }
               ],
               "owners": [],
+              "created_at": "2024-12-11T16:44:54.078203+01:00",
+              "updated_at": "2024-12-11T16:44:55.500110+01:00",
               "name": "mygroup",
               "description": "This describes the group"
             }
@@ -13837,6 +14289,8 @@
             }
           ],
           "owners": [],
+          "created_at": "2024-12-11T16:44:54.078203+01:00",
+          "updated_at": "2024-12-11T16:44:55.500110+01:00",
           "name": "mygroup",
           "description": "This describes the group"
         }
@@ -13852,6 +14306,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:44:54.968112+01:00",
+              "updated_at": "2024-12-11T16:44:54.968130+01:00",
               "txt": "v=spf1 -all",
               "host": 10
             }
@@ -13860,6 +14316,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:44:54.954097+01:00",
+          "updated_at": "2024-12-11T16:44:54.954110+01:00",
           "name": "testhost2.example.org",
           "contact": "",
           "ttl": null,
@@ -13897,6 +14355,8 @@
                 }
               ],
               "owners": [],
+              "created_at": "2024-12-11T16:44:54.078203+01:00",
+              "updated_at": "2024-12-11T16:44:55.692565+01:00",
               "name": "mygroup",
               "description": "This describes the group"
             }
@@ -13935,6 +14395,8 @@
             }
           ],
           "owners": [],
+          "created_at": "2024-12-11T16:44:54.078203+01:00",
+          "updated_at": "2024-12-11T16:44:55.692565+01:00",
           "name": "mygroup",
           "description": "This describes the group"
         }
@@ -13973,6 +14435,8 @@
                   "name": "myself"
                 }
               ],
+              "created_at": "2024-12-11T16:44:54.078203+01:00",
+              "updated_at": "2024-12-11T16:44:55.692565+01:00",
               "name": "mygroup",
               "description": "This describes the group"
             }
@@ -14015,6 +14479,8 @@
               "name": "myself"
             }
           ],
+          "created_at": "2024-12-11T16:44:54.078203+01:00",
+          "updated_at": "2024-12-11T16:44:55.692565+01:00",
           "name": "mygroup",
           "description": "This describes the group"
         }
@@ -14030,6 +14496,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:44:54.968112+01:00",
+              "updated_at": "2024-12-11T16:44:54.968130+01:00",
               "txt": "v=spf1 -all",
               "host": 10
             }
@@ -14038,6 +14506,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:44:54.954097+01:00",
+          "updated_at": "2024-12-11T16:44:54.954110+01:00",
           "name": "testhost2.example.org",
           "contact": "",
           "ttl": null,
@@ -14074,6 +14544,8 @@
                   "name": "myself"
                 }
               ],
+              "created_at": "2024-12-11T16:44:54.078203+01:00",
+              "updated_at": "2024-12-11T16:44:56.044625+01:00",
               "name": "mygroup",
               "description": "This describes the group"
             }
@@ -14098,8 +14570,8 @@
       "Parents:      ",
       "Groups:       ",
       "Hosts:        1",
-      "Created:      Tue Oct  8 15:31:16 2024",
-      "Updated:      Tue Oct  8 15:31:17 2024"
+      "Created:      Wed Dec 11 16:44:54 2024",
+      "Updated:      Wed Dec 11 16:44:56 2024"
     ],
     "api_requests": [
       {
@@ -14120,6 +14592,8 @@
               "name": "myself"
             }
           ],
+          "created_at": "2024-12-11T16:44:54.078203+01:00",
+          "updated_at": "2024-12-11T16:44:56.044625+01:00",
           "name": "mygroup",
           "description": "This describes the group"
         }
@@ -14348,6 +14822,8 @@
           "groups": [],
           "hosts": [],
           "owners": [],
+          "created_at": "2024-12-11T16:44:56.440003+01:00",
+          "updated_at": "2024-12-11T16:44:56.440025+01:00",
           "name": "yourgroup",
           "description": "meh"
         }
@@ -14377,6 +14853,8 @@
           "groups": [],
           "hosts": [],
           "owners": [],
+          "created_at": "2024-12-11T16:44:56.440003+01:00",
+          "updated_at": "2024-12-11T16:44:56.440025+01:00",
           "name": "yourgroup",
           "description": "meh"
         }
@@ -14399,6 +14877,8 @@
               "name": "myself"
             }
           ],
+          "created_at": "2024-12-11T16:44:54.078203+01:00",
+          "updated_at": "2024-12-11T16:44:56.044625+01:00",
           "name": "mygroup",
           "description": "This describes the group"
         }
@@ -14438,6 +14918,8 @@
                   "name": "myself"
                 }
               ],
+              "created_at": "2024-12-11T16:44:54.078203+01:00",
+              "updated_at": "2024-12-11T16:44:56.640484+01:00",
               "name": "mygroup",
               "description": "This describes the group"
             }
@@ -14462,8 +14944,8 @@
       "Parents:      ",
       "Groups:       yourgroup",
       "Hosts:        1",
-      "Created:      Tue Oct  8 15:31:16 2024",
-      "Updated:      Tue Oct  8 15:31:17 2024"
+      "Created:      Wed Dec 11 16:44:54 2024",
+      "Updated:      Wed Dec 11 16:44:56 2024"
     ],
     "api_requests": [
       {
@@ -14488,6 +14970,8 @@
               "name": "myself"
             }
           ],
+          "created_at": "2024-12-11T16:44:54.078203+01:00",
+          "updated_at": "2024-12-11T16:44:56.640484+01:00",
           "name": "mygroup",
           "description": "This describes the group"
         }
@@ -14529,6 +15013,8 @@
               "name": "myself"
             }
           ],
+          "created_at": "2024-12-11T16:44:54.078203+01:00",
+          "updated_at": "2024-12-11T16:44:56.640484+01:00",
           "name": "mygroup",
           "description": "This describes the group"
         }
@@ -14562,6 +15048,8 @@
                   "name": "myself"
                 }
               ],
+              "created_at": "2024-12-11T16:44:54.078203+01:00",
+              "updated_at": "2024-12-11T16:44:56.864542+01:00",
               "name": "mygroup",
               "description": "This describes the group"
             }
@@ -14601,6 +15089,8 @@
               "name": "myself"
             }
           ],
+          "created_at": "2024-12-11T16:44:54.078203+01:00",
+          "updated_at": "2024-12-11T16:44:56.864542+01:00",
           "name": "mygroup",
           "description": "This describes the group"
         }
@@ -14615,7 +15105,7 @@
       },
       {
         "method": "GET",
-        "url": "/api/v1/hostgroups/?id=<ID>",
+        "url": "/api/v1/hostgroups/?id=1",
         "data": {},
         "status": 200,
         "response": {
@@ -14639,6 +15129,8 @@
                   "name": "anotherowner"
                 }
               ],
+              "created_at": "2024-12-11T16:44:54.078203+01:00",
+              "updated_at": "2024-12-11T16:44:56.864542+01:00",
               "name": "mygroup",
               "description": "This describes the group"
             }
@@ -14681,6 +15173,8 @@
               "name": "myself"
             }
           ],
+          "created_at": "2024-12-11T16:44:54.078203+01:00",
+          "updated_at": "2024-12-11T16:44:56.864542+01:00",
           "name": "mygroup",
           "description": "This describes the group"
         }
@@ -14714,6 +15208,8 @@
                   "name": "anotherowner"
                 }
               ],
+              "created_at": "2024-12-11T16:44:54.078203+01:00",
+              "updated_at": "2024-12-11T16:44:56.864542+01:00",
               "name": "mygroup",
               "description": "This describes the group"
             }
@@ -15042,6 +15538,8 @@
               "name": "anotherowner"
             }
           ],
+          "created_at": "2024-12-11T16:44:54.078203+01:00",
+          "updated_at": "2024-12-11T16:44:56.864542+01:00",
           "name": "mygroup",
           "description": "This describes the group"
         }
@@ -15079,6 +15577,8 @@
               "name": "anotherowner"
             }
           ],
+          "created_at": "2024-12-11T16:44:54.078203+01:00",
+          "updated_at": "2024-12-11T16:44:56.864542+01:00",
           "name": "mygroup",
           "description": "This describes the group"
         }
@@ -15114,6 +15614,8 @@
           "groups": [],
           "hosts": [],
           "owners": [],
+          "created_at": "2024-12-11T16:44:56.440003+01:00",
+          "updated_at": "2024-12-11T16:44:56.440025+01:00",
           "name": "yourgroup",
           "description": "meh"
         }
@@ -15150,6 +15652,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:44:54.399698+01:00",
+              "updated_at": "2024-12-11T16:44:54.399718+01:00",
               "txt": "v=spf1 -all",
               "host": 9
             }
@@ -15158,6 +15662,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:44:54.385177+01:00",
+          "updated_at": "2024-12-11T16:44:54.385200+01:00",
           "name": "testhost1.example.org",
           "contact": "",
           "ttl": null,
@@ -15221,6 +15727,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:44:54.968112+01:00",
+              "updated_at": "2024-12-11T16:44:54.968130+01:00",
               "txt": "v=spf1 -all",
               "host": 10
             }
@@ -15229,6 +15737,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:44:54.954097+01:00",
+          "updated_at": "2024-12-11T16:44:54.954110+01:00",
           "name": "testhost2.example.org",
           "contact": "",
           "ttl": null,
@@ -15289,13 +15799,18 @@
         "response": {
           "nameservers": [
             {
+              "created_at": "2024-12-11T16:44:40.356452+01:00",
+              "updated_at": "2024-12-11T16:44:40.356481+01:00",
               "name": "ns2.example.org",
               "ttl": null
             }
           ],
+          "created_at": "2024-12-11T16:44:39.701254+01:00",
+          "updated_at": "2024-12-11T16:44:58.340358+01:00",
           "updated": true,
           "primary_ns": "ns2.example.org",
           "email": "hostperson@example.org",
+          "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
           "refresh": 360,
           "retry": 1800,
           "expire": 2400,
@@ -15350,10 +15865,14 @@
         "response": {
           "nameservers": [
             {
+              "created_at": "2024-12-11T16:44:40.356452+01:00",
+              "updated_at": "2024-12-11T16:44:40.356481+01:00",
               "name": "ns2.example.org",
               "ttl": null
             }
           ],
+          "created_at": "2024-12-11T16:44:58.566491+01:00",
+          "updated_at": "2024-12-11T16:44:58.588744+01:00",
           "name": "wut.example.org",
           "comment": "",
           "zone": 1
@@ -15382,13 +15901,18 @@
         "response": {
           "nameservers": [
             {
+              "created_at": "2024-12-11T16:44:40.356452+01:00",
+              "updated_at": "2024-12-11T16:44:40.356481+01:00",
               "name": "ns2.example.org",
               "ttl": null
             }
           ],
+          "created_at": "2024-12-11T16:44:39.701254+01:00",
+          "updated_at": "2024-12-11T16:44:58.600163+01:00",
           "updated": true,
           "primary_ns": "ns2.example.org",
           "email": "hostperson@example.org",
+          "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
           "refresh": 360,
           "retry": 1800,
           "expire": 2400,
@@ -15405,10 +15929,14 @@
         "response": {
           "nameservers": [
             {
+              "created_at": "2024-12-11T16:44:40.356452+01:00",
+              "updated_at": "2024-12-11T16:44:40.356481+01:00",
               "name": "ns2.example.org",
               "ttl": null
             }
           ],
+          "created_at": "2024-12-11T16:44:58.566491+01:00",
+          "updated_at": "2024-12-11T16:44:58.588744+01:00",
           "name": "wut.example.org",
           "comment": "",
           "zone": 1
@@ -15449,13 +15977,18 @@
         "response": {
           "nameservers": [
             {
+              "created_at": "2024-12-11T16:44:40.356452+01:00",
+              "updated_at": "2024-12-11T16:44:40.356481+01:00",
               "name": "ns2.example.org",
               "ttl": null
             }
           ],
+          "created_at": "2024-12-11T16:44:39.701254+01:00",
+          "updated_at": "2024-12-11T16:44:58.774765+01:00",
           "updated": true,
           "primary_ns": "ns2.example.org",
           "email": "hostperson@example.org",
+          "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
           "refresh": 360,
           "retry": 1800,
           "expire": 2400,
@@ -15477,10 +16010,14 @@
             {
               "nameservers": [
                 {
+                  "created_at": "2024-12-11T16:44:40.356452+01:00",
+                  "updated_at": "2024-12-11T16:44:40.356481+01:00",
                   "name": "ns2.example.org",
                   "ttl": null
                 }
               ],
+              "created_at": "2024-12-11T16:44:58.566491+01:00",
+              "updated_at": "2024-12-11T16:44:58.811285+01:00",
               "name": "wut.example.org",
               "comment": "This is a comment",
               "zone": 1
@@ -15530,10 +16067,14 @@
           "delegation": {
             "nameservers": [
               {
+                "created_at": "2024-12-11T16:44:40.356452+01:00",
+                "updated_at": "2024-12-11T16:44:40.356481+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
+            "created_at": "2024-12-11T16:44:58.566491+01:00",
+            "updated_at": "2024-12-11T16:44:58.811285+01:00",
             "name": "wut.example.org",
             "comment": "This is a comment",
             "zone": 1
@@ -15557,8 +16098,8 @@
       "Name:         testhost.wut.example.org",
       "Contact:      ",
       "TTL:          (Default)",
-      "Created:      Tue Oct  8 15:31:17 2024",
-      "Updated:      Tue Oct  8 15:31:17 2024"
+      "Created:      Wed Dec 11 16:44:59 2024",
+      "Updated:      Wed Dec 11 16:44:59 2024"
     ],
     "api_requests": [
       {
@@ -15588,10 +16129,14 @@
           "delegation": {
             "nameservers": [
               {
+                "created_at": "2024-12-11T16:44:40.356452+01:00",
+                "updated_at": "2024-12-11T16:44:40.356481+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
+            "created_at": "2024-12-11T16:44:58.566491+01:00",
+            "updated_at": "2024-12-11T16:44:58.811285+01:00",
             "name": "wut.example.org",
             "comment": "This is a comment",
             "zone": 1
@@ -15620,6 +16165,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:44:59.243214+01:00",
+          "updated_at": "2024-12-11T16:44:59.243232+01:00",
           "name": "testhost.wut.example.org",
           "contact": "",
           "ttl": null,
@@ -15716,6 +16263,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:44:59.243214+01:00",
+          "updated_at": "2024-12-11T16:44:59.243232+01:00",
           "name": "testhost.wut.example.org",
           "contact": "",
           "ttl": null,
@@ -15776,13 +16325,18 @@
         "response": {
           "nameservers": [
             {
+              "created_at": "2024-12-11T16:44:40.356452+01:00",
+              "updated_at": "2024-12-11T16:44:40.356481+01:00",
               "name": "ns2.example.org",
               "ttl": null
             }
           ],
+          "created_at": "2024-12-11T16:44:39.701254+01:00",
+          "updated_at": "2024-12-11T16:44:58.774765+01:00",
           "updated": true,
           "primary_ns": "ns2.example.org",
           "email": "hostperson@example.org",
+          "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
           "refresh": 360,
           "retry": 1800,
           "expire": 2400,
@@ -15799,10 +16353,14 @@
         "response": {
           "nameservers": [
             {
+              "created_at": "2024-12-11T16:44:40.356452+01:00",
+              "updated_at": "2024-12-11T16:44:40.356481+01:00",
               "name": "ns2.example.org",
               "ttl": null
             }
           ],
+          "created_at": "2024-12-11T16:44:58.566491+01:00",
+          "updated_at": "2024-12-11T16:44:58.811285+01:00",
           "name": "wut.example.org",
           "comment": "This is a comment",
           "zone": 1
@@ -15839,13 +16397,18 @@
         "response": {
           "nameservers": [
             {
+              "created_at": "2024-12-11T16:44:40.356452+01:00",
+              "updated_at": "2024-12-11T16:44:40.356481+01:00",
               "name": "ns2.example.org",
               "ttl": null
             }
           ],
+          "created_at": "2024-12-11T16:44:39.701254+01:00",
+          "updated_at": "2024-12-11T16:44:59.950305+01:00",
           "updated": true,
           "primary_ns": "ns2.example.org",
           "email": "hostperson@example.org",
+          "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
           "refresh": 360,
           "retry": 1800,
           "expire": 2400,
@@ -15862,10 +16425,14 @@
         "response": {
           "nameservers": [
             {
+              "created_at": "2024-12-11T16:44:40.356452+01:00",
+              "updated_at": "2024-12-11T16:44:40.356481+01:00",
               "name": "ns2.example.org",
               "ttl": null
             }
           ],
+          "created_at": "2024-12-11T16:44:58.566491+01:00",
+          "updated_at": "2024-12-11T16:44:59.996272+01:00",
           "name": "wut.example.org",
           "comment": "",
           "zone": 1
@@ -15917,6 +16484,7 @@
         "status": 200,
         "response": {
           "roles": [],
+          "updated_at": "2024-12-11T16:45:00.243440+01:00",
           "description": "Here's the description",
           "name": "apple"
         }
@@ -15962,6 +16530,7 @@
         "status": 200,
         "response": {
           "roles": [],
+          "updated_at": "2024-12-11T16:45:00.386958+01:00",
           "description": "Round and orange",
           "name": "orange"
         }
@@ -15994,11 +16563,13 @@
           "results": [
             {
               "roles": [],
+              "updated_at": "2024-12-11T16:45:00.243440+01:00",
               "description": "Here's the description",
               "name": "apple"
             },
             {
               "roles": [],
+              "updated_at": "2024-12-11T16:45:00.386958+01:00",
               "description": "Round and orange",
               "name": "orange"
             }
@@ -16032,6 +16603,7 @@
           "results": [
             {
               "roles": [],
+              "updated_at": "2024-12-11T16:45:00.243440+01:00",
               "description": "Here's the description",
               "name": "apple"
             }
@@ -16079,6 +16651,7 @@
         "response": {
           "hosts": [],
           "atoms": [],
+          "updated_at": "2024-12-11T16:45:00.640584+01:00",
           "description": "5 a day",
           "name": "fruit",
           "labels": []
@@ -16113,6 +16686,7 @@
             {
               "hosts": [],
               "atoms": [],
+              "updated_at": "2024-12-11T16:45:00.640584+01:00",
               "description": "5 a day",
               "name": "fruit",
               "labels": []
@@ -16149,6 +16723,7 @@
             {
               "hosts": [],
               "atoms": [],
+              "updated_at": "2024-12-11T16:45:00.640584+01:00",
               "description": "5 a day",
               "name": "fruit",
               "labels": []
@@ -16179,6 +16754,7 @@
         "response": {
           "hosts": [],
           "atoms": [],
+          "updated_at": "2024-12-11T16:45:00.640584+01:00",
           "description": "5 a day",
           "name": "fruit",
           "labels": []
@@ -16191,6 +16767,7 @@
         "status": 200,
         "response": {
           "roles": [],
+          "updated_at": "2024-12-11T16:45:00.243440+01:00",
           "description": "Here's the description",
           "name": "apple"
         }
@@ -16230,6 +16807,7 @@
               "name": "apple"
             }
           ],
+          "updated_at": "2024-12-11T16:45:01.052408+01:00",
           "description": "5 a day",
           "name": "fruit",
           "labels": []
@@ -16242,6 +16820,7 @@
         "status": 200,
         "response": {
           "roles": [],
+          "updated_at": "2024-12-11T16:45:00.386958+01:00",
           "description": "Round and orange",
           "name": "orange"
         }
@@ -16268,7 +16847,7 @@
     "output": [
       "Name:         orange",
       "Created:      Sat Jul  7 00:00:00 2018",
-      "Updated:      Tue Oct  8 15:31:18 2024",
+      "Updated:      Wed Dec 11 16:45:00 2024",
       "Description:  Round and orange",
       "Roles where this atom is a member:",
       "               fruit"
@@ -16285,6 +16864,7 @@
               "name": "fruit"
             }
           ],
+          "updated_at": "2024-12-11T16:45:00.386958+01:00",
           "description": "Round and orange",
           "name": "orange"
         }
@@ -16302,8 +16882,8 @@
     "error": [],
     "output": [
       "Name:         fruit",
-      "Created:      Tue Oct  8 00:00:00 2024",
-      "Updated:      Tue Oct  8 15:31:18 2024",
+      "Created:      Wed Dec 11 00:00:00 2024",
+      "Updated:      Wed Dec 11 16:45:01 2024",
       "Description:  5 a day",
       "Atom members:",
       "               apple",
@@ -16335,6 +16915,7 @@
               "name": "orange"
             }
           ],
+          "updated_at": "2024-12-11T16:45:01.258316+01:00",
           "description": "5 a day",
           "name": "fruit",
           "labels": []
@@ -16372,6 +16953,7 @@
               "name": "orange"
             }
           ],
+          "updated_at": "2024-12-11T16:45:01.258316+01:00",
           "description": "5 a day",
           "name": "fruit",
           "labels": []
@@ -16491,6 +17073,7 @@
               "name": "fruit"
             }
           ],
+          "updated_at": "2024-12-11T16:45:00.243440+01:00",
           "description": "Here's the description",
           "name": "apple"
         }
@@ -16515,6 +17098,7 @@
                   "name": "orange"
                 }
               ],
+              "updated_at": "2024-12-11T16:45:01.258316+01:00",
               "description": "5 a day",
               "name": "fruit",
               "labels": []
@@ -16552,6 +17136,7 @@
               "name": "orange"
             }
           ],
+          "updated_at": "2024-12-11T16:45:01.258316+01:00",
           "description": "5 a day",
           "name": "fruit",
           "labels": []
@@ -16687,6 +17272,7 @@
         "status": 200,
         "response": {
           "roles": [],
+          "updated_at": "2024-12-11T16:45:00.243440+01:00",
           "description": "Here's the description",
           "name": "apple"
         }
@@ -16735,6 +17321,7 @@
               "name": "fruit"
             }
           ],
+          "updated_at": "2024-12-11T16:45:00.386958+01:00",
           "description": "Round and orange",
           "name": "orange"
         }
@@ -16763,6 +17350,7 @@
                   "name": "fruit"
                 }
               ],
+              "updated_at": "2024-12-11T16:45:02.376357+01:00",
               "description": "Juicy",
               "name": "orange"
             }
@@ -16813,6 +17401,7 @@
               "name": "fruit"
             }
           ],
+          "updated_at": "2024-12-11T16:45:02.376357+01:00",
           "description": "Juicy",
           "name": "orange"
         }
@@ -16841,6 +17430,7 @@
                   "name": "fruit"
                 }
               ],
+              "updated_at": "2024-12-11T16:45:02.667228+01:00",
               "description": "Juicy",
               "name": "tangerine"
             }
@@ -16865,8 +17455,8 @@
       "Contact:      ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Tue Oct  8 15:31:18 2024",
-      "Updated:      Tue Oct  8 15:31:18 2024"
+      "Created:      Wed Dec 11 16:45:02 2024",
+      "Updated:      Wed Dec 11 16:45:02 2024"
     ],
     "api_requests": [
       {
@@ -16896,13 +17486,18 @@
           "zone": {
             "nameservers": [
               {
+                "created_at": "2024-12-11T16:44:40.356452+01:00",
+                "updated_at": "2024-12-11T16:44:40.356481+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
+            "created_at": "2024-12-11T16:44:39.701254+01:00",
+            "updated_at": "2024-12-11T16:45:00.157412+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
+            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -16931,6 +17526,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:02.958146+01:00",
+              "updated_at": "2024-12-11T16:45:02.958166+01:00",
               "txt": "v=spf1 -all",
               "host": 12
             }
@@ -16939,6 +17536,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:02.933960+01:00",
+          "updated_at": "2024-12-11T16:45:02.933976+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -17022,8 +17621,8 @@
       "Contact:      ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Tue Oct  8 15:31:18 2024",
-      "Updated:      Tue Oct  8 15:31:18 2024"
+      "Created:      Wed Dec 11 16:45:02 2024",
+      "Updated:      Wed Dec 11 16:45:02 2024"
     ],
     "api_requests": [
       {
@@ -17037,6 +17636,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:02.958146+01:00",
+              "updated_at": "2024-12-11T16:45:02.958166+01:00",
               "txt": "v=spf1 -all",
               "host": 12
             }
@@ -17045,6 +17646,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:02.933960+01:00",
+          "updated_at": "2024-12-11T16:45:02.933976+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -17163,6 +17766,7 @@
               "name": "tangerine"
             }
           ],
+          "updated_at": "2024-12-11T16:45:02.648865+01:00",
           "description": "5 a day",
           "name": "fruit",
           "labels": []
@@ -17179,6 +17783,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:02.958146+01:00",
+              "updated_at": "2024-12-11T16:45:02.958166+01:00",
               "txt": "v=spf1 -all",
               "host": 12
             }
@@ -17187,6 +17793,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:02.933960+01:00",
+          "updated_at": "2024-12-11T16:45:02.933976+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -17234,6 +17842,7 @@
               "name": "tangerine"
             }
           ],
+          "updated_at": "2024-12-11T16:45:03.805072+01:00",
           "description": "5 a day",
           "name": "fruit",
           "labels": []
@@ -17266,6 +17875,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:02.958146+01:00",
+              "updated_at": "2024-12-11T16:45:02.958166+01:00",
               "txt": "v=spf1 -all",
               "host": 12
             }
@@ -17274,6 +17885,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:02.933960+01:00",
+          "updated_at": "2024-12-11T16:45:02.933976+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -17302,6 +17915,7 @@
                   "name": "tangerine"
                 }
               ],
+              "updated_at": "2024-12-11T16:45:03.805072+01:00",
               "description": "5 a day",
               "name": "fruit",
               "labels": []
@@ -17326,8 +17940,8 @@
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
       "Roles:        fruit",
-      "Created:      Tue Oct  8 15:31:18 2024",
-      "Updated:      Tue Oct  8 15:31:18 2024"
+      "Created:      Wed Dec 11 16:45:02 2024",
+      "Updated:      Wed Dec 11 16:45:02 2024"
     ],
     "api_requests": [
       {
@@ -17341,6 +17955,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:02.958146+01:00",
+              "updated_at": "2024-12-11T16:45:02.958166+01:00",
               "txt": "v=spf1 -all",
               "host": 12
             }
@@ -17349,6 +17965,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:02.933960+01:00",
+          "updated_at": "2024-12-11T16:45:02.933976+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -17413,6 +18031,7 @@
                   "name": "tangerine"
                 }
               ],
+              "updated_at": "2024-12-11T16:45:03.805072+01:00",
               "description": "5 a day",
               "name": "fruit",
               "labels": []
@@ -17463,6 +18082,7 @@
               "name": "tangerine"
             }
           ],
+          "updated_at": "2024-12-11T16:45:03.805072+01:00",
           "description": "5 a day",
           "name": "fruit",
           "labels": []
@@ -17479,6 +18099,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:02.958146+01:00",
+              "updated_at": "2024-12-11T16:45:02.958166+01:00",
               "txt": "v=spf1 -all",
               "host": 12
             }
@@ -17487,6 +18109,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:02.933960+01:00",
+          "updated_at": "2024-12-11T16:45:02.933976+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -17527,6 +18151,7 @@
               "name": "tangerine"
             }
           ],
+          "updated_at": "2024-12-11T16:45:04.346261+01:00",
           "description": "5 a day",
           "name": "fruit",
           "labels": []
@@ -17559,6 +18184,7 @@
               "name": "tangerine"
             }
           ],
+          "updated_at": "2024-12-11T16:45:04.346261+01:00",
           "description": "5 a day",
           "name": "fruit",
           "labels": []
@@ -17852,6 +18478,7 @@
         "response": {
           "hosts": [],
           "atoms": [],
+          "updated_at": "2024-12-11T16:45:04.506713+01:00",
           "description": "5 a day",
           "name": "fruit",
           "labels": []
@@ -17885,6 +18512,7 @@
         "status": 200,
         "response": {
           "roles": [],
+          "updated_at": "2024-12-11T16:45:02.667228+01:00",
           "description": "Juicy",
           "name": "tangerine"
         }
@@ -17933,6 +18561,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:02.958146+01:00",
+              "updated_at": "2024-12-11T16:45:02.958166+01:00",
               "txt": "v=spf1 -all",
               "host": 12
             }
@@ -17941,6 +18571,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:02.933960+01:00",
+          "updated_at": "2024-12-11T16:45:02.933976+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -18015,6 +18647,8 @@
         },
         "status": 201,
         "response": {
+          "created_at": "2024-12-11T16:45:05.428527+01:00",
+          "updated_at": "2024-12-11T16:45:05.428550+01:00",
           "group": "somegroup",
           "range": "10.0.0.0/24",
           "regex": "[abc]+.uio.no",
@@ -18048,6 +18682,8 @@
           "previous": null,
           "results": [
             {
+              "created_at": "2024-12-11T16:45:05.428527+01:00",
+              "updated_at": "2024-12-11T16:45:05.428550+01:00",
               "group": "somegroup",
               "range": "10.0.0.0/24",
               "regex": "[abc]+.uio.no",
@@ -18121,6 +18757,8 @@
           "previous": null,
           "results": [
             {
+              "created_at": "2024-12-11T16:45:05.428527+01:00",
+              "updated_at": "2024-12-11T16:45:05.428550+01:00",
               "group": "somegroup",
               "range": "10.0.0.0/24",
               "regex": "[abc]+.uio.no",
@@ -18180,6 +18818,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:45:05.867822+01:00",
+          "updated_at": "2024-12-11T16:45:05.867856+01:00",
           "network": "10.0.0.0/24",
           "description": "foo",
           "vlan": 1234,
@@ -18208,8 +18848,8 @@
       "Contact:      ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Tue Oct  8 15:31:19 2024",
-      "Updated:      Tue Oct  8 15:31:19 2024"
+      "Created:      Wed Dec 11 16:45:06 2024",
+      "Updated:      Wed Dec 11 16:45:06 2024"
     ],
     "api_requests": [
       {
@@ -18239,13 +18879,18 @@
           "zone": {
             "nameservers": [
               {
+                "created_at": "2024-12-11T16:44:40.356452+01:00",
+                "updated_at": "2024-12-11T16:44:40.356481+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
+            "created_at": "2024-12-11T16:44:39.701254+01:00",
+            "updated_at": "2024-12-11T16:45:05.293515+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
+            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -18274,6 +18919,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:06.156299+01:00",
+              "updated_at": "2024-12-11T16:45:06.156320+01:00",
               "txt": "v=spf1 -all",
               "host": 13
             }
@@ -18282,6 +18929,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:06.137012+01:00",
+          "updated_at": "2024-12-11T16:45:06.137037+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -18375,6 +19024,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:06.156299+01:00",
+              "updated_at": "2024-12-11T16:45:06.156320+01:00",
               "txt": "v=spf1 -all",
               "host": 13
             }
@@ -18383,6 +19034,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:06.137012+01:00",
+          "updated_at": "2024-12-11T16:45:06.137037+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -18397,6 +19050,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:45:05.867822+01:00",
+          "updated_at": "2024-12-11T16:45:05.867856+01:00",
           "network": "10.0.0.0/24",
           "description": "foo",
           "vlan": 1234,
@@ -18429,6 +19084,8 @@
         "status": 201,
         "response": {
           "macaddress": "",
+          "created_at": "2024-12-11T16:45:06.825644+01:00",
+          "updated_at": "2024-12-11T16:45:06.825657+01:00",
           "ipaddress": "10.0.0.5",
           "host": 13
         }
@@ -18447,6 +19104,8 @@
               "ipaddresses": [
                 {
                   "macaddress": "",
+                  "created_at": "2024-12-11T16:45:06.825644+01:00",
+                  "updated_at": "2024-12-11T16:45:06.825657+01:00",
                   "ipaddress": "10.0.0.5",
                   "host": 13
                 }
@@ -18455,6 +19114,8 @@
               "mxs": [],
               "txts": [
                 {
+                  "created_at": "2024-12-11T16:45:06.156299+01:00",
+                  "updated_at": "2024-12-11T16:45:06.156320+01:00",
                   "txt": "v=spf1 -all",
                   "host": 13
                 }
@@ -18463,6 +19124,8 @@
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
+              "created_at": "2024-12-11T16:45:06.137012+01:00",
+              "updated_at": "2024-12-11T16:45:06.137037+01:00",
               "name": "foo.example.org",
               "contact": "",
               "ttl": null,
@@ -18550,6 +19213,8 @@
           "results": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:06.825644+01:00",
+              "updated_at": "2024-12-11T16:45:06.825657+01:00",
               "ipaddress": "10.0.0.5",
               "host": 13
             }
@@ -18571,6 +19236,8 @@
         "status": 200,
         "response": {
           "macaddress": "aa:bb:cc:dd:ee:ff",
+          "created_at": "2024-12-11T16:45:06.825644+01:00",
+          "updated_at": "2024-12-11T16:45:07.191958+01:00",
           "ipaddress": "10.0.0.5",
           "host": 13
         }
@@ -18629,6 +19296,8 @@
           "results": [
             {
               "macaddress": "aa:bb:cc:dd:ee:ff",
+              "created_at": "2024-12-11T16:45:06.825644+01:00",
+              "updated_at": "2024-12-11T16:45:07.191958+01:00",
               "ipaddress": "10.0.0.5",
               "host": 13
             }
@@ -18650,6 +19319,8 @@
         "status": 200,
         "response": {
           "macaddress": "",
+          "created_at": "2024-12-11T16:45:06.825644+01:00",
+          "updated_at": "2024-12-11T16:45:07.470501+01:00",
           "ipaddress": "10.0.0.5",
           "host": 13
         }
@@ -18735,6 +19406,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:06.825644+01:00",
+              "updated_at": "2024-12-11T16:45:07.470501+01:00",
               "ipaddress": "10.0.0.5",
               "host": 13
             }
@@ -18743,6 +19416,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:06.156299+01:00",
+              "updated_at": "2024-12-11T16:45:06.156320+01:00",
               "txt": "v=spf1 -all",
               "host": 13
             }
@@ -18751,6 +19426,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:06.137012+01:00",
+          "updated_at": "2024-12-11T16:45:06.137037+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -18773,6 +19450,8 @@
         "status": 200,
         "response": {
           "macaddress": "aa:bb:cc:dd:ee:ff",
+          "created_at": "2024-12-11T16:45:06.825644+01:00",
+          "updated_at": "2024-12-11T16:45:07.909151+01:00",
           "ipaddress": "10.0.0.5",
           "host": 13
         }
@@ -18801,6 +19480,8 @@
           "ipaddresses": [
             {
               "macaddress": "aa:bb:cc:dd:ee:ff",
+              "created_at": "2024-12-11T16:45:06.825644+01:00",
+              "updated_at": "2024-12-11T16:45:07.909151+01:00",
               "ipaddress": "10.0.0.5",
               "host": 13
             }
@@ -18809,6 +19490,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:06.156299+01:00",
+              "updated_at": "2024-12-11T16:45:06.156320+01:00",
               "txt": "v=spf1 -all",
               "host": 13
             }
@@ -18817,6 +19500,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:06.137012+01:00",
+          "updated_at": "2024-12-11T16:45:06.137037+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -18839,6 +19524,8 @@
         "status": 200,
         "response": {
           "macaddress": "",
+          "created_at": "2024-12-11T16:45:06.825644+01:00",
+          "updated_at": "2024-12-11T16:45:08.135007+01:00",
           "ipaddress": "10.0.0.5",
           "host": 13
         }
@@ -18900,6 +19587,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:06.825644+01:00",
+              "updated_at": "2024-12-11T16:45:08.135007+01:00",
               "ipaddress": "10.0.0.5",
               "host": 13
             }
@@ -18908,6 +19597,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:06.156299+01:00",
+              "updated_at": "2024-12-11T16:45:06.156320+01:00",
               "txt": "v=spf1 -all",
               "host": 13
             }
@@ -18916,6 +19607,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:06.137012+01:00",
+          "updated_at": "2024-12-11T16:45:06.137037+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -18967,6 +19660,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:06.156299+01:00",
+              "updated_at": "2024-12-11T16:45:06.156320+01:00",
               "txt": "v=spf1 -all",
               "host": 13
             }
@@ -18975,6 +19670,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:06.137012+01:00",
+          "updated_at": "2024-12-11T16:45:06.137037+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -19008,6 +19705,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:06.156299+01:00",
+              "updated_at": "2024-12-11T16:45:06.156320+01:00",
               "txt": "v=spf1 -all",
               "host": 13
             }
@@ -19016,6 +19715,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:06.137012+01:00",
+          "updated_at": "2024-12-11T16:45:06.137037+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -19030,6 +19731,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:45:05.867822+01:00",
+          "updated_at": "2024-12-11T16:45:05.867856+01:00",
           "network": "10.0.0.0/24",
           "description": "foo",
           "vlan": 1234,
@@ -19062,6 +19765,8 @@
         "status": 201,
         "response": {
           "macaddress": "",
+          "created_at": "2024-12-11T16:45:08.679831+01:00",
+          "updated_at": "2024-12-11T16:45:08.679843+01:00",
           "ipaddress": "10.0.0.5",
           "host": 13
         }
@@ -19080,6 +19785,8 @@
               "ipaddresses": [
                 {
                   "macaddress": "",
+                  "created_at": "2024-12-11T16:45:08.679831+01:00",
+                  "updated_at": "2024-12-11T16:45:08.679843+01:00",
                   "ipaddress": "10.0.0.5",
                   "host": 13
                 }
@@ -19088,6 +19795,8 @@
               "mxs": [],
               "txts": [
                 {
+                  "created_at": "2024-12-11T16:45:06.156299+01:00",
+                  "updated_at": "2024-12-11T16:45:06.156320+01:00",
                   "txt": "v=spf1 -all",
                   "host": 13
                 }
@@ -19096,6 +19805,8 @@
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
+              "created_at": "2024-12-11T16:45:06.137012+01:00",
+              "updated_at": "2024-12-11T16:45:06.137037+01:00",
               "name": "foo.example.org",
               "contact": "",
               "ttl": null,
@@ -19129,6 +19840,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:08.679831+01:00",
+              "updated_at": "2024-12-11T16:45:08.679843+01:00",
               "ipaddress": "10.0.0.5",
               "host": 13
             }
@@ -19137,6 +19850,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:06.156299+01:00",
+              "updated_at": "2024-12-11T16:45:06.156320+01:00",
               "txt": "v=spf1 -all",
               "host": 13
             }
@@ -19145,6 +19860,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:06.137012+01:00",
+          "updated_at": "2024-12-11T16:45:06.137037+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -19159,6 +19876,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:45:05.867822+01:00",
+          "updated_at": "2024-12-11T16:45:05.867856+01:00",
           "network": "10.0.0.0/24",
           "description": "foo",
           "vlan": 1234,
@@ -19179,6 +19898,8 @@
         "status": 201,
         "response": {
           "macaddress": "",
+          "created_at": "2024-12-11T16:45:08.962896+01:00",
+          "updated_at": "2024-12-11T16:45:08.962917+01:00",
           "ipaddress": "10.0.0.6",
           "host": 13
         }
@@ -19197,11 +19918,15 @@
               "ipaddresses": [
                 {
                   "macaddress": "",
+                  "created_at": "2024-12-11T16:45:08.679831+01:00",
+                  "updated_at": "2024-12-11T16:45:08.679843+01:00",
                   "ipaddress": "10.0.0.5",
                   "host": 13
                 },
                 {
                   "macaddress": "",
+                  "created_at": "2024-12-11T16:45:08.962896+01:00",
+                  "updated_at": "2024-12-11T16:45:08.962917+01:00",
                   "ipaddress": "10.0.0.6",
                   "host": 13
                 }
@@ -19210,6 +19935,8 @@
               "mxs": [],
               "txts": [
                 {
+                  "created_at": "2024-12-11T16:45:06.156299+01:00",
+                  "updated_at": "2024-12-11T16:45:06.156320+01:00",
                   "txt": "v=spf1 -all",
                   "host": 13
                 }
@@ -19218,6 +19945,8 @@
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
+              "created_at": "2024-12-11T16:45:06.137012+01:00",
+              "updated_at": "2024-12-11T16:45:06.137037+01:00",
               "name": "foo.example.org",
               "contact": "",
               "ttl": null,
@@ -19263,11 +19992,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:08.679831+01:00",
+              "updated_at": "2024-12-11T16:45:08.679843+01:00",
               "ipaddress": "10.0.0.5",
               "host": 13
             },
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:08.962896+01:00",
+              "updated_at": "2024-12-11T16:45:08.962917+01:00",
               "ipaddress": "10.0.0.6",
               "host": 13
             }
@@ -19276,6 +20009,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:06.156299+01:00",
+              "updated_at": "2024-12-11T16:45:06.156320+01:00",
               "txt": "v=spf1 -all",
               "host": 13
             }
@@ -19284,6 +20019,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:06.137012+01:00",
+          "updated_at": "2024-12-11T16:45:06.137037+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -19315,11 +20052,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:08.679831+01:00",
+              "updated_at": "2024-12-11T16:45:08.679843+01:00",
               "ipaddress": "10.0.0.5",
               "host": 13
             },
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:08.962896+01:00",
+              "updated_at": "2024-12-11T16:45:08.962917+01:00",
               "ipaddress": "10.0.0.6",
               "host": 13
             }
@@ -19328,6 +20069,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:06.156299+01:00",
+              "updated_at": "2024-12-11T16:45:06.156320+01:00",
               "txt": "v=spf1 -all",
               "host": 13
             }
@@ -19336,6 +20079,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:06.137012+01:00",
+          "updated_at": "2024-12-11T16:45:06.137037+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -19376,6 +20121,8 @@
           "results": [
             {
               "excluded_ranges": [],
+              "created_at": "2024-12-11T16:45:05.867822+01:00",
+              "updated_at": "2024-12-11T16:45:05.867856+01:00",
               "network": "10.0.0.0/24",
               "description": "foo",
               "vlan": 1234,
@@ -19406,6 +20153,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:45:09.480471+01:00",
+          "updated_at": "2024-12-11T16:45:09.480495+01:00",
           "network": "2001:db8::/64",
           "description": "foo_ipv6",
           "vlan": 1234,
@@ -19443,6 +20192,8 @@
           "results": [
             {
               "excluded_ranges": [],
+              "created_at": "2024-12-11T16:45:05.867822+01:00",
+              "updated_at": "2024-12-11T16:45:05.867856+01:00",
               "network": "10.0.0.0/24",
               "description": "foo",
               "vlan": 1234,
@@ -19454,6 +20205,8 @@
             },
             {
               "excluded_ranges": [],
+              "created_at": "2024-12-11T16:45:09.480471+01:00",
+              "updated_at": "2024-12-11T16:45:09.480495+01:00",
               "network": "2001:db8::/64",
               "description": "foo_ipv6",
               "vlan": 1234,
@@ -19484,6 +20237,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:45:09.641456+01:00",
+          "updated_at": "2024-12-11T16:45:09.641474+01:00",
           "network": "2001:db9::/64",
           "description": "notfoo_ipv6",
           "vlan": 1235,
@@ -19518,6 +20273,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:08.679831+01:00",
+              "updated_at": "2024-12-11T16:45:08.679843+01:00",
               "ipaddress": "10.0.0.5",
               "host": 13
             }
@@ -19526,6 +20283,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:06.156299+01:00",
+              "updated_at": "2024-12-11T16:45:06.156320+01:00",
               "txt": "v=spf1 -all",
               "host": 13
             }
@@ -19534,6 +20293,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:06.137012+01:00",
+          "updated_at": "2024-12-11T16:45:06.137037+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -19548,6 +20309,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:45:09.641456+01:00",
+          "updated_at": "2024-12-11T16:45:09.641474+01:00",
           "network": "2001:db9::/64",
           "description": "notfoo_ipv6",
           "vlan": 1235,
@@ -19568,6 +20331,8 @@
         "status": 201,
         "response": {
           "macaddress": "",
+          "created_at": "2024-12-11T16:45:09.887479+01:00",
+          "updated_at": "2024-12-11T16:45:09.887503+01:00",
           "ipaddress": "2001:db9::5",
           "host": 13
         }
@@ -19586,11 +20351,15 @@
               "ipaddresses": [
                 {
                   "macaddress": "",
+                  "created_at": "2024-12-11T16:45:08.679831+01:00",
+                  "updated_at": "2024-12-11T16:45:08.679843+01:00",
                   "ipaddress": "10.0.0.5",
                   "host": 13
                 },
                 {
                   "macaddress": "",
+                  "created_at": "2024-12-11T16:45:09.887479+01:00",
+                  "updated_at": "2024-12-11T16:45:09.887503+01:00",
                   "ipaddress": "2001:db9::5",
                   "host": 13
                 }
@@ -19599,6 +20368,8 @@
               "mxs": [],
               "txts": [
                 {
+                  "created_at": "2024-12-11T16:45:06.156299+01:00",
+                  "updated_at": "2024-12-11T16:45:06.156320+01:00",
                   "txt": "v=spf1 -all",
                   "host": 13
                 }
@@ -19607,6 +20378,8 @@
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
+              "created_at": "2024-12-11T16:45:06.137012+01:00",
+              "updated_at": "2024-12-11T16:45:06.137037+01:00",
               "name": "foo.example.org",
               "contact": "",
               "ttl": null,
@@ -19652,11 +20425,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:08.679831+01:00",
+              "updated_at": "2024-12-11T16:45:08.679843+01:00",
               "ipaddress": "10.0.0.5",
               "host": 13
             },
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:09.887479+01:00",
+              "updated_at": "2024-12-11T16:45:09.887503+01:00",
               "ipaddress": "2001:db9::5",
               "host": 13
             }
@@ -19665,6 +20442,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:06.156299+01:00",
+              "updated_at": "2024-12-11T16:45:06.156320+01:00",
               "txt": "v=spf1 -all",
               "host": 13
             }
@@ -19673,6 +20452,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:06.137012+01:00",
+          "updated_at": "2024-12-11T16:45:06.137037+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -19687,6 +20468,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:45:05.867822+01:00",
+          "updated_at": "2024-12-11T16:45:05.867856+01:00",
           "network": "10.0.0.0/24",
           "description": "foo",
           "vlan": 1234,
@@ -19704,6 +20487,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:45:09.641456+01:00",
+          "updated_at": "2024-12-11T16:45:09.641474+01:00",
           "network": "2001:db9::/64",
           "description": "notfoo_ipv6",
           "vlan": 1235,
@@ -19738,11 +20523,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:08.679831+01:00",
+              "updated_at": "2024-12-11T16:45:08.679843+01:00",
               "ipaddress": "10.0.0.5",
               "host": 13
             },
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:09.887479+01:00",
+              "updated_at": "2024-12-11T16:45:09.887503+01:00",
               "ipaddress": "2001:db9::5",
               "host": 13
             }
@@ -19751,6 +20540,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:06.156299+01:00",
+              "updated_at": "2024-12-11T16:45:06.156320+01:00",
               "txt": "v=spf1 -all",
               "host": 13
             }
@@ -19759,6 +20550,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:06.137012+01:00",
+          "updated_at": "2024-12-11T16:45:06.137037+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -19796,6 +20589,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:08.679831+01:00",
+              "updated_at": "2024-12-11T16:45:08.679843+01:00",
               "ipaddress": "10.0.0.5",
               "host": 13
             }
@@ -19804,6 +20599,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:06.156299+01:00",
+              "updated_at": "2024-12-11T16:45:06.156320+01:00",
               "txt": "v=spf1 -all",
               "host": 13
             }
@@ -19812,6 +20609,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:06.137012+01:00",
+          "updated_at": "2024-12-11T16:45:06.137037+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -19826,6 +20625,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:45:09.480471+01:00",
+          "updated_at": "2024-12-11T16:45:09.480495+01:00",
           "network": "2001:db8::/64",
           "description": "foo_ipv6",
           "vlan": 1234,
@@ -19846,6 +20647,8 @@
         "status": 201,
         "response": {
           "macaddress": "",
+          "created_at": "2024-12-11T16:45:10.531279+01:00",
+          "updated_at": "2024-12-11T16:45:10.531300+01:00",
           "ipaddress": "2001:db8::5",
           "host": 13
         }
@@ -19864,11 +20667,15 @@
               "ipaddresses": [
                 {
                   "macaddress": "",
+                  "created_at": "2024-12-11T16:45:08.679831+01:00",
+                  "updated_at": "2024-12-11T16:45:08.679843+01:00",
                   "ipaddress": "10.0.0.5",
                   "host": 13
                 },
                 {
                   "macaddress": "",
+                  "created_at": "2024-12-11T16:45:10.531279+01:00",
+                  "updated_at": "2024-12-11T16:45:10.531300+01:00",
                   "ipaddress": "2001:db8::5",
                   "host": 13
                 }
@@ -19877,6 +20684,8 @@
               "mxs": [],
               "txts": [
                 {
+                  "created_at": "2024-12-11T16:45:06.156299+01:00",
+                  "updated_at": "2024-12-11T16:45:06.156320+01:00",
                   "txt": "v=spf1 -all",
                   "host": 13
                 }
@@ -19885,6 +20694,8 @@
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
+              "created_at": "2024-12-11T16:45:06.137012+01:00",
+              "updated_at": "2024-12-11T16:45:06.137037+01:00",
               "name": "foo.example.org",
               "contact": "",
               "ttl": null,
@@ -19930,11 +20741,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:08.679831+01:00",
+              "updated_at": "2024-12-11T16:45:08.679843+01:00",
               "ipaddress": "10.0.0.5",
               "host": 13
             },
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:10.531279+01:00",
+              "updated_at": "2024-12-11T16:45:10.531300+01:00",
               "ipaddress": "2001:db8::5",
               "host": 13
             }
@@ -19943,6 +20758,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:06.156299+01:00",
+              "updated_at": "2024-12-11T16:45:06.156320+01:00",
               "txt": "v=spf1 -all",
               "host": 13
             }
@@ -19951,6 +20768,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:06.137012+01:00",
+          "updated_at": "2024-12-11T16:45:06.137037+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -19965,6 +20784,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:45:05.867822+01:00",
+          "updated_at": "2024-12-11T16:45:05.867856+01:00",
           "network": "10.0.0.0/24",
           "description": "foo",
           "vlan": 1234,
@@ -19982,6 +20803,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:45:09.480471+01:00",
+          "updated_at": "2024-12-11T16:45:09.480495+01:00",
           "network": "2001:db8::/64",
           "description": "foo_ipv6",
           "vlan": 1234,
@@ -20007,6 +20830,8 @@
         "status": 200,
         "response": {
           "macaddress": "aa:bb:cc:dd:ee:ff",
+          "created_at": "2024-12-11T16:45:08.679831+01:00",
+          "updated_at": "2024-12-11T16:45:11.011903+01:00",
           "ipaddress": "10.0.0.5",
           "host": 13
         }
@@ -20031,8 +20856,8 @@
       "              2001:db8::5   <not set>",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Thu Nov 21 10:34:55 2024",
-      "Updated:      Thu Nov 21 10:34:55 2024"
+      "Created:      Wed Dec 11 16:45:06 2024",
+      "Updated:      Wed Dec 11 16:45:06 2024"
     ],
     "api_requests": [
       {
@@ -20044,11 +20869,15 @@
           "ipaddresses": [
             {
               "macaddress": "aa:bb:cc:dd:ee:ff",
+              "created_at": "2024-12-11T16:45:08.679831+01:00",
+              "updated_at": "2024-12-11T16:45:11.011903+01:00",
               "ipaddress": "10.0.0.5",
               "host": 13
             },
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:10.531279+01:00",
+              "updated_at": "2024-12-11T16:45:10.531300+01:00",
               "ipaddress": "2001:db8::5",
               "host": 13
             }
@@ -20057,6 +20886,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:06.156299+01:00",
+              "updated_at": "2024-12-11T16:45:06.156320+01:00",
               "txt": "v=spf1 -all",
               "host": 13
             }
@@ -20065,6 +20896,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:06.137012+01:00",
+          "updated_at": "2024-12-11T16:45:06.137037+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -20156,11 +20989,15 @@
           "ipaddresses": [
             {
               "macaddress": "aa:bb:cc:dd:ee:ff",
+              "created_at": "2024-12-11T16:45:08.679831+01:00",
+              "updated_at": "2024-12-11T16:45:11.011903+01:00",
               "ipaddress": "10.0.0.5",
               "host": 13
             },
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:10.531279+01:00",
+              "updated_at": "2024-12-11T16:45:10.531300+01:00",
               "ipaddress": "2001:db8::5",
               "host": 13
             }
@@ -20169,6 +21006,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:06.156299+01:00",
+              "updated_at": "2024-12-11T16:45:06.156320+01:00",
               "txt": "v=spf1 -all",
               "host": 13
             }
@@ -20177,6 +21016,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:06.137012+01:00",
+          "updated_at": "2024-12-11T16:45:06.137037+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -20191,6 +21032,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:45:05.867822+01:00",
+          "updated_at": "2024-12-11T16:45:05.867856+01:00",
           "network": "10.0.0.0/24",
           "description": "foo",
           "vlan": 1234,
@@ -20208,6 +21051,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:45:09.480471+01:00",
+          "updated_at": "2024-12-11T16:45:09.480495+01:00",
           "network": "2001:db8::/64",
           "description": "foo_ipv6",
           "vlan": 1234,
@@ -20270,6 +21115,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:45:05.867822+01:00",
+          "updated_at": "2024-12-11T16:45:05.867856+01:00",
           "network": "10.0.0.0/24",
           "description": "foo",
           "vlan": 1234,
@@ -20315,6 +21162,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:45:09.480471+01:00",
+          "updated_at": "2024-12-11T16:45:09.480495+01:00",
           "network": "2001:db8::/64",
           "description": "foo_ipv6",
           "vlan": 1234,
@@ -20360,6 +21209,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:45:09.641456+01:00",
+          "updated_at": "2024-12-11T16:45:09.641474+01:00",
           "network": "2001:db9::/64",
           "description": "notfoo_ipv6",
           "vlan": 1235,
@@ -20427,6 +21278,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:45:12.363738+01:00",
+          "updated_at": "2024-12-11T16:45:12.363771+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -20464,6 +21317,8 @@
           "results": [
             {
               "excluded_ranges": [],
+              "created_at": "2024-12-11T16:45:12.363738+01:00",
+              "updated_at": "2024-12-11T16:45:12.363771+01:00",
               "network": "10.0.0.0/24",
               "description": "lorem ipsum",
               "vlan": null,
@@ -20493,6 +21348,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:45:12.555848+01:00",
+          "updated_at": "2024-12-11T16:45:12.555870+01:00",
           "network": "2001:db8::/64",
           "description": "dolor sit amet",
           "vlan": null,
@@ -20524,8 +21381,8 @@
       "              10.0.0.10     11:22:33:aa:bb:cc",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Tue Oct  8 15:31:20 2024",
-      "Updated:      Tue Oct  8 15:31:20 2024"
+      "Created:      Wed Dec 11 16:45:12 2024",
+      "Updated:      Wed Dec 11 16:45:12 2024"
     ],
     "api_requests": [
       {
@@ -20567,13 +21424,18 @@
           "zone": {
             "nameservers": [
               {
+                "created_at": "2024-12-11T16:44:40.356452+01:00",
+                "updated_at": "2024-12-11T16:44:40.356481+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
+            "created_at": "2024-12-11T16:44:39.701254+01:00",
+            "updated_at": "2024-12-11T16:45:11.813653+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
+            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -20590,6 +21452,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:45:12.363738+01:00",
+          "updated_at": "2024-12-11T16:45:12.363771+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -20620,6 +21484,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:12.965204+01:00",
+              "updated_at": "2024-12-11T16:45:12.965220+01:00",
               "ipaddress": "10.0.0.10",
               "host": 14
             }
@@ -20628,6 +21494,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:12.938227+01:00",
+              "updated_at": "2024-12-11T16:45:12.938240+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -20636,6 +21504,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:12.933964+01:00",
+          "updated_at": "2024-12-11T16:45:12.933979+01:00",
           "name": "foo.example.org",
           "contact": "hi@ho.com",
           "ttl": null,
@@ -20670,6 +21540,8 @@
         "status": 200,
         "response": {
           "macaddress": "11:22:33:aa:bb:cc",
+          "created_at": "2024-12-11T16:45:12.965204+01:00",
+          "updated_at": "2024-12-11T16:45:13.218208+01:00",
           "ipaddress": "10.0.0.10",
           "host": 14
         }
@@ -20688,6 +21560,8 @@
               "ipaddresses": [
                 {
                   "macaddress": "11:22:33:aa:bb:cc",
+                  "created_at": "2024-12-11T16:45:12.965204+01:00",
+                  "updated_at": "2024-12-11T16:45:13.218208+01:00",
                   "ipaddress": "10.0.0.10",
                   "host": 14
                 }
@@ -20696,6 +21570,8 @@
               "mxs": [],
               "txts": [
                 {
+                  "created_at": "2024-12-11T16:45:12.938227+01:00",
+                  "updated_at": "2024-12-11T16:45:12.938240+01:00",
                   "txt": "v=spf1 -all",
                   "host": 14
                 }
@@ -20704,6 +21580,8 @@
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
+              "created_at": "2024-12-11T16:45:12.933964+01:00",
+              "updated_at": "2024-12-11T16:45:12.933979+01:00",
               "name": "foo.example.org",
               "contact": "hi@ho.com",
               "ttl": null,
@@ -20792,8 +21670,8 @@
       "              10.0.0.10     11:22:33:aa:bb:cc",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Tue Oct  8 15:31:20 2024",
-      "Updated:      Tue Oct  8 15:31:20 2024"
+      "Created:      Wed Dec 11 16:45:12 2024",
+      "Updated:      Wed Dec 11 16:45:12 2024"
     ],
     "api_requests": [
       {
@@ -20805,6 +21683,8 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
+              "created_at": "2024-12-11T16:45:12.965204+01:00",
+              "updated_at": "2024-12-11T16:45:13.218208+01:00",
               "ipaddress": "10.0.0.10",
               "host": 14
             }
@@ -20813,6 +21693,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:12.938227+01:00",
+              "updated_at": "2024-12-11T16:45:12.938240+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -20821,6 +21703,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:12.933964+01:00",
+          "updated_at": "2024-12-11T16:45:12.933979+01:00",
           "name": "foo.example.org",
           "contact": "hi@ho.com",
           "ttl": null,
@@ -20918,6 +21802,8 @@
               "ipaddresses": [
                 {
                   "macaddress": "11:22:33:aa:bb:cc",
+                  "created_at": "2024-12-11T16:45:12.965204+01:00",
+                  "updated_at": "2024-12-11T16:45:13.218208+01:00",
                   "ipaddress": "10.0.0.10",
                   "host": 14
                 }
@@ -20926,6 +21812,8 @@
               "mxs": [],
               "txts": [
                 {
+                  "created_at": "2024-12-11T16:45:12.938227+01:00",
+                  "updated_at": "2024-12-11T16:45:12.938240+01:00",
                   "txt": "v=spf1 -all",
                   "host": 14
                 }
@@ -20934,6 +21822,8 @@
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
+              "created_at": "2024-12-11T16:45:12.933964+01:00",
+              "updated_at": "2024-12-11T16:45:12.933979+01:00",
               "name": "foo.example.org",
               "contact": "hi@ho.com",
               "ttl": null,
@@ -20973,6 +21863,8 @@
               "ipaddresses": [
                 {
                   "macaddress": "11:22:33:aa:bb:cc",
+                  "created_at": "2024-12-11T16:45:12.965204+01:00",
+                  "updated_at": "2024-12-11T16:45:13.218208+01:00",
                   "ipaddress": "10.0.0.10",
                   "host": 14
                 }
@@ -20981,6 +21873,8 @@
               "mxs": [],
               "txts": [
                 {
+                  "created_at": "2024-12-11T16:45:12.938227+01:00",
+                  "updated_at": "2024-12-11T16:45:12.938240+01:00",
                   "txt": "v=spf1 -all",
                   "host": 14
                 }
@@ -20989,6 +21883,8 @@
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
+              "created_at": "2024-12-11T16:45:12.933964+01:00",
+              "updated_at": "2024-12-11T16:45:12.933979+01:00",
               "name": "foo.example.org",
               "contact": "hi@ho.com",
               "ttl": null,
@@ -21028,6 +21924,8 @@
               "ipaddresses": [
                 {
                   "macaddress": "11:22:33:aa:bb:cc",
+                  "created_at": "2024-12-11T16:45:12.965204+01:00",
+                  "updated_at": "2024-12-11T16:45:13.218208+01:00",
                   "ipaddress": "10.0.0.10",
                   "host": 14
                 }
@@ -21036,6 +21934,8 @@
               "mxs": [],
               "txts": [
                 {
+                  "created_at": "2024-12-11T16:45:12.938227+01:00",
+                  "updated_at": "2024-12-11T16:45:12.938240+01:00",
                   "txt": "v=spf1 -all",
                   "host": 14
                 }
@@ -21044,6 +21944,8 @@
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
+              "created_at": "2024-12-11T16:45:12.933964+01:00",
+              "updated_at": "2024-12-11T16:45:12.933979+01:00",
               "name": "foo.example.org",
               "contact": "hi@ho.com",
               "ttl": null,
@@ -21083,6 +21985,8 @@
               "ipaddresses": [
                 {
                   "macaddress": "11:22:33:aa:bb:cc",
+                  "created_at": "2024-12-11T16:45:12.965204+01:00",
+                  "updated_at": "2024-12-11T16:45:13.218208+01:00",
                   "ipaddress": "10.0.0.10",
                   "host": 14
                 }
@@ -21091,6 +21995,8 @@
               "mxs": [],
               "txts": [
                 {
+                  "created_at": "2024-12-11T16:45:12.938227+01:00",
+                  "updated_at": "2024-12-11T16:45:12.938240+01:00",
                   "txt": "v=spf1 -all",
                   "host": 14
                 }
@@ -21099,6 +22005,8 @@
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
+              "created_at": "2024-12-11T16:45:12.933964+01:00",
+              "updated_at": "2024-12-11T16:45:12.933979+01:00",
               "name": "foo.example.org",
               "contact": "hi@ho.com",
               "ttl": null,
@@ -21132,6 +22040,8 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
+              "created_at": "2024-12-11T16:45:12.965204+01:00",
+              "updated_at": "2024-12-11T16:45:13.218208+01:00",
               "ipaddress": "10.0.0.10",
               "host": 14
             }
@@ -21140,6 +22050,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:12.938227+01:00",
+              "updated_at": "2024-12-11T16:45:12.938240+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -21148,6 +22060,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:12.933964+01:00",
+          "updated_at": "2024-12-11T16:45:12.933979+01:00",
           "name": "foo.example.org",
           "contact": "hi@ho.com",
           "ttl": null,
@@ -21182,13 +22096,18 @@
           "zone": {
             "nameservers": [
               {
+                "created_at": "2024-12-11T16:44:40.356452+01:00",
+                "updated_at": "2024-12-11T16:44:40.356481+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
+            "created_at": "2024-12-11T16:44:39.701254+01:00",
+            "updated_at": "2024-12-11T16:45:13.207899+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
+            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -21220,6 +22139,8 @@
               "ipaddresses": [
                 {
                   "macaddress": "11:22:33:aa:bb:cc",
+                  "created_at": "2024-12-11T16:45:12.965204+01:00",
+                  "updated_at": "2024-12-11T16:45:13.218208+01:00",
                   "ipaddress": "10.0.0.10",
                   "host": 14
                 }
@@ -21228,6 +22149,8 @@
               "mxs": [],
               "txts": [
                 {
+                  "created_at": "2024-12-11T16:45:12.938227+01:00",
+                  "updated_at": "2024-12-11T16:45:12.938240+01:00",
                   "txt": "v=spf1 -all",
                   "host": 14
                 }
@@ -21236,6 +22159,8 @@
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
+              "created_at": "2024-12-11T16:45:12.933964+01:00",
+              "updated_at": "2024-12-11T16:45:14.695886+01:00",
               "name": "bar.example.org",
               "contact": "hi@ho.com",
               "ttl": null,
@@ -21269,6 +22194,8 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
+              "created_at": "2024-12-11T16:45:12.965204+01:00",
+              "updated_at": "2024-12-11T16:45:13.218208+01:00",
               "ipaddress": "10.0.0.10",
               "host": 14
             }
@@ -21277,6 +22204,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:12.938227+01:00",
+              "updated_at": "2024-12-11T16:45:12.938240+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -21285,6 +22214,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:12.933964+01:00",
+          "updated_at": "2024-12-11T16:45:14.695886+01:00",
           "name": "bar.example.org",
           "contact": "hi@ho.com",
           "ttl": null,
@@ -21314,6 +22245,8 @@
               "ipaddresses": [
                 {
                   "macaddress": "11:22:33:aa:bb:cc",
+                  "created_at": "2024-12-11T16:45:12.965204+01:00",
+                  "updated_at": "2024-12-11T16:45:13.218208+01:00",
                   "ipaddress": "10.0.0.10",
                   "host": 14
                 }
@@ -21322,6 +22255,8 @@
               "mxs": [],
               "txts": [
                 {
+                  "created_at": "2024-12-11T16:45:12.938227+01:00",
+                  "updated_at": "2024-12-11T16:45:12.938240+01:00",
                   "txt": "v=spf1 -all",
                   "host": 14
                 }
@@ -21330,6 +22265,8 @@
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
+              "created_at": "2024-12-11T16:45:12.933964+01:00",
+              "updated_at": "2024-12-11T16:45:15.002679+01:00",
               "name": "bar.example.org",
               "contact": "hi@ho.com",
               "ttl": null,
@@ -21363,6 +22300,8 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
+              "created_at": "2024-12-11T16:45:12.965204+01:00",
+              "updated_at": "2024-12-11T16:45:13.218208+01:00",
               "ipaddress": "10.0.0.10",
               "host": 14
             }
@@ -21371,6 +22310,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:12.938227+01:00",
+              "updated_at": "2024-12-11T16:45:12.938240+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -21379,6 +22320,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:12.933964+01:00",
+          "updated_at": "2024-12-11T16:45:15.002679+01:00",
           "name": "bar.example.org",
           "contact": "hi@ho.com",
           "ttl": null,
@@ -21423,6 +22366,8 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
+              "created_at": "2024-12-11T16:45:12.965204+01:00",
+              "updated_at": "2024-12-11T16:45:13.218208+01:00",
               "ipaddress": "10.0.0.10",
               "host": 14
             }
@@ -21431,6 +22376,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:12.938227+01:00",
+              "updated_at": "2024-12-11T16:45:12.938240+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -21439,6 +22386,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:12.933964+01:00",
+          "updated_at": "2024-12-11T16:45:15.002679+01:00",
           "name": "bar.example.org",
           "contact": "hi@ho.com",
           "ttl": null,
@@ -21468,6 +22417,8 @@
               "ipaddresses": [
                 {
                   "macaddress": "11:22:33:aa:bb:cc",
+                  "created_at": "2024-12-11T16:45:12.965204+01:00",
+                  "updated_at": "2024-12-11T16:45:13.218208+01:00",
                   "ipaddress": "10.0.0.10",
                   "host": 14
                 }
@@ -21476,6 +22427,8 @@
               "mxs": [],
               "txts": [
                 {
+                  "created_at": "2024-12-11T16:45:12.938227+01:00",
+                  "updated_at": "2024-12-11T16:45:12.938240+01:00",
                   "txt": "v=spf1 -all",
                   "host": 14
                 }
@@ -21484,6 +22437,8 @@
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
+              "created_at": "2024-12-11T16:45:12.933964+01:00",
+              "updated_at": "2024-12-11T16:45:15.502403+01:00",
               "name": "bar.example.org",
               "contact": "me@example.org",
               "ttl": null,
@@ -21517,6 +22472,8 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
+              "created_at": "2024-12-11T16:45:12.965204+01:00",
+              "updated_at": "2024-12-11T16:45:13.218208+01:00",
               "ipaddress": "10.0.0.10",
               "host": 14
             }
@@ -21525,6 +22482,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:12.938227+01:00",
+              "updated_at": "2024-12-11T16:45:12.938240+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -21533,6 +22492,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:12.933964+01:00",
+          "updated_at": "2024-12-11T16:45:15.502403+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -21547,6 +22508,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:45:12.363738+01:00",
+          "updated_at": "2024-12-11T16:45:12.363771+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -21581,6 +22544,8 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
+              "created_at": "2024-12-11T16:45:12.965204+01:00",
+              "updated_at": "2024-12-11T16:45:13.218208+01:00",
               "ipaddress": "10.0.0.10",
               "host": 14
             }
@@ -21589,6 +22554,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:12.938227+01:00",
+              "updated_at": "2024-12-11T16:45:12.938240+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -21597,6 +22564,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:12.933964+01:00",
+          "updated_at": "2024-12-11T16:45:15.502403+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -21611,6 +22580,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:45:12.363738+01:00",
+          "updated_at": "2024-12-11T16:45:12.363771+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -21631,6 +22602,8 @@
         "status": 201,
         "response": {
           "macaddress": "",
+          "created_at": "2024-12-11T16:45:15.977555+01:00",
+          "updated_at": "2024-12-11T16:45:15.977566+01:00",
           "ipaddress": "10.0.0.12",
           "host": 14
         }
@@ -21649,11 +22622,15 @@
               "ipaddresses": [
                 {
                   "macaddress": "11:22:33:aa:bb:cc",
+                  "created_at": "2024-12-11T16:45:12.965204+01:00",
+                  "updated_at": "2024-12-11T16:45:13.218208+01:00",
                   "ipaddress": "10.0.0.10",
                   "host": 14
                 },
                 {
                   "macaddress": "",
+                  "created_at": "2024-12-11T16:45:15.977555+01:00",
+                  "updated_at": "2024-12-11T16:45:15.977566+01:00",
                   "ipaddress": "10.0.0.12",
                   "host": 14
                 }
@@ -21662,6 +22639,8 @@
               "mxs": [],
               "txts": [
                 {
+                  "created_at": "2024-12-11T16:45:12.938227+01:00",
+                  "updated_at": "2024-12-11T16:45:12.938240+01:00",
                   "txt": "v=spf1 -all",
                   "host": 14
                 }
@@ -21670,6 +22649,8 @@
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
+              "created_at": "2024-12-11T16:45:12.933964+01:00",
+              "updated_at": "2024-12-11T16:45:15.502403+01:00",
               "name": "bar.example.org",
               "contact": "me@example.org",
               "ttl": null,
@@ -21703,11 +22684,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
+              "created_at": "2024-12-11T16:45:12.965204+01:00",
+              "updated_at": "2024-12-11T16:45:13.218208+01:00",
               "ipaddress": "10.0.0.10",
               "host": 14
             },
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:15.977555+01:00",
+              "updated_at": "2024-12-11T16:45:15.977566+01:00",
               "ipaddress": "10.0.0.12",
               "host": 14
             }
@@ -21716,6 +22701,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:12.938227+01:00",
+              "updated_at": "2024-12-11T16:45:12.938240+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -21724,6 +22711,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:12.933964+01:00",
+          "updated_at": "2024-12-11T16:45:15.502403+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -21738,6 +22727,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:45:12.363738+01:00",
+          "updated_at": "2024-12-11T16:45:12.363771+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -21759,6 +22750,8 @@
         "status": 201,
         "response": {
           "macaddress": "11:22:33:44:55:66",
+          "created_at": "2024-12-11T16:45:16.291195+01:00",
+          "updated_at": "2024-12-11T16:45:16.291214+01:00",
           "ipaddress": "10.0.0.13",
           "host": 14
         }
@@ -21777,16 +22770,22 @@
               "ipaddresses": [
                 {
                   "macaddress": "11:22:33:aa:bb:cc",
+                  "created_at": "2024-12-11T16:45:12.965204+01:00",
+                  "updated_at": "2024-12-11T16:45:13.218208+01:00",
                   "ipaddress": "10.0.0.10",
                   "host": 14
                 },
                 {
                   "macaddress": "",
+                  "created_at": "2024-12-11T16:45:15.977555+01:00",
+                  "updated_at": "2024-12-11T16:45:15.977566+01:00",
                   "ipaddress": "10.0.0.12",
                   "host": 14
                 },
                 {
                   "macaddress": "11:22:33:44:55:66",
+                  "created_at": "2024-12-11T16:45:16.291195+01:00",
+                  "updated_at": "2024-12-11T16:45:16.291214+01:00",
                   "ipaddress": "10.0.0.13",
                   "host": 14
                 }
@@ -21795,6 +22794,8 @@
               "mxs": [],
               "txts": [
                 {
+                  "created_at": "2024-12-11T16:45:12.938227+01:00",
+                  "updated_at": "2024-12-11T16:45:12.938240+01:00",
                   "txt": "v=spf1 -all",
                   "host": 14
                 }
@@ -21803,6 +22804,8 @@
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
+              "created_at": "2024-12-11T16:45:12.933964+01:00",
+              "updated_at": "2024-12-11T16:45:15.502403+01:00",
               "name": "bar.example.org",
               "contact": "me@example.org",
               "ttl": null,
@@ -21836,16 +22839,22 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
+              "created_at": "2024-12-11T16:45:12.965204+01:00",
+              "updated_at": "2024-12-11T16:45:13.218208+01:00",
               "ipaddress": "10.0.0.10",
               "host": 14
             },
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:15.977555+01:00",
+              "updated_at": "2024-12-11T16:45:15.977566+01:00",
               "ipaddress": "10.0.0.12",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
+              "created_at": "2024-12-11T16:45:16.291195+01:00",
+              "updated_at": "2024-12-11T16:45:16.291214+01:00",
               "ipaddress": "10.0.0.13",
               "host": 14
             }
@@ -21854,6 +22863,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:12.938227+01:00",
+              "updated_at": "2024-12-11T16:45:12.938240+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -21862,6 +22873,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:12.933964+01:00",
+          "updated_at": "2024-12-11T16:45:15.502403+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -21876,6 +22889,8 @@
         "status": 200,
         "response": {
           "macaddress": "",
+          "created_at": "2024-12-11T16:45:15.977555+01:00",
+          "updated_at": "2024-12-11T16:45:15.977566+01:00",
           "ipaddress": "10.0.0.12",
           "host": 14
         }
@@ -21907,6 +22922,8 @@
         "status": 200,
         "response": {
           "macaddress": "",
+          "created_at": "2024-12-11T16:45:15.977555+01:00",
+          "updated_at": "2024-12-11T16:45:16.676520+01:00",
           "ipaddress": "10.0.0.14",
           "host": 14
         }
@@ -21935,16 +22952,22 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
+              "created_at": "2024-12-11T16:45:12.965204+01:00",
+              "updated_at": "2024-12-11T16:45:13.218208+01:00",
               "ipaddress": "10.0.0.10",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
+              "created_at": "2024-12-11T16:45:16.291195+01:00",
+              "updated_at": "2024-12-11T16:45:16.291214+01:00",
               "ipaddress": "10.0.0.13",
               "host": 14
             },
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:15.977555+01:00",
+              "updated_at": "2024-12-11T16:45:16.676520+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             }
@@ -21953,6 +22976,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:12.938227+01:00",
+              "updated_at": "2024-12-11T16:45:12.938240+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -21961,6 +22986,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:12.933964+01:00",
+          "updated_at": "2024-12-11T16:45:15.502403+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -21975,6 +23002,8 @@
         "status": 200,
         "response": {
           "macaddress": "11:22:33:44:55:66",
+          "created_at": "2024-12-11T16:45:16.291195+01:00",
+          "updated_at": "2024-12-11T16:45:16.291214+01:00",
           "ipaddress": "10.0.0.13",
           "host": 14
         }
@@ -22006,6 +23035,8 @@
         "status": 200,
         "response": {
           "macaddress": "11:22:33:44:55:66",
+          "created_at": "2024-12-11T16:45:16.291195+01:00",
+          "updated_at": "2024-12-11T16:45:16.979511+01:00",
           "ipaddress": "10.0.0.15",
           "host": 14
         }
@@ -22034,16 +23065,22 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
+              "created_at": "2024-12-11T16:45:12.965204+01:00",
+              "updated_at": "2024-12-11T16:45:13.218208+01:00",
               "ipaddress": "10.0.0.10",
               "host": 14
             },
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:15.977555+01:00",
+              "updated_at": "2024-12-11T16:45:16.676520+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
+              "created_at": "2024-12-11T16:45:16.291195+01:00",
+              "updated_at": "2024-12-11T16:45:16.979511+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
@@ -22052,6 +23089,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:12.938227+01:00",
+              "updated_at": "2024-12-11T16:45:12.938240+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -22060,6 +23099,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:12.933964+01:00",
+          "updated_at": "2024-12-11T16:45:15.502403+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -22085,8 +23126,8 @@
       "Contact:      ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Tue Oct  8 15:31:21 2024",
-      "Updated:      Tue Oct  8 15:31:21 2024"
+      "Created:      Wed Dec 11 16:45:17 2024",
+      "Updated:      Wed Dec 11 16:45:17 2024"
     ],
     "api_requests": [
       {
@@ -22116,13 +23157,18 @@
           "zone": {
             "nameservers": [
               {
+                "created_at": "2024-12-11T16:44:40.356452+01:00",
+                "updated_at": "2024-12-11T16:44:40.356481+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
+            "created_at": "2024-12-11T16:44:39.701254+01:00",
+            "updated_at": "2024-12-11T16:45:16.974494+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
+            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -22151,6 +23197,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:17.316836+01:00",
+              "updated_at": "2024-12-11T16:45:17.316858+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
@@ -22159,6 +23207,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:17.293046+01:00",
+          "updated_at": "2024-12-11T16:45:17.293070+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -22250,16 +23300,22 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
+              "created_at": "2024-12-11T16:45:12.965204+01:00",
+              "updated_at": "2024-12-11T16:45:13.218208+01:00",
               "ipaddress": "10.0.0.10",
               "host": 14
             },
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:15.977555+01:00",
+              "updated_at": "2024-12-11T16:45:16.676520+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
+              "created_at": "2024-12-11T16:45:16.291195+01:00",
+              "updated_at": "2024-12-11T16:45:16.979511+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
@@ -22268,6 +23324,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:12.938227+01:00",
+              "updated_at": "2024-12-11T16:45:12.938240+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -22276,6 +23334,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:12.933964+01:00",
+          "updated_at": "2024-12-11T16:45:15.502403+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -22294,6 +23354,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:17.316836+01:00",
+              "updated_at": "2024-12-11T16:45:17.316858+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
@@ -22302,6 +23364,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:17.293046+01:00",
+          "updated_at": "2024-12-11T16:45:17.293070+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -22324,6 +23388,8 @@
         "status": 200,
         "response": {
           "macaddress": "11:22:33:aa:bb:cc",
+          "created_at": "2024-12-11T16:45:12.965204+01:00",
+          "updated_at": "2024-12-11T16:45:17.976116+01:00",
           "ipaddress": "10.0.0.10",
           "host": 15
         }
@@ -22353,6 +23419,8 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
+              "created_at": "2024-12-11T16:45:12.965204+01:00",
+              "updated_at": "2024-12-11T16:45:17.976116+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             }
@@ -22361,6 +23429,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:17.316836+01:00",
+              "updated_at": "2024-12-11T16:45:17.316858+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
@@ -22369,6 +23439,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:17.293046+01:00",
+          "updated_at": "2024-12-11T16:45:17.293070+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -22400,11 +23472,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:15.977555+01:00",
+              "updated_at": "2024-12-11T16:45:16.676520+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
+              "created_at": "2024-12-11T16:45:16.291195+01:00",
+              "updated_at": "2024-12-11T16:45:16.979511+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
@@ -22413,6 +23489,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:12.938227+01:00",
+              "updated_at": "2024-12-11T16:45:12.938240+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -22421,6 +23499,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:12.933964+01:00",
+          "updated_at": "2024-12-11T16:45:15.502403+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -22435,6 +23515,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:45:12.555848+01:00",
+          "updated_at": "2024-12-11T16:45:12.555870+01:00",
           "network": "2001:db8::/64",
           "description": "dolor sit amet",
           "vlan": null,
@@ -22476,11 +23558,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:15.977555+01:00",
+              "updated_at": "2024-12-11T16:45:16.676520+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
+              "created_at": "2024-12-11T16:45:16.291195+01:00",
+              "updated_at": "2024-12-11T16:45:16.979511+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
@@ -22489,6 +23575,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:12.938227+01:00",
+              "updated_at": "2024-12-11T16:45:12.938240+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -22497,6 +23585,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:12.933964+01:00",
+          "updated_at": "2024-12-11T16:45:15.502403+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -22511,6 +23601,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:45:12.555848+01:00",
+          "updated_at": "2024-12-11T16:45:12.555870+01:00",
           "network": "2001:db8::/64",
           "description": "dolor sit amet",
           "vlan": null,
@@ -22531,6 +23623,8 @@
         "status": 201,
         "response": {
           "macaddress": "",
+          "created_at": "2024-12-11T16:45:18.437354+01:00",
+          "updated_at": "2024-12-11T16:45:18.437376+01:00",
           "ipaddress": "2001:db8::11",
           "host": 14
         }
@@ -22549,16 +23643,22 @@
               "ipaddresses": [
                 {
                   "macaddress": "",
+                  "created_at": "2024-12-11T16:45:15.977555+01:00",
+                  "updated_at": "2024-12-11T16:45:16.676520+01:00",
                   "ipaddress": "10.0.0.14",
                   "host": 14
                 },
                 {
                   "macaddress": "11:22:33:44:55:66",
+                  "created_at": "2024-12-11T16:45:16.291195+01:00",
+                  "updated_at": "2024-12-11T16:45:16.979511+01:00",
                   "ipaddress": "10.0.0.15",
                   "host": 14
                 },
                 {
                   "macaddress": "",
+                  "created_at": "2024-12-11T16:45:18.437354+01:00",
+                  "updated_at": "2024-12-11T16:45:18.437376+01:00",
                   "ipaddress": "2001:db8::11",
                   "host": 14
                 }
@@ -22567,6 +23667,8 @@
               "mxs": [],
               "txts": [
                 {
+                  "created_at": "2024-12-11T16:45:12.938227+01:00",
+                  "updated_at": "2024-12-11T16:45:12.938240+01:00",
                   "txt": "v=spf1 -all",
                   "host": 14
                 }
@@ -22575,6 +23677,8 @@
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
+              "created_at": "2024-12-11T16:45:12.933964+01:00",
+              "updated_at": "2024-12-11T16:45:15.502403+01:00",
               "name": "bar.example.org",
               "contact": "me@example.org",
               "ttl": null,
@@ -22608,16 +23712,22 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:15.977555+01:00",
+              "updated_at": "2024-12-11T16:45:16.676520+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
+              "created_at": "2024-12-11T16:45:16.291195+01:00",
+              "updated_at": "2024-12-11T16:45:16.979511+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             },
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:18.437354+01:00",
+              "updated_at": "2024-12-11T16:45:18.437376+01:00",
               "ipaddress": "2001:db8::11",
               "host": 14
             }
@@ -22626,6 +23736,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:12.938227+01:00",
+              "updated_at": "2024-12-11T16:45:12.938240+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -22634,6 +23746,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:12.933964+01:00",
+          "updated_at": "2024-12-11T16:45:15.502403+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -22648,6 +23762,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:45:12.555848+01:00",
+          "updated_at": "2024-12-11T16:45:12.555870+01:00",
           "network": "2001:db8::/64",
           "description": "dolor sit amet",
           "vlan": null,
@@ -22669,6 +23785,8 @@
         "status": 201,
         "response": {
           "macaddress": "11:22:33:44:55:67",
+          "created_at": "2024-12-11T16:45:18.689074+01:00",
+          "updated_at": "2024-12-11T16:45:18.689090+01:00",
           "ipaddress": "2001:db8::12",
           "host": 14
         }
@@ -22687,21 +23805,29 @@
               "ipaddresses": [
                 {
                   "macaddress": "",
+                  "created_at": "2024-12-11T16:45:15.977555+01:00",
+                  "updated_at": "2024-12-11T16:45:16.676520+01:00",
                   "ipaddress": "10.0.0.14",
                   "host": 14
                 },
                 {
                   "macaddress": "11:22:33:44:55:66",
+                  "created_at": "2024-12-11T16:45:16.291195+01:00",
+                  "updated_at": "2024-12-11T16:45:16.979511+01:00",
                   "ipaddress": "10.0.0.15",
                   "host": 14
                 },
                 {
                   "macaddress": "",
+                  "created_at": "2024-12-11T16:45:18.437354+01:00",
+                  "updated_at": "2024-12-11T16:45:18.437376+01:00",
                   "ipaddress": "2001:db8::11",
                   "host": 14
                 },
                 {
                   "macaddress": "11:22:33:44:55:67",
+                  "created_at": "2024-12-11T16:45:18.689074+01:00",
+                  "updated_at": "2024-12-11T16:45:18.689090+01:00",
                   "ipaddress": "2001:db8::12",
                   "host": 14
                 }
@@ -22710,6 +23836,8 @@
               "mxs": [],
               "txts": [
                 {
+                  "created_at": "2024-12-11T16:45:12.938227+01:00",
+                  "updated_at": "2024-12-11T16:45:12.938240+01:00",
                   "txt": "v=spf1 -all",
                   "host": 14
                 }
@@ -22718,6 +23846,8 @@
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
+              "created_at": "2024-12-11T16:45:12.933964+01:00",
+              "updated_at": "2024-12-11T16:45:15.502403+01:00",
               "name": "bar.example.org",
               "contact": "me@example.org",
               "ttl": null,
@@ -22751,21 +23881,29 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:15.977555+01:00",
+              "updated_at": "2024-12-11T16:45:16.676520+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
+              "created_at": "2024-12-11T16:45:16.291195+01:00",
+              "updated_at": "2024-12-11T16:45:16.979511+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             },
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:18.437354+01:00",
+              "updated_at": "2024-12-11T16:45:18.437376+01:00",
               "ipaddress": "2001:db8::11",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:67",
+              "created_at": "2024-12-11T16:45:18.689074+01:00",
+              "updated_at": "2024-12-11T16:45:18.689090+01:00",
               "ipaddress": "2001:db8::12",
               "host": 14
             }
@@ -22774,6 +23912,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:12.938227+01:00",
+              "updated_at": "2024-12-11T16:45:12.938240+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -22782,6 +23922,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:12.933964+01:00",
+          "updated_at": "2024-12-11T16:45:15.502403+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -22796,6 +23938,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:45:12.363738+01:00",
+          "updated_at": "2024-12-11T16:45:12.363771+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -22813,6 +23957,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:45:12.363738+01:00",
+          "updated_at": "2024-12-11T16:45:12.363771+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -22830,6 +23976,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:45:12.555848+01:00",
+          "updated_at": "2024-12-11T16:45:12.555870+01:00",
           "network": "2001:db8::/64",
           "description": "dolor sit amet",
           "vlan": null,
@@ -22847,6 +23995,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:45:12.555848+01:00",
+          "updated_at": "2024-12-11T16:45:12.555870+01:00",
           "network": "2001:db8::/64",
           "description": "dolor sit amet",
           "vlan": null,
@@ -22907,21 +24057,29 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:15.977555+01:00",
+              "updated_at": "2024-12-11T16:45:16.676520+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
+              "created_at": "2024-12-11T16:45:16.291195+01:00",
+              "updated_at": "2024-12-11T16:45:16.979511+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             },
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:18.437354+01:00",
+              "updated_at": "2024-12-11T16:45:18.437376+01:00",
               "ipaddress": "2001:db8::11",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:67",
+              "created_at": "2024-12-11T16:45:18.689074+01:00",
+              "updated_at": "2024-12-11T16:45:18.689090+01:00",
               "ipaddress": "2001:db8::12",
               "host": 14
             }
@@ -22930,6 +24088,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:12.938227+01:00",
+              "updated_at": "2024-12-11T16:45:12.938240+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -22938,6 +24098,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:12.933964+01:00",
+          "updated_at": "2024-12-11T16:45:15.502403+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -22969,21 +24131,29 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:15.977555+01:00",
+              "updated_at": "2024-12-11T16:45:16.676520+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
+              "created_at": "2024-12-11T16:45:16.291195+01:00",
+              "updated_at": "2024-12-11T16:45:16.979511+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             },
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:18.437354+01:00",
+              "updated_at": "2024-12-11T16:45:18.437376+01:00",
               "ipaddress": "2001:db8::11",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:67",
+              "created_at": "2024-12-11T16:45:18.689074+01:00",
+              "updated_at": "2024-12-11T16:45:18.689090+01:00",
               "ipaddress": "2001:db8::12",
               "host": 14
             }
@@ -22992,6 +24162,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:12.938227+01:00",
+              "updated_at": "2024-12-11T16:45:12.938240+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -23000,6 +24172,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:12.933964+01:00",
+          "updated_at": "2024-12-11T16:45:15.502403+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -23014,6 +24188,8 @@
         "status": 200,
         "response": {
           "macaddress": "",
+          "created_at": "2024-12-11T16:45:18.437354+01:00",
+          "updated_at": "2024-12-11T16:45:18.437376+01:00",
           "ipaddress": "2001:db8::11",
           "host": 14
         }
@@ -23045,6 +24221,8 @@
         "status": 200,
         "response": {
           "macaddress": "",
+          "created_at": "2024-12-11T16:45:18.437354+01:00",
+          "updated_at": "2024-12-11T16:45:19.477304+01:00",
           "ipaddress": "2001:db8::13",
           "host": 14
         }
@@ -23073,21 +24251,29 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:15.977555+01:00",
+              "updated_at": "2024-12-11T16:45:16.676520+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
+              "created_at": "2024-12-11T16:45:16.291195+01:00",
+              "updated_at": "2024-12-11T16:45:16.979511+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:67",
+              "created_at": "2024-12-11T16:45:18.689074+01:00",
+              "updated_at": "2024-12-11T16:45:18.689090+01:00",
               "ipaddress": "2001:db8::12",
               "host": 14
             },
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:18.437354+01:00",
+              "updated_at": "2024-12-11T16:45:19.477304+01:00",
               "ipaddress": "2001:db8::13",
               "host": 14
             }
@@ -23096,6 +24282,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:12.938227+01:00",
+              "updated_at": "2024-12-11T16:45:12.938240+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -23104,6 +24292,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:12.933964+01:00",
+          "updated_at": "2024-12-11T16:45:15.502403+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -23118,6 +24308,8 @@
         "status": 200,
         "response": {
           "macaddress": "11:22:33:44:55:67",
+          "created_at": "2024-12-11T16:45:18.689074+01:00",
+          "updated_at": "2024-12-11T16:45:18.689090+01:00",
           "ipaddress": "2001:db8::12",
           "host": 14
         }
@@ -23149,6 +24341,8 @@
         "status": 200,
         "response": {
           "macaddress": "11:22:33:44:55:67",
+          "created_at": "2024-12-11T16:45:18.689074+01:00",
+          "updated_at": "2024-12-11T16:45:19.788296+01:00",
           "ipaddress": "2001:db8::14",
           "host": 14
         }
@@ -23177,21 +24371,29 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:15.977555+01:00",
+              "updated_at": "2024-12-11T16:45:16.676520+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
+              "created_at": "2024-12-11T16:45:16.291195+01:00",
+              "updated_at": "2024-12-11T16:45:16.979511+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             },
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:18.437354+01:00",
+              "updated_at": "2024-12-11T16:45:19.477304+01:00",
               "ipaddress": "2001:db8::13",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:67",
+              "created_at": "2024-12-11T16:45:18.689074+01:00",
+              "updated_at": "2024-12-11T16:45:19.788296+01:00",
               "ipaddress": "2001:db8::14",
               "host": 14
             }
@@ -23200,6 +24402,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:12.938227+01:00",
+              "updated_at": "2024-12-11T16:45:12.938240+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -23208,6 +24412,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:12.933964+01:00",
+          "updated_at": "2024-12-11T16:45:15.502403+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -23245,16 +24451,22 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:15.977555+01:00",
+              "updated_at": "2024-12-11T16:45:16.676520+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
+              "created_at": "2024-12-11T16:45:16.291195+01:00",
+              "updated_at": "2024-12-11T16:45:16.979511+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:67",
+              "created_at": "2024-12-11T16:45:18.689074+01:00",
+              "updated_at": "2024-12-11T16:45:19.788296+01:00",
               "ipaddress": "2001:db8::14",
               "host": 14
             }
@@ -23263,6 +24475,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:12.938227+01:00",
+              "updated_at": "2024-12-11T16:45:12.938240+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -23271,6 +24485,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:12.933964+01:00",
+          "updated_at": "2024-12-11T16:45:15.502403+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -23287,6 +24503,8 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
+              "created_at": "2024-12-11T16:45:12.965204+01:00",
+              "updated_at": "2024-12-11T16:45:17.976116+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             }
@@ -23295,6 +24513,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:17.316836+01:00",
+              "updated_at": "2024-12-11T16:45:17.316858+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
@@ -23303,6 +24523,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:17.293046+01:00",
+          "updated_at": "2024-12-11T16:45:17.293070+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -23325,6 +24547,8 @@
         "status": 200,
         "response": {
           "macaddress": "11:22:33:44:55:67",
+          "created_at": "2024-12-11T16:45:18.689074+01:00",
+          "updated_at": "2024-12-11T16:45:20.166005+01:00",
           "ipaddress": "2001:db8::14",
           "host": 15
         }
@@ -23354,11 +24578,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
+              "created_at": "2024-12-11T16:45:12.965204+01:00",
+              "updated_at": "2024-12-11T16:45:17.976116+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             },
             {
               "macaddress": "11:22:33:44:55:67",
+              "created_at": "2024-12-11T16:45:18.689074+01:00",
+              "updated_at": "2024-12-11T16:45:20.166005+01:00",
               "ipaddress": "2001:db8::14",
               "host": 15
             }
@@ -23367,6 +24595,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:17.316836+01:00",
+              "updated_at": "2024-12-11T16:45:17.316858+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
@@ -23375,6 +24605,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:17.293046+01:00",
+          "updated_at": "2024-12-11T16:45:17.293070+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -23406,11 +24638,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:15.977555+01:00",
+              "updated_at": "2024-12-11T16:45:16.676520+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
+              "created_at": "2024-12-11T16:45:16.291195+01:00",
+              "updated_at": "2024-12-11T16:45:16.979511+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
@@ -23419,6 +24655,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:12.938227+01:00",
+              "updated_at": "2024-12-11T16:45:12.938240+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -23427,6 +24665,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:12.933964+01:00",
+          "updated_at": "2024-12-11T16:45:15.502403+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -23461,13 +24701,18 @@
           "zone": {
             "nameservers": [
               {
+                "created_at": "2024-12-11T16:44:40.356452+01:00",
+                "updated_at": "2024-12-11T16:44:40.356481+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
+            "created_at": "2024-12-11T16:44:39.701254+01:00",
+            "updated_at": "2024-12-11T16:45:20.161160+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
+            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -23486,6 +24731,8 @@
         },
         "status": 201,
         "response": {
+          "created_at": "2024-12-11T16:45:20.454046+01:00",
+          "updated_at": "2024-12-11T16:45:20.454066+01:00",
           "name": "fubar.example.org",
           "ttl": null,
           "zone": 1,
@@ -23501,17 +24748,23 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:15.977555+01:00",
+              "updated_at": "2024-12-11T16:45:16.676520+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
+              "created_at": "2024-12-11T16:45:16.291195+01:00",
+              "updated_at": "2024-12-11T16:45:16.979511+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
           ],
           "cnames": [
             {
+              "created_at": "2024-12-11T16:45:20.454046+01:00",
+              "updated_at": "2024-12-11T16:45:20.454066+01:00",
               "name": "fubar.example.org",
               "ttl": null,
               "zone": 1,
@@ -23521,6 +24774,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:12.938227+01:00",
+              "updated_at": "2024-12-11T16:45:12.938240+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -23529,6 +24784,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:12.933964+01:00",
+          "updated_at": "2024-12-11T16:45:15.502403+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -23547,6 +24804,8 @@
           "previous": null,
           "results": [
             {
+              "created_at": "2024-12-11T16:45:20.454046+01:00",
+              "updated_at": "2024-12-11T16:45:20.454066+01:00",
               "name": "fubar.example.org",
               "ttl": null,
               "zone": 1,
@@ -23579,17 +24838,23 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:15.977555+01:00",
+              "updated_at": "2024-12-11T16:45:16.676520+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
+              "created_at": "2024-12-11T16:45:16.291195+01:00",
+              "updated_at": "2024-12-11T16:45:16.979511+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
           ],
           "cnames": [
             {
+              "created_at": "2024-12-11T16:45:20.454046+01:00",
+              "updated_at": "2024-12-11T16:45:20.454066+01:00",
               "name": "fubar.example.org",
               "ttl": null,
               "zone": 1,
@@ -23599,6 +24864,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:12.938227+01:00",
+              "updated_at": "2024-12-11T16:45:12.938240+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -23607,6 +24874,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:12.933964+01:00",
+          "updated_at": "2024-12-11T16:45:15.502403+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -23621,6 +24890,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:45:12.363738+01:00",
+          "updated_at": "2024-12-11T16:45:12.363771+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -23638,6 +24909,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:45:12.363738+01:00",
+          "updated_at": "2024-12-11T16:45:12.363771+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -23696,17 +24969,23 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:15.977555+01:00",
+              "updated_at": "2024-12-11T16:45:16.676520+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
+              "created_at": "2024-12-11T16:45:16.291195+01:00",
+              "updated_at": "2024-12-11T16:45:16.979511+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
           ],
           "cnames": [
             {
+              "created_at": "2024-12-11T16:45:20.454046+01:00",
+              "updated_at": "2024-12-11T16:45:20.454066+01:00",
               "name": "fubar.example.org",
               "ttl": null,
               "zone": 1,
@@ -23716,6 +24995,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:12.938227+01:00",
+              "updated_at": "2024-12-11T16:45:12.938240+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -23724,6 +25005,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:12.933964+01:00",
+          "updated_at": "2024-12-11T16:45:15.502403+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -23755,17 +25038,23 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:15.977555+01:00",
+              "updated_at": "2024-12-11T16:45:16.676520+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
+              "created_at": "2024-12-11T16:45:16.291195+01:00",
+              "updated_at": "2024-12-11T16:45:16.979511+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
           ],
           "cnames": [
             {
+              "created_at": "2024-12-11T16:45:20.454046+01:00",
+              "updated_at": "2024-12-11T16:45:20.454066+01:00",
               "name": "fubar.example.org",
               "ttl": null,
               "zone": 1,
@@ -23775,6 +25064,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:12.938227+01:00",
+              "updated_at": "2024-12-11T16:45:12.938240+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -23783,6 +25074,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:12.933964+01:00",
+          "updated_at": "2024-12-11T16:45:15.502403+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -23805,6 +25098,8 @@
         "data": {},
         "status": 200,
         "response": {
+          "created_at": "2024-12-11T16:45:20.454046+01:00",
+          "updated_at": "2024-12-11T16:45:20.454066+01:00",
           "name": "fubar.example.org",
           "ttl": null,
           "zone": 1,
@@ -23841,11 +25136,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
+              "created_at": "2024-12-11T16:45:12.965204+01:00",
+              "updated_at": "2024-12-11T16:45:17.976116+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             },
             {
               "macaddress": "11:22:33:44:55:67",
+              "created_at": "2024-12-11T16:45:18.689074+01:00",
+              "updated_at": "2024-12-11T16:45:20.166005+01:00",
               "ipaddress": "2001:db8::14",
               "host": 15
             }
@@ -23854,6 +25153,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:17.316836+01:00",
+              "updated_at": "2024-12-11T16:45:17.316858+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
@@ -23862,6 +25163,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:17.293046+01:00",
+          "updated_at": "2024-12-11T16:45:17.293070+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -23880,6 +25183,8 @@
         "status": 201,
         "response": {
           "host": 15,
+          "created_at": "2024-12-11T16:45:21.275602+01:00",
+          "updated_at": "2024-12-11T16:45:21.275631+01:00",
           "cpu": "x86",
           "os": "Win"
         }
@@ -23898,11 +25203,15 @@
               "ipaddresses": [
                 {
                   "macaddress": "11:22:33:aa:bb:cc",
+                  "created_at": "2024-12-11T16:45:12.965204+01:00",
+                  "updated_at": "2024-12-11T16:45:17.976116+01:00",
                   "ipaddress": "10.0.0.10",
                   "host": 15
                 },
                 {
                   "macaddress": "11:22:33:44:55:67",
+                  "created_at": "2024-12-11T16:45:18.689074+01:00",
+                  "updated_at": "2024-12-11T16:45:20.166005+01:00",
                   "ipaddress": "2001:db8::14",
                   "host": 15
                 }
@@ -23911,6 +25220,8 @@
               "mxs": [],
               "txts": [
                 {
+                  "created_at": "2024-12-11T16:45:17.316836+01:00",
+                  "updated_at": "2024-12-11T16:45:17.316858+01:00",
                   "txt": "v=spf1 -all",
                   "host": 15
                 }
@@ -23918,11 +25229,15 @@
               "ptr_overrides": [],
               "hinfo": {
                 "host": 15,
+                "created_at": "2024-12-11T16:45:21.275602+01:00",
+                "updated_at": "2024-12-11T16:45:21.275631+01:00",
                 "cpu": "x86",
                 "os": "Win"
               },
               "loc": null,
               "bacnetid": null,
+              "created_at": "2024-12-11T16:45:17.293046+01:00",
+              "updated_at": "2024-12-11T16:45:17.293070+01:00",
               "name": "baz.example.org",
               "contact": "",
               "ttl": null,
@@ -23956,11 +25271,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
+              "created_at": "2024-12-11T16:45:12.965204+01:00",
+              "updated_at": "2024-12-11T16:45:17.976116+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             },
             {
               "macaddress": "11:22:33:44:55:67",
+              "created_at": "2024-12-11T16:45:18.689074+01:00",
+              "updated_at": "2024-12-11T16:45:20.166005+01:00",
               "ipaddress": "2001:db8::14",
               "host": 15
             }
@@ -23969,6 +25288,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:17.316836+01:00",
+              "updated_at": "2024-12-11T16:45:17.316858+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
@@ -23976,11 +25297,15 @@
           "ptr_overrides": [],
           "hinfo": {
             "host": 15,
+            "created_at": "2024-12-11T16:45:21.275602+01:00",
+            "updated_at": "2024-12-11T16:45:21.275631+01:00",
             "cpu": "x86",
             "os": "Win"
           },
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:17.293046+01:00",
+          "updated_at": "2024-12-11T16:45:17.293070+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -23995,6 +25320,8 @@
         "status": 200,
         "response": {
           "host": 15,
+          "created_at": "2024-12-11T16:45:21.275602+01:00",
+          "updated_at": "2024-12-11T16:45:21.275631+01:00",
           "cpu": "x86",
           "os": "Win"
         }
@@ -24023,11 +25350,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
+              "created_at": "2024-12-11T16:45:12.965204+01:00",
+              "updated_at": "2024-12-11T16:45:17.976116+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             },
             {
               "macaddress": "11:22:33:44:55:67",
+              "created_at": "2024-12-11T16:45:18.689074+01:00",
+              "updated_at": "2024-12-11T16:45:20.166005+01:00",
               "ipaddress": "2001:db8::14",
               "host": 15
             }
@@ -24036,6 +25367,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:17.316836+01:00",
+              "updated_at": "2024-12-11T16:45:17.316858+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
@@ -24043,11 +25376,15 @@
           "ptr_overrides": [],
           "hinfo": {
             "host": 15,
+            "created_at": "2024-12-11T16:45:21.275602+01:00",
+            "updated_at": "2024-12-11T16:45:21.275631+01:00",
             "cpu": "x86",
             "os": "Win"
           },
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:17.293046+01:00",
+          "updated_at": "2024-12-11T16:45:17.293070+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -24062,6 +25399,8 @@
         "status": 200,
         "response": {
           "host": 15,
+          "created_at": "2024-12-11T16:45:21.275602+01:00",
+          "updated_at": "2024-12-11T16:45:21.275631+01:00",
           "cpu": "x86",
           "os": "Win"
         }
@@ -24096,11 +25435,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
+              "created_at": "2024-12-11T16:45:12.965204+01:00",
+              "updated_at": "2024-12-11T16:45:17.976116+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             },
             {
               "macaddress": "11:22:33:44:55:67",
+              "created_at": "2024-12-11T16:45:18.689074+01:00",
+              "updated_at": "2024-12-11T16:45:20.166005+01:00",
               "ipaddress": "2001:db8::14",
               "host": 15
             }
@@ -24109,6 +25452,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:17.316836+01:00",
+              "updated_at": "2024-12-11T16:45:17.316858+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
@@ -24117,6 +25462,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:17.293046+01:00",
+          "updated_at": "2024-12-11T16:45:17.293070+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -24134,6 +25481,8 @@
         "status": 201,
         "response": {
           "host": 15,
+          "created_at": "2024-12-11T16:45:21.726240+01:00",
+          "updated_at": "2024-12-11T16:45:21.726255+01:00",
           "loc": "52 22 23.000 N 4 53 32.000 E -2.00m 0.00m 10000m 10m"
         }
       },
@@ -24151,11 +25500,15 @@
               "ipaddresses": [
                 {
                   "macaddress": "11:22:33:aa:bb:cc",
+                  "created_at": "2024-12-11T16:45:12.965204+01:00",
+                  "updated_at": "2024-12-11T16:45:17.976116+01:00",
                   "ipaddress": "10.0.0.10",
                   "host": 15
                 },
                 {
                   "macaddress": "11:22:33:44:55:67",
+                  "created_at": "2024-12-11T16:45:18.689074+01:00",
+                  "updated_at": "2024-12-11T16:45:20.166005+01:00",
                   "ipaddress": "2001:db8::14",
                   "host": 15
                 }
@@ -24164,6 +25517,8 @@
               "mxs": [],
               "txts": [
                 {
+                  "created_at": "2024-12-11T16:45:17.316836+01:00",
+                  "updated_at": "2024-12-11T16:45:17.316858+01:00",
                   "txt": "v=spf1 -all",
                   "host": 15
                 }
@@ -24172,9 +25527,13 @@
               "hinfo": null,
               "loc": {
                 "host": 15,
+                "created_at": "2024-12-11T16:45:21.726240+01:00",
+                "updated_at": "2024-12-11T16:45:21.726255+01:00",
                 "loc": "52 22 23.000 N 4 53 32.000 E -2.00m 0.00m 10000m 10m"
               },
               "bacnetid": null,
+              "created_at": "2024-12-11T16:45:17.293046+01:00",
+              "updated_at": "2024-12-11T16:45:17.293070+01:00",
               "name": "baz.example.org",
               "contact": "",
               "ttl": null,
@@ -24208,11 +25567,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
+              "created_at": "2024-12-11T16:45:12.965204+01:00",
+              "updated_at": "2024-12-11T16:45:17.976116+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             },
             {
               "macaddress": "11:22:33:44:55:67",
+              "created_at": "2024-12-11T16:45:18.689074+01:00",
+              "updated_at": "2024-12-11T16:45:20.166005+01:00",
               "ipaddress": "2001:db8::14",
               "host": 15
             }
@@ -24221,6 +25584,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:17.316836+01:00",
+              "updated_at": "2024-12-11T16:45:17.316858+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
@@ -24229,9 +25594,13 @@
           "hinfo": null,
           "loc": {
             "host": 15,
+            "created_at": "2024-12-11T16:45:21.726240+01:00",
+            "updated_at": "2024-12-11T16:45:21.726255+01:00",
             "loc": "52 22 23.000 N 4 53 32.000 E -2.00m 0.00m 10000m 10m"
           },
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:17.293046+01:00",
+          "updated_at": "2024-12-11T16:45:17.293070+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -24263,11 +25632,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
+              "created_at": "2024-12-11T16:45:12.965204+01:00",
+              "updated_at": "2024-12-11T16:45:17.976116+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             },
             {
               "macaddress": "11:22:33:44:55:67",
+              "created_at": "2024-12-11T16:45:18.689074+01:00",
+              "updated_at": "2024-12-11T16:45:20.166005+01:00",
               "ipaddress": "2001:db8::14",
               "host": 15
             }
@@ -24276,6 +25649,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:17.316836+01:00",
+              "updated_at": "2024-12-11T16:45:17.316858+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
@@ -24284,9 +25659,13 @@
           "hinfo": null,
           "loc": {
             "host": 15,
+            "created_at": "2024-12-11T16:45:21.726240+01:00",
+            "updated_at": "2024-12-11T16:45:21.726255+01:00",
             "loc": "52 22 23.000 N 4 53 32.000 E -2.00m 0.00m 10000m 10m"
           },
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:17.293046+01:00",
+          "updated_at": "2024-12-11T16:45:17.293070+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -24324,11 +25703,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
+              "created_at": "2024-12-11T16:45:12.965204+01:00",
+              "updated_at": "2024-12-11T16:45:17.976116+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             },
             {
               "macaddress": "11:22:33:44:55:67",
+              "created_at": "2024-12-11T16:45:18.689074+01:00",
+              "updated_at": "2024-12-11T16:45:20.166005+01:00",
               "ipaddress": "2001:db8::14",
               "host": 15
             }
@@ -24337,6 +25720,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:17.316836+01:00",
+              "updated_at": "2024-12-11T16:45:17.316858+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
@@ -24345,6 +25730,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:17.293046+01:00",
+          "updated_at": "2024-12-11T16:45:17.293070+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -24362,6 +25749,8 @@
         },
         "status": 201,
         "response": {
+          "created_at": "2024-12-11T16:45:22.104171+01:00",
+          "updated_at": "2024-12-11T16:45:22.104192+01:00",
           "priority": 10,
           "mx": "mail.example.org",
           "host": 15
@@ -24392,11 +25781,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
+              "created_at": "2024-12-11T16:45:12.965204+01:00",
+              "updated_at": "2024-12-11T16:45:17.976116+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             },
             {
               "macaddress": "11:22:33:44:55:67",
+              "created_at": "2024-12-11T16:45:18.689074+01:00",
+              "updated_at": "2024-12-11T16:45:20.166005+01:00",
               "ipaddress": "2001:db8::14",
               "host": 15
             }
@@ -24404,6 +25797,8 @@
           "cnames": [],
           "mxs": [
             {
+              "created_at": "2024-12-11T16:45:22.104171+01:00",
+              "updated_at": "2024-12-11T16:45:22.104192+01:00",
               "priority": 10,
               "mx": "mail.example.org",
               "host": 15
@@ -24411,6 +25806,8 @@
           ],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:17.316836+01:00",
+              "updated_at": "2024-12-11T16:45:17.316858+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
@@ -24419,6 +25816,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:17.293046+01:00",
+          "updated_at": "2024-12-11T16:45:17.293070+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -24450,11 +25849,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
+              "created_at": "2024-12-11T16:45:12.965204+01:00",
+              "updated_at": "2024-12-11T16:45:17.976116+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             },
             {
               "macaddress": "11:22:33:44:55:67",
+              "created_at": "2024-12-11T16:45:18.689074+01:00",
+              "updated_at": "2024-12-11T16:45:20.166005+01:00",
               "ipaddress": "2001:db8::14",
               "host": 15
             }
@@ -24462,6 +25865,8 @@
           "cnames": [],
           "mxs": [
             {
+              "created_at": "2024-12-11T16:45:22.104171+01:00",
+              "updated_at": "2024-12-11T16:45:22.104192+01:00",
               "priority": 10,
               "mx": "mail.example.org",
               "host": 15
@@ -24469,6 +25874,8 @@
           ],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:17.316836+01:00",
+              "updated_at": "2024-12-11T16:45:17.316858+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
@@ -24477,6 +25884,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:17.293046+01:00",
+          "updated_at": "2024-12-11T16:45:17.293070+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -24491,6 +25900,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:45:12.363738+01:00",
+          "updated_at": "2024-12-11T16:45:12.363771+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -24508,6 +25919,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:45:12.555848+01:00",
+          "updated_at": "2024-12-11T16:45:12.555870+01:00",
           "network": "2001:db8::/64",
           "description": "dolor sit amet",
           "vlan": null,
@@ -24566,11 +25979,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
+              "created_at": "2024-12-11T16:45:12.965204+01:00",
+              "updated_at": "2024-12-11T16:45:17.976116+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             },
             {
               "macaddress": "11:22:33:44:55:67",
+              "created_at": "2024-12-11T16:45:18.689074+01:00",
+              "updated_at": "2024-12-11T16:45:20.166005+01:00",
               "ipaddress": "2001:db8::14",
               "host": 15
             }
@@ -24578,6 +25995,8 @@
           "cnames": [],
           "mxs": [
             {
+              "created_at": "2024-12-11T16:45:22.104171+01:00",
+              "updated_at": "2024-12-11T16:45:22.104192+01:00",
               "priority": 10,
               "mx": "mail.example.org",
               "host": 15
@@ -24585,6 +26004,8 @@
           ],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:17.316836+01:00",
+              "updated_at": "2024-12-11T16:45:17.316858+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
@@ -24593,6 +26014,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:17.293046+01:00",
+          "updated_at": "2024-12-11T16:45:17.293070+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -24611,6 +26034,8 @@
           "previous": null,
           "results": [
             {
+              "created_at": "2024-12-11T16:45:22.104171+01:00",
+              "updated_at": "2024-12-11T16:45:22.104192+01:00",
               "priority": 10,
               "mx": "mail.example.org",
               "host": 15
@@ -24648,11 +26073,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
+              "created_at": "2024-12-11T16:45:12.965204+01:00",
+              "updated_at": "2024-12-11T16:45:17.976116+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             },
             {
               "macaddress": "11:22:33:44:55:67",
+              "created_at": "2024-12-11T16:45:18.689074+01:00",
+              "updated_at": "2024-12-11T16:45:20.166005+01:00",
               "ipaddress": "2001:db8::14",
               "host": 15
             }
@@ -24661,6 +26090,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:17.316836+01:00",
+              "updated_at": "2024-12-11T16:45:17.316858+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
@@ -24669,6 +26100,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:17.293046+01:00",
+          "updated_at": "2024-12-11T16:45:17.293070+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -24702,6 +26135,8 @@
         },
         "status": 201,
         "response": {
+          "created_at": "2024-12-11T16:45:22.749075+01:00",
+          "updated_at": "2024-12-11T16:45:22.749092+01:00",
           "preference": 16384,
           "order": 3,
           "flag": "u",
@@ -24736,11 +26171,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
+              "created_at": "2024-12-11T16:45:12.965204+01:00",
+              "updated_at": "2024-12-11T16:45:17.976116+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             },
             {
               "macaddress": "11:22:33:44:55:67",
+              "created_at": "2024-12-11T16:45:18.689074+01:00",
+              "updated_at": "2024-12-11T16:45:20.166005+01:00",
               "ipaddress": "2001:db8::14",
               "host": 15
             }
@@ -24749,6 +26188,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:17.316836+01:00",
+              "updated_at": "2024-12-11T16:45:17.316858+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
@@ -24757,6 +26198,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:17.293046+01:00",
+          "updated_at": "2024-12-11T16:45:17.293070+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -24775,6 +26218,8 @@
           "previous": null,
           "results": [
             {
+              "created_at": "2024-12-11T16:45:22.749075+01:00",
+              "updated_at": "2024-12-11T16:45:22.749092+01:00",
               "preference": 16384,
               "order": 3,
               "flag": "u",
@@ -24810,11 +26255,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
+              "created_at": "2024-12-11T16:45:12.965204+01:00",
+              "updated_at": "2024-12-11T16:45:17.976116+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             },
             {
               "macaddress": "11:22:33:44:55:67",
+              "created_at": "2024-12-11T16:45:18.689074+01:00",
+              "updated_at": "2024-12-11T16:45:20.166005+01:00",
               "ipaddress": "2001:db8::14",
               "host": 15
             }
@@ -24823,6 +26272,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:17.316836+01:00",
+              "updated_at": "2024-12-11T16:45:17.316858+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
@@ -24831,6 +26282,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:17.293046+01:00",
+          "updated_at": "2024-12-11T16:45:17.293070+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -24849,6 +26302,8 @@
           "previous": null,
           "results": [
             {
+              "created_at": "2024-12-11T16:45:22.749075+01:00",
+              "updated_at": "2024-12-11T16:45:22.749092+01:00",
               "preference": 16384,
               "order": 3,
               "flag": "u",
@@ -24890,11 +26345,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
+              "created_at": "2024-12-11T16:45:12.965204+01:00",
+              "updated_at": "2024-12-11T16:45:17.976116+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             },
             {
               "macaddress": "11:22:33:44:55:67",
+              "created_at": "2024-12-11T16:45:18.689074+01:00",
+              "updated_at": "2024-12-11T16:45:20.166005+01:00",
               "ipaddress": "2001:db8::14",
               "host": 15
             }
@@ -24903,6 +26362,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:17.316836+01:00",
+              "updated_at": "2024-12-11T16:45:17.316858+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
@@ -24911,6 +26372,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:17.293046+01:00",
+          "updated_at": "2024-12-11T16:45:17.293070+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -24937,6 +26400,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:45:12.363738+01:00",
+          "updated_at": "2024-12-11T16:45:12.363771+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -24969,6 +26434,8 @@
         },
         "status": 201,
         "response": {
+          "created_at": "2024-12-11T16:45:23.272704+01:00",
+          "updated_at": "2024-12-11T16:45:23.272722+01:00",
           "ipaddress": "10.0.0.20",
           "host": 15
         }
@@ -25014,11 +26481,15 @@
               "ipaddresses": [
                 {
                   "macaddress": "11:22:33:aa:bb:cc",
+                  "created_at": "2024-12-11T16:45:12.965204+01:00",
+                  "updated_at": "2024-12-11T16:45:17.976116+01:00",
                   "ipaddress": "10.0.0.10",
                   "host": 15
                 },
                 {
                   "macaddress": "11:22:33:44:55:67",
+                  "created_at": "2024-12-11T16:45:18.689074+01:00",
+                  "updated_at": "2024-12-11T16:45:20.166005+01:00",
                   "ipaddress": "2001:db8::14",
                   "host": 15
                 }
@@ -25027,12 +26498,16 @@
               "mxs": [],
               "txts": [
                 {
+                  "created_at": "2024-12-11T16:45:17.316836+01:00",
+                  "updated_at": "2024-12-11T16:45:17.316858+01:00",
                   "txt": "v=spf1 -all",
                   "host": 15
                 }
               ],
               "ptr_overrides": [
                 {
+                  "created_at": "2024-12-11T16:45:23.272704+01:00",
+                  "updated_at": "2024-12-11T16:45:23.272722+01:00",
                   "ipaddress": "10.0.0.20",
                   "host": 15
                 }
@@ -25040,6 +26515,8 @@
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
+              "created_at": "2024-12-11T16:45:17.293046+01:00",
+              "updated_at": "2024-12-11T16:45:17.293070+01:00",
               "name": "baz.example.org",
               "contact": "",
               "ttl": null,
@@ -25063,11 +26540,15 @@
               "ipaddresses": [
                 {
                   "macaddress": "11:22:33:aa:bb:cc",
+                  "created_at": "2024-12-11T16:45:12.965204+01:00",
+                  "updated_at": "2024-12-11T16:45:17.976116+01:00",
                   "ipaddress": "10.0.0.10",
                   "host": 15
                 },
                 {
                   "macaddress": "11:22:33:44:55:67",
+                  "created_at": "2024-12-11T16:45:18.689074+01:00",
+                  "updated_at": "2024-12-11T16:45:20.166005+01:00",
                   "ipaddress": "2001:db8::14",
                   "host": 15
                 }
@@ -25076,12 +26557,16 @@
               "mxs": [],
               "txts": [
                 {
+                  "created_at": "2024-12-11T16:45:17.316836+01:00",
+                  "updated_at": "2024-12-11T16:45:17.316858+01:00",
                   "txt": "v=spf1 -all",
                   "host": 15
                 }
               ],
               "ptr_overrides": [
                 {
+                  "created_at": "2024-12-11T16:45:23.272704+01:00",
+                  "updated_at": "2024-12-11T16:45:23.272722+01:00",
                   "ipaddress": "10.0.0.20",
                   "host": 15
                 }
@@ -25089,6 +26574,8 @@
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
+              "created_at": "2024-12-11T16:45:17.293046+01:00",
+              "updated_at": "2024-12-11T16:45:17.293070+01:00",
               "name": "baz.example.org",
               "contact": "",
               "ttl": null,
@@ -25116,8 +26603,8 @@
       "Contact:      ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Tue Oct  8 15:31:22 2024",
-      "Updated:      Tue Oct  8 15:31:22 2024"
+      "Created:      Wed Dec 11 16:45:23 2024",
+      "Updated:      Wed Dec 11 16:45:23 2024"
     ],
     "api_requests": [
       {
@@ -25147,13 +26634,18 @@
           "zone": {
             "nameservers": [
               {
+                "created_at": "2024-12-11T16:44:40.356452+01:00",
+                "updated_at": "2024-12-11T16:44:40.356481+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
+            "created_at": "2024-12-11T16:44:39.701254+01:00",
+            "updated_at": "2024-12-11T16:45:23.262277+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
+            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -25182,6 +26674,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:23.750260+01:00",
+              "updated_at": "2024-12-11T16:45:23.750274+01:00",
               "txt": "v=spf1 -all",
               "host": 16
             }
@@ -25190,6 +26684,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:23.732624+01:00",
+          "updated_at": "2024-12-11T16:45:23.732643+01:00",
           "name": "clover.example.org",
           "contact": "",
           "ttl": null,
@@ -25281,11 +26777,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
+              "created_at": "2024-12-11T16:45:12.965204+01:00",
+              "updated_at": "2024-12-11T16:45:17.976116+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             },
             {
               "macaddress": "11:22:33:44:55:67",
+              "created_at": "2024-12-11T16:45:18.689074+01:00",
+              "updated_at": "2024-12-11T16:45:20.166005+01:00",
               "ipaddress": "2001:db8::14",
               "host": 15
             }
@@ -25294,12 +26794,16 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:17.316836+01:00",
+              "updated_at": "2024-12-11T16:45:17.316858+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
           ],
           "ptr_overrides": [
             {
+              "created_at": "2024-12-11T16:45:23.272704+01:00",
+              "updated_at": "2024-12-11T16:45:23.272722+01:00",
               "ipaddress": "10.0.0.20",
               "host": 15
             }
@@ -25307,6 +26811,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:17.293046+01:00",
+          "updated_at": "2024-12-11T16:45:17.293070+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -25325,6 +26831,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:23.750260+01:00",
+              "updated_at": "2024-12-11T16:45:23.750274+01:00",
               "txt": "v=spf1 -all",
               "host": 16
             }
@@ -25333,6 +26841,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:23.732624+01:00",
+          "updated_at": "2024-12-11T16:45:23.732643+01:00",
           "name": "clover.example.org",
           "contact": "",
           "ttl": null,
@@ -25354,6 +26864,8 @@
         "data": {},
         "status": 200,
         "response": {
+          "created_at": "2024-12-11T16:45:23.272704+01:00",
+          "updated_at": "2024-12-11T16:45:24.254413+01:00",
           "ipaddress": "10.0.0.20",
           "host": 16
         }
@@ -25384,12 +26896,16 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:23.750260+01:00",
+              "updated_at": "2024-12-11T16:45:23.750274+01:00",
               "txt": "v=spf1 -all",
               "host": 16
             }
           ],
           "ptr_overrides": [
             {
+              "created_at": "2024-12-11T16:45:23.272704+01:00",
+              "updated_at": "2024-12-11T16:45:24.254413+01:00",
               "ipaddress": "10.0.0.20",
               "host": 16
             }
@@ -25397,6 +26913,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:23.732624+01:00",
+          "updated_at": "2024-12-11T16:45:23.732643+01:00",
           "name": "clover.example.org",
           "contact": "",
           "ttl": null,
@@ -25446,11 +26964,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
+              "created_at": "2024-12-11T16:45:12.965204+01:00",
+              "updated_at": "2024-12-11T16:45:17.976116+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             },
             {
               "macaddress": "11:22:33:44:55:67",
+              "created_at": "2024-12-11T16:45:18.689074+01:00",
+              "updated_at": "2024-12-11T16:45:20.166005+01:00",
               "ipaddress": "2001:db8::14",
               "host": 15
             }
@@ -25459,6 +26981,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:17.316836+01:00",
+              "updated_at": "2024-12-11T16:45:17.316858+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
@@ -25467,6 +26991,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:17.293046+01:00",
+          "updated_at": "2024-12-11T16:45:17.293070+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -25483,13 +27009,18 @@
           "zone": {
             "nameservers": [
               {
+                "created_at": "2024-12-11T16:44:40.356452+01:00",
+                "updated_at": "2024-12-11T16:44:40.356481+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
+            "created_at": "2024-12-11T16:44:39.701254+01:00",
+            "updated_at": "2024-12-11T16:45:24.423238+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
+            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -25508,13 +27039,18 @@
           "zone": {
             "nameservers": [
               {
+                "created_at": "2024-12-11T16:44:40.356452+01:00",
+                "updated_at": "2024-12-11T16:44:40.356481+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
+            "created_at": "2024-12-11T16:44:39.701254+01:00",
+            "updated_at": "2024-12-11T16:45:24.423238+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
+            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -25577,11 +27113,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
+              "created_at": "2024-12-11T16:45:12.965204+01:00",
+              "updated_at": "2024-12-11T16:45:17.976116+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             },
             {
               "macaddress": "11:22:33:44:55:67",
+              "created_at": "2024-12-11T16:45:18.689074+01:00",
+              "updated_at": "2024-12-11T16:45:20.166005+01:00",
               "ipaddress": "2001:db8::14",
               "host": 15
             }
@@ -25590,6 +27130,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:17.316836+01:00",
+              "updated_at": "2024-12-11T16:45:17.316858+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
@@ -25598,6 +27140,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:17.293046+01:00",
+          "updated_at": "2024-12-11T16:45:17.293070+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -25614,13 +27158,18 @@
           "zone": {
             "nameservers": [
               {
+                "created_at": "2024-12-11T16:44:40.356452+01:00",
+                "updated_at": "2024-12-11T16:44:40.356481+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
+            "created_at": "2024-12-11T16:44:39.701254+01:00",
+            "updated_at": "2024-12-11T16:45:24.423238+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
+            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -25639,13 +27188,18 @@
           "zone": {
             "nameservers": [
               {
+                "created_at": "2024-12-11T16:44:40.356452+01:00",
+                "updated_at": "2024-12-11T16:44:40.356481+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
+            "created_at": "2024-12-11T16:44:39.701254+01:00",
+            "updated_at": "2024-12-11T16:45:24.423238+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
+            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -25679,6 +27233,8 @@
         },
         "status": 201,
         "response": {
+          "created_at": "2024-12-11T16:45:25.058544+01:00",
+          "updated_at": "2024-12-11T16:45:25.058565+01:00",
           "name": "_sip._tcp.example.org",
           "priority": 10,
           "weight": 5,
@@ -25714,6 +27270,8 @@
           "previous": null,
           "results": [
             {
+              "created_at": "2024-12-11T16:45:25.058544+01:00",
+              "updated_at": "2024-12-11T16:45:25.058565+01:00",
               "name": "_sip._tcp.example.org",
               "priority": 10,
               "weight": 5,
@@ -25739,11 +27297,15 @@
               "ipaddresses": [
                 {
                   "macaddress": "11:22:33:aa:bb:cc",
+                  "created_at": "2024-12-11T16:45:12.965204+01:00",
+                  "updated_at": "2024-12-11T16:45:17.976116+01:00",
                   "ipaddress": "10.0.0.10",
                   "host": 15
                 },
                 {
                   "macaddress": "11:22:33:44:55:67",
+                  "created_at": "2024-12-11T16:45:18.689074+01:00",
+                  "updated_at": "2024-12-11T16:45:20.166005+01:00",
                   "ipaddress": "2001:db8::14",
                   "host": 15
                 }
@@ -25752,6 +27314,8 @@
               "mxs": [],
               "txts": [
                 {
+                  "created_at": "2024-12-11T16:45:17.316836+01:00",
+                  "updated_at": "2024-12-11T16:45:17.316858+01:00",
                   "txt": "v=spf1 -all",
                   "host": 15
                 }
@@ -25760,6 +27324,8 @@
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
+              "created_at": "2024-12-11T16:45:17.293046+01:00",
+              "updated_at": "2024-12-11T16:45:17.293070+01:00",
               "name": "baz.example.org",
               "contact": "",
               "ttl": null,
@@ -25793,11 +27359,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
+              "created_at": "2024-12-11T16:45:12.965204+01:00",
+              "updated_at": "2024-12-11T16:45:17.976116+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             },
             {
               "macaddress": "11:22:33:44:55:67",
+              "created_at": "2024-12-11T16:45:18.689074+01:00",
+              "updated_at": "2024-12-11T16:45:20.166005+01:00",
               "ipaddress": "2001:db8::14",
               "host": 15
             }
@@ -25806,6 +27376,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:17.316836+01:00",
+              "updated_at": "2024-12-11T16:45:17.316858+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
@@ -25814,6 +27386,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:17.293046+01:00",
+          "updated_at": "2024-12-11T16:45:17.293070+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -25832,6 +27406,8 @@
           "previous": null,
           "results": [
             {
+              "created_at": "2024-12-11T16:45:25.058544+01:00",
+              "updated_at": "2024-12-11T16:45:25.058565+01:00",
               "name": "_sip._tcp.example.org",
               "priority": 10,
               "weight": 5,
@@ -25873,11 +27449,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:15.977555+01:00",
+              "updated_at": "2024-12-11T16:45:16.676520+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
+              "created_at": "2024-12-11T16:45:16.291195+01:00",
+              "updated_at": "2024-12-11T16:45:16.979511+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
@@ -25886,6 +27466,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:12.938227+01:00",
+              "updated_at": "2024-12-11T16:45:12.938240+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -25894,6 +27476,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:12.933964+01:00",
+          "updated_at": "2024-12-11T16:45:15.502403+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -25924,6 +27508,8 @@
         },
         "status": 201,
         "response": {
+          "created_at": "2024-12-11T16:45:25.629669+01:00",
+          "updated_at": "2024-12-11T16:45:25.629690+01:00",
           "ttl": null,
           "algorithm": 1,
           "hash_type": 1,
@@ -25956,11 +27542,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:15.977555+01:00",
+              "updated_at": "2024-12-11T16:45:16.676520+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
+              "created_at": "2024-12-11T16:45:16.291195+01:00",
+              "updated_at": "2024-12-11T16:45:16.979511+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
@@ -25969,6 +27559,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:12.938227+01:00",
+              "updated_at": "2024-12-11T16:45:12.938240+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -25977,6 +27569,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:12.933964+01:00",
+          "updated_at": "2024-12-11T16:45:15.502403+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -25995,6 +27589,8 @@
           "previous": null,
           "results": [
             {
+              "created_at": "2024-12-11T16:45:25.629669+01:00",
+              "updated_at": "2024-12-11T16:45:25.629690+01:00",
               "ttl": null,
               "algorithm": 1,
               "hash_type": 1,
@@ -26028,11 +27624,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:15.977555+01:00",
+              "updated_at": "2024-12-11T16:45:16.676520+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
+              "created_at": "2024-12-11T16:45:16.291195+01:00",
+              "updated_at": "2024-12-11T16:45:16.979511+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
@@ -26041,6 +27641,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:12.938227+01:00",
+              "updated_at": "2024-12-11T16:45:12.938240+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -26049,6 +27651,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:12.933964+01:00",
+          "updated_at": "2024-12-11T16:45:15.502403+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -26092,11 +27696,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:15.977555+01:00",
+              "updated_at": "2024-12-11T16:45:16.676520+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
+              "created_at": "2024-12-11T16:45:16.291195+01:00",
+              "updated_at": "2024-12-11T16:45:16.979511+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
@@ -26105,6 +27713,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:12.938227+01:00",
+              "updated_at": "2024-12-11T16:45:12.938240+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -26113,6 +27723,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:12.933964+01:00",
+          "updated_at": "2024-12-11T16:45:15.502403+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -26131,6 +27743,8 @@
           "previous": null,
           "results": [
             {
+              "created_at": "2024-12-11T16:45:25.629669+01:00",
+              "updated_at": "2024-12-11T16:45:25.629690+01:00",
               "ttl": null,
               "algorithm": 1,
               "hash_type": 1,
@@ -26170,11 +27784,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:15.977555+01:00",
+              "updated_at": "2024-12-11T16:45:16.676520+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
+              "created_at": "2024-12-11T16:45:16.291195+01:00",
+              "updated_at": "2024-12-11T16:45:16.979511+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
@@ -26183,6 +27801,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:12.938227+01:00",
+              "updated_at": "2024-12-11T16:45:12.938240+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -26191,6 +27811,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:12.933964+01:00",
+          "updated_at": "2024-12-11T16:45:15.502403+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -26220,11 +27842,15 @@
               "ipaddresses": [
                 {
                   "macaddress": "",
+                  "created_at": "2024-12-11T16:45:15.977555+01:00",
+                  "updated_at": "2024-12-11T16:45:16.676520+01:00",
                   "ipaddress": "10.0.0.14",
                   "host": 14
                 },
                 {
                   "macaddress": "11:22:33:44:55:66",
+                  "created_at": "2024-12-11T16:45:16.291195+01:00",
+                  "updated_at": "2024-12-11T16:45:16.979511+01:00",
                   "ipaddress": "10.0.0.15",
                   "host": 14
                 }
@@ -26233,6 +27859,8 @@
               "mxs": [],
               "txts": [
                 {
+                  "created_at": "2024-12-11T16:45:12.938227+01:00",
+                  "updated_at": "2024-12-11T16:45:12.938240+01:00",
                   "txt": "v=spf1 -all",
                   "host": 14
                 }
@@ -26241,6 +27869,8 @@
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
+              "created_at": "2024-12-11T16:45:12.933964+01:00",
+              "updated_at": "2024-12-11T16:45:26.283495+01:00",
               "name": "bar.example.org",
               "contact": "me@example.org",
               "ttl": 3600,
@@ -26274,11 +27904,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:15.977555+01:00",
+              "updated_at": "2024-12-11T16:45:16.676520+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
+              "created_at": "2024-12-11T16:45:16.291195+01:00",
+              "updated_at": "2024-12-11T16:45:16.979511+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
@@ -26287,6 +27921,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:12.938227+01:00",
+              "updated_at": "2024-12-11T16:45:12.938240+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -26295,6 +27931,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:12.933964+01:00",
+          "updated_at": "2024-12-11T16:45:26.283495+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": 3600,
@@ -26326,11 +27964,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:15.977555+01:00",
+              "updated_at": "2024-12-11T16:45:16.676520+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
+              "created_at": "2024-12-11T16:45:16.291195+01:00",
+              "updated_at": "2024-12-11T16:45:16.979511+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
@@ -26339,6 +27981,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:12.938227+01:00",
+              "updated_at": "2024-12-11T16:45:12.938240+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -26347,6 +27991,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:12.933964+01:00",
+          "updated_at": "2024-12-11T16:45:26.283495+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": 3600,
@@ -26376,11 +28022,15 @@
               "ipaddresses": [
                 {
                   "macaddress": "",
+                  "created_at": "2024-12-11T16:45:15.977555+01:00",
+                  "updated_at": "2024-12-11T16:45:16.676520+01:00",
                   "ipaddress": "10.0.0.14",
                   "host": 14
                 },
                 {
                   "macaddress": "11:22:33:44:55:66",
+                  "created_at": "2024-12-11T16:45:16.291195+01:00",
+                  "updated_at": "2024-12-11T16:45:16.979511+01:00",
                   "ipaddress": "10.0.0.15",
                   "host": 14
                 }
@@ -26389,6 +28039,8 @@
               "mxs": [],
               "txts": [
                 {
+                  "created_at": "2024-12-11T16:45:12.938227+01:00",
+                  "updated_at": "2024-12-11T16:45:12.938240+01:00",
                   "txt": "v=spf1 -all",
                   "host": 14
                 }
@@ -26397,6 +28049,8 @@
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
+              "created_at": "2024-12-11T16:45:12.933964+01:00",
+              "updated_at": "2024-12-11T16:45:26.616503+01:00",
               "name": "bar.example.org",
               "contact": "me@example.org",
               "ttl": null,
@@ -26430,11 +28084,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:15.977555+01:00",
+              "updated_at": "2024-12-11T16:45:16.676520+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
+              "created_at": "2024-12-11T16:45:16.291195+01:00",
+              "updated_at": "2024-12-11T16:45:16.979511+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
@@ -26443,6 +28101,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:12.938227+01:00",
+              "updated_at": "2024-12-11T16:45:12.938240+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -26451,6 +28111,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:12.933964+01:00",
+          "updated_at": "2024-12-11T16:45:26.616503+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -26467,6 +28129,8 @@
         },
         "status": 201,
         "response": {
+          "created_at": "2024-12-11T16:45:26.936264+01:00",
+          "updated_at": "2024-12-11T16:45:26.936276+01:00",
           "txt": "Lorem ipsum dolor sit amet",
           "host": 14
         }
@@ -26496,11 +28160,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:15.977555+01:00",
+              "updated_at": "2024-12-11T16:45:16.676520+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
+              "created_at": "2024-12-11T16:45:16.291195+01:00",
+              "updated_at": "2024-12-11T16:45:16.979511+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
@@ -26509,10 +28177,14 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:12.938227+01:00",
+              "updated_at": "2024-12-11T16:45:12.938240+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             },
             {
+              "created_at": "2024-12-11T16:45:26.936264+01:00",
+              "updated_at": "2024-12-11T16:45:26.936276+01:00",
               "txt": "Lorem ipsum dolor sit amet",
               "host": 14
             }
@@ -26521,6 +28193,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:12.933964+01:00",
+          "updated_at": "2024-12-11T16:45:26.616503+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -26552,11 +28226,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:15.977555+01:00",
+              "updated_at": "2024-12-11T16:45:16.676520+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
+              "created_at": "2024-12-11T16:45:16.291195+01:00",
+              "updated_at": "2024-12-11T16:45:16.979511+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
@@ -26565,10 +28243,14 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:12.938227+01:00",
+              "updated_at": "2024-12-11T16:45:12.938240+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             },
             {
+              "created_at": "2024-12-11T16:45:26.936264+01:00",
+              "updated_at": "2024-12-11T16:45:26.936276+01:00",
               "txt": "Lorem ipsum dolor sit amet",
               "host": 14
             }
@@ -26577,6 +28259,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:12.933964+01:00",
+          "updated_at": "2024-12-11T16:45:26.616503+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -26620,11 +28304,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:15.977555+01:00",
+              "updated_at": "2024-12-11T16:45:16.676520+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
+              "created_at": "2024-12-11T16:45:16.291195+01:00",
+              "updated_at": "2024-12-11T16:45:16.979511+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
@@ -26633,10 +28321,14 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:12.938227+01:00",
+              "updated_at": "2024-12-11T16:45:12.938240+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             },
             {
+              "created_at": "2024-12-11T16:45:26.936264+01:00",
+              "updated_at": "2024-12-11T16:45:26.936276+01:00",
               "txt": "Lorem ipsum dolor sit amet",
               "host": 14
             }
@@ -26645,6 +28337,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:12.933964+01:00",
+          "updated_at": "2024-12-11T16:45:26.616503+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -26663,6 +28357,8 @@
           "previous": null,
           "results": [
             {
+              "created_at": "2024-12-11T16:45:26.936264+01:00",
+              "updated_at": "2024-12-11T16:45:26.936276+01:00",
               "txt": "Lorem ipsum dolor sit amet",
               "host": 14
             }
@@ -26693,8 +28389,8 @@
       "Contact:      ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Tue Oct  8 15:31:23 2024",
-      "Updated:      Tue Oct  8 15:31:23 2024"
+      "Created:      Wed Dec 11 16:45:27 2024",
+      "Updated:      Wed Dec 11 16:45:27 2024"
     ],
     "api_requests": [
       {
@@ -26724,13 +28420,18 @@
           "zone": {
             "nameservers": [
               {
+                "created_at": "2024-12-11T16:44:40.356452+01:00",
+                "updated_at": "2024-12-11T16:44:40.356481+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
+            "created_at": "2024-12-11T16:44:39.701254+01:00",
+            "updated_at": "2024-12-11T16:45:27.276284+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
+            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -26759,6 +28460,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:27.521225+01:00",
+              "updated_at": "2024-12-11T16:45:27.521248+01:00",
               "txt": "v=spf1 -all",
               "host": 17
             }
@@ -26767,6 +28470,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:27.501702+01:00",
+          "updated_at": "2024-12-11T16:45:27.501726+01:00",
           "name": "*.example.org",
           "contact": "",
           "ttl": null,
@@ -26860,6 +28565,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:27.521225+01:00",
+              "updated_at": "2024-12-11T16:45:27.521248+01:00",
               "txt": "v=spf1 -all",
               "host": 17
             }
@@ -26868,6 +28575,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:27.501702+01:00",
+          "updated_at": "2024-12-11T16:45:27.501726+01:00",
           "name": "*.example.org",
           "contact": "",
           "ttl": null,
@@ -26929,11 +28638,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:15.977555+01:00",
+              "updated_at": "2024-12-11T16:45:16.676520+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
+              "created_at": "2024-12-11T16:45:16.291195+01:00",
+              "updated_at": "2024-12-11T16:45:16.979511+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
@@ -26942,6 +28655,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:12.938227+01:00",
+              "updated_at": "2024-12-11T16:45:12.938240+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -26950,6 +28665,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:12.933964+01:00",
+          "updated_at": "2024-12-11T16:45:26.616503+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -26964,6 +28681,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:45:12.363738+01:00",
+          "updated_at": "2024-12-11T16:45:12.363771+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -26981,6 +28700,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:45:12.363738+01:00",
+          "updated_at": "2024-12-11T16:45:12.363771+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -27045,11 +28766,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
+              "created_at": "2024-12-11T16:45:12.965204+01:00",
+              "updated_at": "2024-12-11T16:45:17.976116+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             },
             {
               "macaddress": "11:22:33:44:55:67",
+              "created_at": "2024-12-11T16:45:18.689074+01:00",
+              "updated_at": "2024-12-11T16:45:20.166005+01:00",
               "ipaddress": "2001:db8::14",
               "host": 15
             }
@@ -27058,6 +28783,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:17.316836+01:00",
+              "updated_at": "2024-12-11T16:45:17.316858+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
@@ -27066,6 +28793,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:17.293046+01:00",
+          "updated_at": "2024-12-11T16:45:17.293070+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -27080,6 +28809,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:45:12.363738+01:00",
+          "updated_at": "2024-12-11T16:45:12.363771+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -27097,6 +28828,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:45:12.555848+01:00",
+          "updated_at": "2024-12-11T16:45:12.555870+01:00",
           "network": "2001:db8::/64",
           "description": "dolor sit amet",
           "vlan": null,
@@ -27163,6 +28896,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:23.750260+01:00",
+              "updated_at": "2024-12-11T16:45:23.750274+01:00",
               "txt": "v=spf1 -all",
               "host": 16
             }
@@ -27171,6 +28906,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:23.732624+01:00",
+          "updated_at": "2024-12-11T16:45:23.732643+01:00",
           "name": "clover.example.org",
           "contact": "",
           "ttl": null,
@@ -27228,8 +28965,8 @@
       "              10.0.0.4      aa:bb:cc:cc:bb:aa",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Tue Oct  8 15:31:23 2024",
-      "Updated:      Tue Oct  8 15:31:23 2024"
+      "Created:      Wed Dec 11 16:45:29 2024",
+      "Updated:      Wed Dec 11 16:45:29 2024"
     ],
     "api_requests": [
       {
@@ -27271,13 +29008,18 @@
           "zone": {
             "nameservers": [
               {
+                "created_at": "2024-12-11T16:44:40.356452+01:00",
+                "updated_at": "2024-12-11T16:44:40.356481+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
+            "created_at": "2024-12-11T16:44:39.701254+01:00",
+            "updated_at": "2024-12-11T16:45:29.128826+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
+            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -27294,6 +29036,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:45:12.363738+01:00",
+          "updated_at": "2024-12-11T16:45:12.363771+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -27322,6 +29066,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:29.386774+01:00",
+              "updated_at": "2024-12-11T16:45:29.386784+01:00",
               "ipaddress": "10.0.0.4",
               "host": 18
             }
@@ -27330,6 +29076,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:29.367922+01:00",
+              "updated_at": "2024-12-11T16:45:29.367930+01:00",
               "txt": "v=spf1 -all",
               "host": 18
             }
@@ -27338,6 +29086,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:29.365220+01:00",
+          "updated_at": "2024-12-11T16:45:29.365232+01:00",
           "name": "directok.example.org",
           "contact": "",
           "ttl": null,
@@ -27372,6 +29122,8 @@
         "status": 200,
         "response": {
           "macaddress": "aa:bb:cc:cc:bb:aa",
+          "created_at": "2024-12-11T16:45:29.386774+01:00",
+          "updated_at": "2024-12-11T16:45:29.586984+01:00",
           "ipaddress": "10.0.0.4",
           "host": 18
         }
@@ -27390,6 +29142,8 @@
               "ipaddresses": [
                 {
                   "macaddress": "aa:bb:cc:cc:bb:aa",
+                  "created_at": "2024-12-11T16:45:29.386774+01:00",
+                  "updated_at": "2024-12-11T16:45:29.586984+01:00",
                   "ipaddress": "10.0.0.4",
                   "host": 18
                 }
@@ -27398,6 +29152,8 @@
               "mxs": [],
               "txts": [
                 {
+                  "created_at": "2024-12-11T16:45:29.367922+01:00",
+                  "updated_at": "2024-12-11T16:45:29.367930+01:00",
                   "txt": "v=spf1 -all",
                   "host": 18
                 }
@@ -27406,6 +29162,8 @@
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
+              "created_at": "2024-12-11T16:45:29.365220+01:00",
+              "updated_at": "2024-12-11T16:45:29.365232+01:00",
               "name": "directok.example.org",
               "contact": "",
               "ttl": null,
@@ -27485,7 +29243,7 @@
     "command_issued": "host add -ip 10.0.0.0/24 -macaddress aa:bb:cc:cc:bb:aa directfail",
     "ok": [],
     "warning": [
-      "MAC address aa:bb:cc:cc:bb:aa is already associated with IP address 10.0.0.184, must force."
+      "MAC address aa:bb:cc:cc:bb:aa is already associated with IP address 10.0.0.4, must force."
     ],
     "error": [],
     "output": [],
@@ -27502,7 +29260,9 @@
           "results": [
             {
               "macaddress": "aa:bb:cc:cc:bb:aa",
-              "ipaddress": "10.0.0.184",
+              "created_at": "2024-12-11T16:45:29.386774+01:00",
+              "updated_at": "2024-12-11T16:45:29.586984+01:00",
+              "ipaddress": "10.0.0.4",
               "host": 18
             }
           ]
@@ -27532,6 +29292,8 @@
           "ipaddresses": [
             {
               "macaddress": "aa:bb:cc:cc:bb:aa",
+              "created_at": "2024-12-11T16:45:29.386774+01:00",
+              "updated_at": "2024-12-11T16:45:29.586984+01:00",
               "ipaddress": "10.0.0.4",
               "host": 18
             }
@@ -27540,6 +29302,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:29.367922+01:00",
+              "updated_at": "2024-12-11T16:45:29.367930+01:00",
               "txt": "v=spf1 -all",
               "host": 18
             }
@@ -27548,6 +29312,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:29.365220+01:00",
+          "updated_at": "2024-12-11T16:45:29.365232+01:00",
           "name": "directok.example.org",
           "contact": "",
           "ttl": null,
@@ -27605,8 +29371,8 @@
       "              10.0.0.10     <not set>",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Tue Oct  8 15:31:23 2024",
-      "Updated:      Tue Oct  8 15:31:23 2024"
+      "Created:      Wed Dec 11 16:45:30 2024",
+      "Updated:      Wed Dec 11 16:45:30 2024"
     ],
     "api_requests": [
       {
@@ -27636,13 +29402,18 @@
           "zone": {
             "nameservers": [
               {
+                "created_at": "2024-12-11T16:44:40.356452+01:00",
+                "updated_at": "2024-12-11T16:44:40.356481+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
+            "created_at": "2024-12-11T16:44:39.701254+01:00",
+            "updated_at": "2024-12-11T16:45:30.251456+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
+            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -27659,6 +29430,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:45:12.363738+01:00",
+          "updated_at": "2024-12-11T16:45:12.363771+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -27688,6 +29461,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:30.487891+01:00",
+              "updated_at": "2024-12-11T16:45:30.487904+01:00",
               "ipaddress": "10.0.0.10",
               "host": 19
             }
@@ -27696,6 +29471,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:30.467551+01:00",
+              "updated_at": "2024-12-11T16:45:30.467560+01:00",
               "txt": "v=spf1 -all",
               "host": 19
             }
@@ -27704,6 +29481,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:30.464508+01:00",
+          "updated_at": "2024-12-11T16:45:30.464524+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -27795,6 +29574,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:30.487891+01:00",
+              "updated_at": "2024-12-11T16:45:30.487904+01:00",
               "ipaddress": "10.0.0.10",
               "host": 19
             }
@@ -27803,6 +29584,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:30.467551+01:00",
+              "updated_at": "2024-12-11T16:45:30.467560+01:00",
               "txt": "v=spf1 -all",
               "host": 19
             }
@@ -27811,6 +29594,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:30.464508+01:00",
+          "updated_at": "2024-12-11T16:45:30.464524+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -27828,6 +29613,8 @@
         },
         "status": 201,
         "response": {
+          "created_at": "2024-12-11T16:45:30.911540+01:00",
+          "updated_at": "2024-12-11T16:45:30.911562+01:00",
           "priority": 10,
           "mx": "mail.example.org",
           "host": 19
@@ -27857,6 +29644,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:30.487891+01:00",
+              "updated_at": "2024-12-11T16:45:30.487904+01:00",
               "ipaddress": "10.0.0.10",
               "host": 19
             }
@@ -27864,6 +29653,8 @@
           "cnames": [],
           "mxs": [
             {
+              "created_at": "2024-12-11T16:45:30.911540+01:00",
+              "updated_at": "2024-12-11T16:45:30.911562+01:00",
               "priority": 10,
               "mx": "mail.example.org",
               "host": 19
@@ -27871,6 +29662,8 @@
           ],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:30.467551+01:00",
+              "updated_at": "2024-12-11T16:45:30.467560+01:00",
               "txt": "v=spf1 -all",
               "host": 19
             }
@@ -27879,6 +29672,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:30.464508+01:00",
+          "updated_at": "2024-12-11T16:45:30.464524+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -27934,6 +29729,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:30.487891+01:00",
+              "updated_at": "2024-12-11T16:45:30.487904+01:00",
               "ipaddress": "10.0.0.10",
               "host": 19
             }
@@ -27941,6 +29738,8 @@
           "cnames": [],
           "mxs": [
             {
+              "created_at": "2024-12-11T16:45:30.911540+01:00",
+              "updated_at": "2024-12-11T16:45:30.911562+01:00",
               "priority": 10,
               "mx": "mail.example.org",
               "host": 19
@@ -27948,6 +29747,8 @@
           ],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:30.467551+01:00",
+              "updated_at": "2024-12-11T16:45:30.467560+01:00",
               "txt": "v=spf1 -all",
               "host": 19
             }
@@ -27956,6 +29757,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:30.464508+01:00",
+          "updated_at": "2024-12-11T16:45:30.464524+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -28013,8 +29816,8 @@
       "              10.0.0.10     <not set>",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Tue Oct  8 15:31:24 2024",
-      "Updated:      Tue Oct  8 15:31:24 2024"
+      "Created:      Wed Dec 11 16:45:31 2024",
+      "Updated:      Wed Dec 11 16:45:31 2024"
     ],
     "api_requests": [
       {
@@ -28044,13 +29847,18 @@
           "zone": {
             "nameservers": [
               {
+                "created_at": "2024-12-11T16:44:40.356452+01:00",
+                "updated_at": "2024-12-11T16:44:40.356481+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
+            "created_at": "2024-12-11T16:44:39.701254+01:00",
+            "updated_at": "2024-12-11T16:45:31.351370+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
+            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -28067,6 +29875,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:45:12.363738+01:00",
+          "updated_at": "2024-12-11T16:45:12.363771+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -28096,6 +29906,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:31.587990+01:00",
+              "updated_at": "2024-12-11T16:45:31.588000+01:00",
               "ipaddress": "10.0.0.10",
               "host": 20
             }
@@ -28104,6 +29916,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:31.566412+01:00",
+              "updated_at": "2024-12-11T16:45:31.566424+01:00",
               "txt": "v=spf1 -all",
               "host": 20
             }
@@ -28112,6 +29926,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:31.562942+01:00",
+          "updated_at": "2024-12-11T16:45:31.562956+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -28203,6 +30019,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:31.587990+01:00",
+              "updated_at": "2024-12-11T16:45:31.588000+01:00",
               "ipaddress": "10.0.0.10",
               "host": 20
             }
@@ -28211,6 +30029,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:31.566412+01:00",
+              "updated_at": "2024-12-11T16:45:31.566424+01:00",
               "txt": "v=spf1 -all",
               "host": 20
             }
@@ -28219,6 +30039,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:31.562942+01:00",
+          "updated_at": "2024-12-11T16:45:31.562956+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -28245,6 +30067,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:45:12.363738+01:00",
+          "updated_at": "2024-12-11T16:45:12.363771+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -28277,6 +30101,8 @@
         },
         "status": 201,
         "response": {
+          "created_at": "2024-12-11T16:45:32.083873+01:00",
+          "updated_at": "2024-12-11T16:45:32.083895+01:00",
           "ipaddress": "10.0.0.11",
           "host": 20
         }
@@ -28305,6 +30131,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:31.587990+01:00",
+              "updated_at": "2024-12-11T16:45:31.588000+01:00",
               "ipaddress": "10.0.0.10",
               "host": 20
             }
@@ -28313,12 +30141,16 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:31.566412+01:00",
+              "updated_at": "2024-12-11T16:45:31.566424+01:00",
               "txt": "v=spf1 -all",
               "host": 20
             }
           ],
           "ptr_overrides": [
             {
+              "created_at": "2024-12-11T16:45:32.083873+01:00",
+              "updated_at": "2024-12-11T16:45:32.083895+01:00",
               "ipaddress": "10.0.0.11",
               "host": 20
             }
@@ -28326,6 +30158,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:31.562942+01:00",
+          "updated_at": "2024-12-11T16:45:31.562956+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -28382,6 +30216,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:31.587990+01:00",
+              "updated_at": "2024-12-11T16:45:31.588000+01:00",
               "ipaddress": "10.0.0.10",
               "host": 20
             }
@@ -28390,12 +30226,16 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:31.566412+01:00",
+              "updated_at": "2024-12-11T16:45:31.566424+01:00",
               "txt": "v=spf1 -all",
               "host": 20
             }
           ],
           "ptr_overrides": [
             {
+              "created_at": "2024-12-11T16:45:32.083873+01:00",
+              "updated_at": "2024-12-11T16:45:32.083895+01:00",
               "ipaddress": "10.0.0.11",
               "host": 20
             }
@@ -28403,6 +30243,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:31.562942+01:00",
+          "updated_at": "2024-12-11T16:45:31.562956+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -28460,8 +30302,8 @@
       "              10.0.0.10     <not set>",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Tue Oct  8 15:31:24 2024",
-      "Updated:      Tue Oct  8 15:31:24 2024"
+      "Created:      Wed Dec 11 16:45:32 2024",
+      "Updated:      Wed Dec 11 16:45:32 2024"
     ],
     "api_requests": [
       {
@@ -28491,13 +30333,18 @@
           "zone": {
             "nameservers": [
               {
+                "created_at": "2024-12-11T16:44:40.356452+01:00",
+                "updated_at": "2024-12-11T16:44:40.356481+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
+            "created_at": "2024-12-11T16:44:39.701254+01:00",
+            "updated_at": "2024-12-11T16:45:32.472485+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
+            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -28514,6 +30361,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:45:12.363738+01:00",
+          "updated_at": "2024-12-11T16:45:12.363771+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -28543,6 +30392,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:32.714018+01:00",
+              "updated_at": "2024-12-11T16:45:32.714035+01:00",
               "ipaddress": "10.0.0.10",
               "host": 21
             }
@@ -28551,6 +30402,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:32.684424+01:00",
+              "updated_at": "2024-12-11T16:45:32.684452+01:00",
               "txt": "v=spf1 -all",
               "host": 21
             }
@@ -28559,6 +30412,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:32.678898+01:00",
+          "updated_at": "2024-12-11T16:45:32.678919+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -28650,6 +30505,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:32.714018+01:00",
+              "updated_at": "2024-12-11T16:45:32.714035+01:00",
               "ipaddress": "10.0.0.10",
               "host": 21
             }
@@ -28658,6 +30515,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:32.684424+01:00",
+              "updated_at": "2024-12-11T16:45:32.684452+01:00",
               "txt": "v=spf1 -all",
               "host": 21
             }
@@ -28666,6 +30525,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:32.678898+01:00",
+          "updated_at": "2024-12-11T16:45:32.678919+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -28699,6 +30560,8 @@
         },
         "status": 201,
         "response": {
+          "created_at": "2024-12-11T16:45:33.190093+01:00",
+          "updated_at": "2024-12-11T16:45:33.190107+01:00",
           "preference": 16384,
           "order": 3,
           "flag": "u",
@@ -28732,6 +30595,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:32.714018+01:00",
+              "updated_at": "2024-12-11T16:45:32.714035+01:00",
               "ipaddress": "10.0.0.10",
               "host": 21
             }
@@ -28740,6 +30605,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:32.684424+01:00",
+              "updated_at": "2024-12-11T16:45:32.684452+01:00",
               "txt": "v=spf1 -all",
               "host": 21
             }
@@ -28748,6 +30615,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:32.678898+01:00",
+          "updated_at": "2024-12-11T16:45:32.678919+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -28766,6 +30635,8 @@
           "previous": null,
           "results": [
             {
+              "created_at": "2024-12-11T16:45:33.190093+01:00",
+              "updated_at": "2024-12-11T16:45:33.190107+01:00",
               "preference": 16384,
               "order": 3,
               "flag": "u",
@@ -28814,6 +30685,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:32.714018+01:00",
+              "updated_at": "2024-12-11T16:45:32.714035+01:00",
               "ipaddress": "10.0.0.10",
               "host": 21
             }
@@ -28822,6 +30695,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:32.684424+01:00",
+              "updated_at": "2024-12-11T16:45:32.684452+01:00",
               "txt": "v=spf1 -all",
               "host": 21
             }
@@ -28830,6 +30705,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:32.678898+01:00",
+          "updated_at": "2024-12-11T16:45:32.678919+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -28848,6 +30725,8 @@
           "previous": null,
           "results": [
             {
+              "created_at": "2024-12-11T16:45:33.190093+01:00",
+              "updated_at": "2024-12-11T16:45:33.190107+01:00",
               "preference": 16384,
               "order": 3,
               "flag": "u",
@@ -28897,8 +30776,8 @@
       "              10.0.0.10     <not set>",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Tue Oct  8 15:31:24 2024",
-      "Updated:      Tue Oct  8 15:31:24 2024"
+      "Created:      Wed Dec 11 16:45:33 2024",
+      "Updated:      Wed Dec 11 16:45:33 2024"
     ],
     "api_requests": [
       {
@@ -28928,13 +30807,18 @@
           "zone": {
             "nameservers": [
               {
+                "created_at": "2024-12-11T16:44:40.356452+01:00",
+                "updated_at": "2024-12-11T16:44:40.356481+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
+            "created_at": "2024-12-11T16:44:39.701254+01:00",
+            "updated_at": "2024-12-11T16:45:33.559899+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
+            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -28951,6 +30835,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:45:12.363738+01:00",
+          "updated_at": "2024-12-11T16:45:12.363771+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -28980,6 +30866,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:33.776179+01:00",
+              "updated_at": "2024-12-11T16:45:33.776187+01:00",
               "ipaddress": "10.0.0.10",
               "host": 22
             }
@@ -28988,6 +30876,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:33.759403+01:00",
+              "updated_at": "2024-12-11T16:45:33.759413+01:00",
               "txt": "v=spf1 -all",
               "host": 22
             }
@@ -28996,6 +30886,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:33.756101+01:00",
+          "updated_at": "2024-12-11T16:45:33.756113+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -29087,6 +30979,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:33.776179+01:00",
+              "updated_at": "2024-12-11T16:45:33.776187+01:00",
               "ipaddress": "10.0.0.10",
               "host": 22
             }
@@ -29095,6 +30989,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:33.759403+01:00",
+              "updated_at": "2024-12-11T16:45:33.759413+01:00",
               "txt": "v=spf1 -all",
               "host": 22
             }
@@ -29103,6 +30999,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:33.756101+01:00",
+          "updated_at": "2024-12-11T16:45:33.756113+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -29119,13 +31017,18 @@
           "zone": {
             "nameservers": [
               {
+                "created_at": "2024-12-11T16:44:40.356452+01:00",
+                "updated_at": "2024-12-11T16:44:40.356481+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
+            "created_at": "2024-12-11T16:44:39.701254+01:00",
+            "updated_at": "2024-12-11T16:45:33.775396+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
+            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -29144,13 +31047,18 @@
           "zone": {
             "nameservers": [
               {
+                "created_at": "2024-12-11T16:44:40.356452+01:00",
+                "updated_at": "2024-12-11T16:44:40.356481+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
+            "created_at": "2024-12-11T16:44:39.701254+01:00",
+            "updated_at": "2024-12-11T16:45:33.775396+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
+            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -29184,6 +31092,8 @@
         },
         "status": 201,
         "response": {
+          "created_at": "2024-12-11T16:45:34.272043+01:00",
+          "updated_at": "2024-12-11T16:45:34.272058+01:00",
           "name": "_sip._tcp.example.org",
           "priority": 10,
           "weight": 5,
@@ -29217,6 +31127,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:33.776179+01:00",
+              "updated_at": "2024-12-11T16:45:33.776187+01:00",
               "ipaddress": "10.0.0.10",
               "host": 22
             }
@@ -29225,6 +31137,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:33.759403+01:00",
+              "updated_at": "2024-12-11T16:45:33.759413+01:00",
               "txt": "v=spf1 -all",
               "host": 22
             }
@@ -29233,6 +31147,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:33.756101+01:00",
+          "updated_at": "2024-12-11T16:45:33.756113+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -29263,6 +31179,8 @@
           "previous": null,
           "results": [
             {
+              "created_at": "2024-12-11T16:45:34.272043+01:00",
+              "updated_at": "2024-12-11T16:45:34.272058+01:00",
               "name": "_sip._tcp.example.org",
               "priority": 10,
               "weight": 5,
@@ -29299,6 +31217,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:33.776179+01:00",
+              "updated_at": "2024-12-11T16:45:33.776187+01:00",
               "ipaddress": "10.0.0.10",
               "host": 22
             }
@@ -29307,6 +31227,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:33.759403+01:00",
+              "updated_at": "2024-12-11T16:45:33.759413+01:00",
               "txt": "v=spf1 -all",
               "host": 22
             }
@@ -29315,6 +31237,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:33.756101+01:00",
+          "updated_at": "2024-12-11T16:45:33.756113+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -29345,6 +31269,8 @@
           "previous": null,
           "results": [
             {
+              "created_at": "2024-12-11T16:45:34.272043+01:00",
+              "updated_at": "2024-12-11T16:45:34.272058+01:00",
               "name": "_sip._tcp.example.org",
               "priority": 10,
               "weight": 5,
@@ -29382,8 +31308,8 @@
       "              10.0.0.10     <not set>",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Tue Oct  8 15:31:24 2024",
-      "Updated:      Tue Oct  8 15:31:24 2024"
+      "Created:      Wed Dec 11 16:45:34 2024",
+      "Updated:      Wed Dec 11 16:45:34 2024"
     ],
     "api_requests": [
       {
@@ -29413,13 +31339,18 @@
           "zone": {
             "nameservers": [
               {
+                "created_at": "2024-12-11T16:44:40.356452+01:00",
+                "updated_at": "2024-12-11T16:44:40.356481+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
+            "created_at": "2024-12-11T16:44:39.701254+01:00",
+            "updated_at": "2024-12-11T16:45:34.635561+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
+            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -29436,6 +31367,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:45:12.363738+01:00",
+          "updated_at": "2024-12-11T16:45:12.363771+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -29465,6 +31398,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:34.858848+01:00",
+              "updated_at": "2024-12-11T16:45:34.858857+01:00",
               "ipaddress": "10.0.0.10",
               "host": 23
             }
@@ -29473,6 +31408,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:34.841296+01:00",
+              "updated_at": "2024-12-11T16:45:34.841304+01:00",
               "txt": "v=spf1 -all",
               "host": 23
             }
@@ -29481,6 +31418,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:34.837222+01:00",
+          "updated_at": "2024-12-11T16:45:34.837236+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -29572,6 +31511,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:34.858848+01:00",
+              "updated_at": "2024-12-11T16:45:34.858857+01:00",
               "ipaddress": "10.0.0.10",
               "host": 23
             }
@@ -29580,6 +31521,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:34.841296+01:00",
+              "updated_at": "2024-12-11T16:45:34.841304+01:00",
               "txt": "v=spf1 -all",
               "host": 23
             }
@@ -29588,6 +31531,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:34.837222+01:00",
+          "updated_at": "2024-12-11T16:45:34.837236+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -29622,13 +31567,18 @@
           "zone": {
             "nameservers": [
               {
+                "created_at": "2024-12-11T16:44:40.356452+01:00",
+                "updated_at": "2024-12-11T16:44:40.356481+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
+            "created_at": "2024-12-11T16:44:39.701254+01:00",
+            "updated_at": "2024-12-11T16:45:34.858049+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
+            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -29647,6 +31597,8 @@
         },
         "status": 201,
         "response": {
+          "created_at": "2024-12-11T16:45:35.367441+01:00",
+          "updated_at": "2024-12-11T16:45:35.367455+01:00",
           "name": "fubar.example.org",
           "ttl": null,
           "zone": 1,
@@ -29662,12 +31614,16 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:34.858848+01:00",
+              "updated_at": "2024-12-11T16:45:34.858857+01:00",
               "ipaddress": "10.0.0.10",
               "host": 23
             }
           ],
           "cnames": [
             {
+              "created_at": "2024-12-11T16:45:35.367441+01:00",
+              "updated_at": "2024-12-11T16:45:35.367455+01:00",
               "name": "fubar.example.org",
               "ttl": null,
               "zone": 1,
@@ -29677,6 +31633,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:34.841296+01:00",
+              "updated_at": "2024-12-11T16:45:34.841304+01:00",
               "txt": "v=spf1 -all",
               "host": 23
             }
@@ -29685,6 +31643,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:34.837222+01:00",
+          "updated_at": "2024-12-11T16:45:34.837236+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -29703,6 +31663,8 @@
           "previous": null,
           "results": [
             {
+              "created_at": "2024-12-11T16:45:35.367441+01:00",
+              "updated_at": "2024-12-11T16:45:35.367455+01:00",
               "name": "fubar.example.org",
               "ttl": null,
               "zone": 1,
@@ -29735,12 +31697,16 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:34.858848+01:00",
+              "updated_at": "2024-12-11T16:45:34.858857+01:00",
               "ipaddress": "10.0.0.10",
               "host": 23
             }
           ],
           "cnames": [
             {
+              "created_at": "2024-12-11T16:45:35.367441+01:00",
+              "updated_at": "2024-12-11T16:45:35.367455+01:00",
               "name": "fubar.example.org",
               "ttl": null,
               "zone": 1,
@@ -29750,6 +31716,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:34.841296+01:00",
+              "updated_at": "2024-12-11T16:45:34.841304+01:00",
               "txt": "v=spf1 -all",
               "host": 23
             }
@@ -29758,6 +31726,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:34.837222+01:00",
+          "updated_at": "2024-12-11T16:45:34.837236+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -29813,12 +31783,16 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:34.858848+01:00",
+              "updated_at": "2024-12-11T16:45:34.858857+01:00",
               "ipaddress": "10.0.0.10",
               "host": 23
             }
           ],
           "cnames": [
             {
+              "created_at": "2024-12-11T16:45:35.367441+01:00",
+              "updated_at": "2024-12-11T16:45:35.367455+01:00",
               "name": "fubar.example.org",
               "ttl": null,
               "zone": 1,
@@ -29828,6 +31802,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:34.841296+01:00",
+              "updated_at": "2024-12-11T16:45:34.841304+01:00",
               "txt": "v=spf1 -all",
               "host": 23
             }
@@ -29836,6 +31812,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:34.837222+01:00",
+          "updated_at": "2024-12-11T16:45:34.837236+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -29893,8 +31871,8 @@
       "              10.0.0.10     <not set>",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Tue Oct  8 15:31:25 2024",
-      "Updated:      Tue Oct  8 15:31:25 2024"
+      "Created:      Wed Dec 11 16:45:36 2024",
+      "Updated:      Wed Dec 11 16:45:36 2024"
     ],
     "api_requests": [
       {
@@ -29924,13 +31902,18 @@
           "zone": {
             "nameservers": [
               {
+                "created_at": "2024-12-11T16:44:40.356452+01:00",
+                "updated_at": "2024-12-11T16:44:40.356481+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
+            "created_at": "2024-12-11T16:44:39.701254+01:00",
+            "updated_at": "2024-12-11T16:45:35.818010+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
+            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -29947,6 +31930,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:45:12.363738+01:00",
+          "updated_at": "2024-12-11T16:45:12.363771+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -29976,6 +31961,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:36.048114+01:00",
+              "updated_at": "2024-12-11T16:45:36.048123+01:00",
               "ipaddress": "10.0.0.10",
               "host": 24
             }
@@ -29984,6 +31971,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:36.029619+01:00",
+              "updated_at": "2024-12-11T16:45:36.029627+01:00",
               "txt": "v=spf1 -all",
               "host": 24
             }
@@ -29992,6 +31981,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:36.027149+01:00",
+          "updated_at": "2024-12-11T16:45:36.027158+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -30083,6 +32074,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:36.048114+01:00",
+              "updated_at": "2024-12-11T16:45:36.048123+01:00",
               "ipaddress": "10.0.0.10",
               "host": 24
             }
@@ -30091,6 +32084,8 @@
           "mxs": [],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:36.029619+01:00",
+              "updated_at": "2024-12-11T16:45:36.029627+01:00",
               "txt": "v=spf1 -all",
               "host": 24
             }
@@ -30099,6 +32094,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:36.027149+01:00",
+          "updated_at": "2024-12-11T16:45:36.027158+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -30116,6 +32113,8 @@
         },
         "status": 201,
         "response": {
+          "created_at": "2024-12-11T16:45:36.430253+01:00",
+          "updated_at": "2024-12-11T16:45:36.430266+01:00",
           "priority": 10,
           "mx": "mail.example.org",
           "host": 24
@@ -30145,6 +32144,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:36.048114+01:00",
+              "updated_at": "2024-12-11T16:45:36.048123+01:00",
               "ipaddress": "10.0.0.10",
               "host": 24
             }
@@ -30152,6 +32153,8 @@
           "cnames": [],
           "mxs": [
             {
+              "created_at": "2024-12-11T16:45:36.430253+01:00",
+              "updated_at": "2024-12-11T16:45:36.430266+01:00",
               "priority": 10,
               "mx": "mail.example.org",
               "host": 24
@@ -30159,6 +32162,8 @@
           ],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:36.029619+01:00",
+              "updated_at": "2024-12-11T16:45:36.029627+01:00",
               "txt": "v=spf1 -all",
               "host": 24
             }
@@ -30167,6 +32172,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:36.027149+01:00",
+          "updated_at": "2024-12-11T16:45:36.027158+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -30193,6 +32200,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:45:12.363738+01:00",
+          "updated_at": "2024-12-11T16:45:12.363771+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -30225,6 +32234,8 @@
         },
         "status": 201,
         "response": {
+          "created_at": "2024-12-11T16:45:36.648723+01:00",
+          "updated_at": "2024-12-11T16:45:36.648735+01:00",
           "ipaddress": "10.0.0.11",
           "host": 24
         }
@@ -30253,6 +32264,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:36.048114+01:00",
+              "updated_at": "2024-12-11T16:45:36.048123+01:00",
               "ipaddress": "10.0.0.10",
               "host": 24
             }
@@ -30260,6 +32273,8 @@
           "cnames": [],
           "mxs": [
             {
+              "created_at": "2024-12-11T16:45:36.430253+01:00",
+              "updated_at": "2024-12-11T16:45:36.430266+01:00",
               "priority": 10,
               "mx": "mail.example.org",
               "host": 24
@@ -30267,12 +32282,16 @@
           ],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:36.029619+01:00",
+              "updated_at": "2024-12-11T16:45:36.029627+01:00",
               "txt": "v=spf1 -all",
               "host": 24
             }
           ],
           "ptr_overrides": [
             {
+              "created_at": "2024-12-11T16:45:36.648723+01:00",
+              "updated_at": "2024-12-11T16:45:36.648735+01:00",
               "ipaddress": "10.0.0.11",
               "host": 24
             }
@@ -30280,6 +32299,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:36.027149+01:00",
+          "updated_at": "2024-12-11T16:45:36.027158+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -30313,6 +32334,8 @@
         },
         "status": 201,
         "response": {
+          "created_at": "2024-12-11T16:45:36.789752+01:00",
+          "updated_at": "2024-12-11T16:45:36.789788+01:00",
           "preference": 16384,
           "order": 3,
           "flag": "u",
@@ -30346,6 +32369,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:36.048114+01:00",
+              "updated_at": "2024-12-11T16:45:36.048123+01:00",
               "ipaddress": "10.0.0.10",
               "host": 24
             }
@@ -30353,6 +32378,8 @@
           "cnames": [],
           "mxs": [
             {
+              "created_at": "2024-12-11T16:45:36.430253+01:00",
+              "updated_at": "2024-12-11T16:45:36.430266+01:00",
               "priority": 10,
               "mx": "mail.example.org",
               "host": 24
@@ -30360,12 +32387,16 @@
           ],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:36.029619+01:00",
+              "updated_at": "2024-12-11T16:45:36.029627+01:00",
               "txt": "v=spf1 -all",
               "host": 24
             }
           ],
           "ptr_overrides": [
             {
+              "created_at": "2024-12-11T16:45:36.648723+01:00",
+              "updated_at": "2024-12-11T16:45:36.648735+01:00",
               "ipaddress": "10.0.0.11",
               "host": 24
             }
@@ -30373,6 +32404,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:36.027149+01:00",
+          "updated_at": "2024-12-11T16:45:36.027158+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -30389,13 +32422,18 @@
           "zone": {
             "nameservers": [
               {
+                "created_at": "2024-12-11T16:44:40.356452+01:00",
+                "updated_at": "2024-12-11T16:44:40.356481+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
+            "created_at": "2024-12-11T16:44:39.701254+01:00",
+            "updated_at": "2024-12-11T16:45:36.784422+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
+            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -30414,13 +32452,18 @@
           "zone": {
             "nameservers": [
               {
+                "created_at": "2024-12-11T16:44:40.356452+01:00",
+                "updated_at": "2024-12-11T16:44:40.356481+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
+            "created_at": "2024-12-11T16:44:39.701254+01:00",
+            "updated_at": "2024-12-11T16:45:36.784422+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
+            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -30454,6 +32497,8 @@
         },
         "status": 201,
         "response": {
+          "created_at": "2024-12-11T16:45:37.022008+01:00",
+          "updated_at": "2024-12-11T16:45:37.022022+01:00",
           "name": "_sip._tcp.example.org",
           "priority": 10,
           "weight": 5,
@@ -30487,6 +32532,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:36.048114+01:00",
+              "updated_at": "2024-12-11T16:45:36.048123+01:00",
               "ipaddress": "10.0.0.10",
               "host": 24
             }
@@ -30494,6 +32541,8 @@
           "cnames": [],
           "mxs": [
             {
+              "created_at": "2024-12-11T16:45:36.430253+01:00",
+              "updated_at": "2024-12-11T16:45:36.430266+01:00",
               "priority": 10,
               "mx": "mail.example.org",
               "host": 24
@@ -30501,12 +32550,16 @@
           ],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:36.029619+01:00",
+              "updated_at": "2024-12-11T16:45:36.029627+01:00",
               "txt": "v=spf1 -all",
               "host": 24
             }
           ],
           "ptr_overrides": [
             {
+              "created_at": "2024-12-11T16:45:36.648723+01:00",
+              "updated_at": "2024-12-11T16:45:36.648735+01:00",
               "ipaddress": "10.0.0.11",
               "host": 24
             }
@@ -30514,6 +32567,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:36.027149+01:00",
+          "updated_at": "2024-12-11T16:45:36.027158+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -30548,13 +32603,18 @@
           "zone": {
             "nameservers": [
               {
+                "created_at": "2024-12-11T16:44:40.356452+01:00",
+                "updated_at": "2024-12-11T16:44:40.356481+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
+            "created_at": "2024-12-11T16:44:39.701254+01:00",
+            "updated_at": "2024-12-11T16:45:37.010300+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
+            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -30573,6 +32633,8 @@
         },
         "status": 201,
         "response": {
+          "created_at": "2024-12-11T16:45:37.247207+01:00",
+          "updated_at": "2024-12-11T16:45:37.247221+01:00",
           "name": "fubar.example.org",
           "ttl": null,
           "zone": 1,
@@ -30588,12 +32650,16 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:36.048114+01:00",
+              "updated_at": "2024-12-11T16:45:36.048123+01:00",
               "ipaddress": "10.0.0.10",
               "host": 24
             }
           ],
           "cnames": [
             {
+              "created_at": "2024-12-11T16:45:37.247207+01:00",
+              "updated_at": "2024-12-11T16:45:37.247221+01:00",
               "name": "fubar.example.org",
               "ttl": null,
               "zone": 1,
@@ -30602,6 +32668,8 @@
           ],
           "mxs": [
             {
+              "created_at": "2024-12-11T16:45:36.430253+01:00",
+              "updated_at": "2024-12-11T16:45:36.430266+01:00",
               "priority": 10,
               "mx": "mail.example.org",
               "host": 24
@@ -30609,12 +32677,16 @@
           ],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:36.029619+01:00",
+              "updated_at": "2024-12-11T16:45:36.029627+01:00",
               "txt": "v=spf1 -all",
               "host": 24
             }
           ],
           "ptr_overrides": [
             {
+              "created_at": "2024-12-11T16:45:36.648723+01:00",
+              "updated_at": "2024-12-11T16:45:36.648735+01:00",
               "ipaddress": "10.0.0.11",
               "host": 24
             }
@@ -30622,6 +32694,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:36.027149+01:00",
+          "updated_at": "2024-12-11T16:45:36.027158+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -30640,6 +32714,8 @@
           "previous": null,
           "results": [
             {
+              "created_at": "2024-12-11T16:45:37.247207+01:00",
+              "updated_at": "2024-12-11T16:45:37.247221+01:00",
               "name": "fubar.example.org",
               "ttl": null,
               "zone": 1,
@@ -30672,12 +32748,16 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:36.048114+01:00",
+              "updated_at": "2024-12-11T16:45:36.048123+01:00",
               "ipaddress": "10.0.0.10",
               "host": 24
             }
           ],
           "cnames": [
             {
+              "created_at": "2024-12-11T16:45:37.247207+01:00",
+              "updated_at": "2024-12-11T16:45:37.247221+01:00",
               "name": "fubar.example.org",
               "ttl": null,
               "zone": 1,
@@ -30686,6 +32766,8 @@
           ],
           "mxs": [
             {
+              "created_at": "2024-12-11T16:45:36.430253+01:00",
+              "updated_at": "2024-12-11T16:45:36.430266+01:00",
               "priority": 10,
               "mx": "mail.example.org",
               "host": 24
@@ -30693,12 +32775,16 @@
           ],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:36.029619+01:00",
+              "updated_at": "2024-12-11T16:45:36.029627+01:00",
               "txt": "v=spf1 -all",
               "host": 24
             }
           ],
           "ptr_overrides": [
             {
+              "created_at": "2024-12-11T16:45:36.648723+01:00",
+              "updated_at": "2024-12-11T16:45:36.648735+01:00",
               "ipaddress": "10.0.0.11",
               "host": 24
             }
@@ -30706,6 +32792,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:36.027149+01:00",
+          "updated_at": "2024-12-11T16:45:36.027158+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -30724,6 +32812,8 @@
           "previous": null,
           "results": [
             {
+              "created_at": "2024-12-11T16:45:36.789752+01:00",
+              "updated_at": "2024-12-11T16:45:36.789788+01:00",
               "preference": 16384,
               "order": 3,
               "flag": "u",
@@ -30746,6 +32836,8 @@
           "previous": null,
           "results": [
             {
+              "created_at": "2024-12-11T16:45:37.022008+01:00",
+              "updated_at": "2024-12-11T16:45:37.022022+01:00",
               "name": "_sip._tcp.example.org",
               "priority": 10,
               "weight": 5,
@@ -30784,12 +32876,16 @@
           "ipaddresses": [
             {
               "macaddress": "",
+              "created_at": "2024-12-11T16:45:36.048114+01:00",
+              "updated_at": "2024-12-11T16:45:36.048123+01:00",
               "ipaddress": "10.0.0.10",
               "host": 24
             }
           ],
           "cnames": [
             {
+              "created_at": "2024-12-11T16:45:37.247207+01:00",
+              "updated_at": "2024-12-11T16:45:37.247221+01:00",
               "name": "fubar.example.org",
               "ttl": null,
               "zone": 1,
@@ -30798,6 +32894,8 @@
           ],
           "mxs": [
             {
+              "created_at": "2024-12-11T16:45:36.430253+01:00",
+              "updated_at": "2024-12-11T16:45:36.430266+01:00",
               "priority": 10,
               "mx": "mail.example.org",
               "host": 24
@@ -30805,12 +32903,16 @@
           ],
           "txts": [
             {
+              "created_at": "2024-12-11T16:45:36.029619+01:00",
+              "updated_at": "2024-12-11T16:45:36.029627+01:00",
               "txt": "v=spf1 -all",
               "host": 24
             }
           ],
           "ptr_overrides": [
             {
+              "created_at": "2024-12-11T16:45:36.648723+01:00",
+              "updated_at": "2024-12-11T16:45:36.648735+01:00",
               "ipaddress": "10.0.0.11",
               "host": 24
             }
@@ -30818,6 +32920,8 @@
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
+          "created_at": "2024-12-11T16:45:36.027149+01:00",
+          "updated_at": "2024-12-11T16:45:36.027158+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -30836,6 +32940,8 @@
           "previous": null,
           "results": [
             {
+              "created_at": "2024-12-11T16:45:36.789752+01:00",
+              "updated_at": "2024-12-11T16:45:36.789788+01:00",
               "preference": 16384,
               "order": 3,
               "flag": "u",
@@ -30858,6 +32964,8 @@
           "previous": null,
           "results": [
             {
+              "created_at": "2024-12-11T16:45:37.022008+01:00",
+              "updated_at": "2024-12-11T16:45:37.022022+01:00",
               "name": "_sip._tcp.example.org",
               "priority": 10,
               "weight": 5,
@@ -30897,6 +33005,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:45:12.363738+01:00",
+          "updated_at": "2024-12-11T16:45:12.363771+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -30942,6 +33052,8 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
+          "created_at": "2024-12-11T16:45:12.555848+01:00",
+          "updated_at": "2024-12-11T16:45:12.555870+01:00",
           "network": "2001:db8::/64",
           "description": "dolor sit amet",
           "vlan": null,
@@ -31016,6 +33128,8 @@
           "previous": null,
           "results": [
             {
+              "created_at": "2024-12-11T16:45:38.097351+01:00",
+              "updated_at": "2024-12-11T16:45:38.097369+01:00",
               "name": "postit",
               "description": "This is a label"
             }
@@ -31053,6 +33167,8 @@
           "previous": null,
           "results": [
             {
+              "created_at": "2024-12-11T16:45:38.097351+01:00",
+              "updated_at": "2024-12-11T16:45:38.097369+01:00",
               "name": "postit",
               "description": "This is a label"
             }
@@ -31109,6 +33225,8 @@
           "previous": null,
           "results": [
             {
+              "created_at": "2024-12-11T16:45:38.097351+01:00",
+              "updated_at": "2024-12-11T16:45:38.097369+01:00",
               "name": "postit",
               "description": "This is a label"
             }
@@ -31129,6 +33247,8 @@
         "data": {},
         "status": 200,
         "response": {
+          "created_at": "2024-12-11T16:45:38.097351+01:00",
+          "updated_at": "2024-12-11T16:45:38.353381+01:00",
           "name": "mylabel",
           "description": "This is a label"
         }
@@ -31159,6 +33279,8 @@
           "previous": null,
           "results": [
             {
+              "created_at": "2024-12-11T16:45:38.097351+01:00",
+              "updated_at": "2024-12-11T16:45:38.353381+01:00",
               "name": "mylabel",
               "description": "This is a label"
             }
@@ -31179,6 +33301,8 @@
         "data": {},
         "status": 200,
         "response": {
+          "created_at": "2024-12-11T16:45:38.097351+01:00",
+          "updated_at": "2024-12-11T16:45:38.486049+01:00",
           "name": "mylabel",
           "description": "This is the new description"
         }
@@ -31209,6 +33333,8 @@
           "previous": null,
           "results": [
             {
+              "created_at": "2024-12-11T16:45:38.097351+01:00",
+              "updated_at": "2024-12-11T16:45:38.486049+01:00",
               "name": "mylabel",
               "description": "This is the new description"
             }
@@ -31286,6 +33412,7 @@
         "response": {
           "hosts": [],
           "atoms": [],
+          "updated_at": "2024-12-11T16:45:38.788140+01:00",
           "description": "This is the description",
           "name": "myrole",
           "labels": []
@@ -31314,6 +33441,7 @@
         "response": {
           "hosts": [],
           "atoms": [],
+          "updated_at": "2024-12-11T16:45:38.788140+01:00",
           "description": "This is the description",
           "name": "myrole",
           "labels": []
@@ -31330,6 +33458,8 @@
           "previous": null,
           "results": [
             {
+              "created_at": "2024-12-11T16:45:38.691439+01:00",
+              "updated_at": "2024-12-11T16:45:38.691461+01:00",
               "name": "postit",
               "description": "A label again"
             }
@@ -31359,6 +33489,7 @@
             {
               "hosts": [],
               "atoms": [],
+              "updated_at": "2024-12-11T16:45:39.026164+01:00",
               "description": "This is the description",
               "name": "myrole",
               "labels": [
@@ -31397,6 +33528,7 @@
             {
               "hosts": [],
               "atoms": [],
+              "updated_at": "2024-12-11T16:45:39.026164+01:00",
               "description": "This is the description",
               "name": "myrole",
               "labels": [
@@ -31412,6 +33544,8 @@
         "data": {},
         "status": 200,
         "response": {
+          "created_at": "2024-12-11T16:45:38.691439+01:00",
+          "updated_at": "2024-12-11T16:45:38.691461+01:00",
           "name": "postit",
           "description": "A label again"
         }
@@ -31429,8 +33563,8 @@
     "error": [],
     "output": [
       "Name:         myrole",
-      "Created:      Tue Oct  8 00:00:00 2024",
-      "Updated:      Tue Oct  8 15:31:25 2024",
+      "Created:      Wed Dec 11 00:00:00 2024",
+      "Updated:      Wed Dec 11 16:45:39 2024",
       "Description:  This is the description",
       "Atom members:",
       "Labels:",
@@ -31454,6 +33588,7 @@
         "response": {
           "hosts": [],
           "atoms": [],
+          "updated_at": "2024-12-11T16:45:39.026164+01:00",
           "description": "This is the description",
           "name": "myrole",
           "labels": [
@@ -31467,6 +33602,8 @@
         "data": {},
         "status": 200,
         "response": {
+          "created_at": "2024-12-11T16:45:38.691439+01:00",
+          "updated_at": "2024-12-11T16:45:38.691461+01:00",
           "name": "postit",
           "description": "A label again"
         }
@@ -31502,6 +33639,8 @@
           "previous": null,
           "results": [
             {
+              "created_at": "2024-12-11T16:45:38.691439+01:00",
+              "updated_at": "2024-12-11T16:45:38.691461+01:00",
               "name": "postit",
               "description": "A label again"
             }
@@ -31521,6 +33660,7 @@
             {
               "hosts": [],
               "atoms": [],
+              "updated_at": "2024-12-11T16:45:39.026164+01:00",
               "description": "This is the description",
               "name": "myrole",
               "labels": [
@@ -31565,6 +33705,7 @@
         "response": {
           "hosts": [],
           "atoms": [],
+          "updated_at": "2024-12-11T16:45:39.026164+01:00",
           "description": "This is the description",
           "name": "myrole",
           "labels": [
@@ -31583,6 +33724,8 @@
           "previous": null,
           "results": [
             {
+              "created_at": "2024-12-11T16:45:38.691439+01:00",
+              "updated_at": "2024-12-11T16:45:38.691461+01:00",
               "name": "postit",
               "description": "A label again"
             }
@@ -31610,6 +33753,7 @@
             {
               "hosts": [],
               "atoms": [],
+              "updated_at": "2024-12-11T16:45:39.632188+01:00",
               "description": "This is the description",
               "name": "myrole",
               "labels": []
@@ -31640,6 +33784,7 @@
         "response": {
           "hosts": [],
           "atoms": [],
+          "updated_at": "2024-12-11T16:45:39.632188+01:00",
           "description": "This is the description",
           "name": "myrole",
           "labels": []
@@ -31688,6 +33833,8 @@
         },
         "status": 201,
         "response": {
+          "created_at": "2024-12-11T16:45:39.885936+01:00",
+          "updated_at": "2024-12-11T16:45:39.885950+01:00",
           "group": "mygroup",
           "range": "192.168.0.0/16",
           "regex": ".*",
@@ -31720,6 +33867,8 @@
           "previous": null,
           "results": [
             {
+              "created_at": "2024-12-11T16:45:39.885936+01:00",
+              "updated_at": "2024-12-11T16:45:39.885950+01:00",
               "group": "mygroup",
               "range": "192.168.0.0/16",
               "regex": ".*",
@@ -31739,6 +33888,8 @@
           "previous": null,
           "results": [
             {
+              "created_at": "2024-12-11T16:45:38.691439+01:00",
+              "updated_at": "2024-12-11T16:45:38.691461+01:00",
               "name": "postit",
               "description": "A label again"
             }
@@ -31761,6 +33912,8 @@
         "data": {},
         "status": 200,
         "response": {
+          "created_at": "2024-12-11T16:45:39.885936+01:00",
+          "updated_at": "2024-12-11T16:45:40.035819+01:00",
           "group": "mygroup",
           "range": "192.168.0.0/16",
           "regex": ".*",
@@ -31796,6 +33949,8 @@
           "previous": null,
           "results": [
             {
+              "created_at": "2024-12-11T16:45:39.885936+01:00",
+              "updated_at": "2024-12-11T16:45:40.035819+01:00",
               "group": "mygroup",
               "range": "192.168.0.0/16",
               "regex": ".*",
@@ -31817,6 +33972,8 @@
           "previous": null,
           "results": [
             {
+              "created_at": "2024-12-11T16:45:38.691439+01:00",
+              "updated_at": "2024-12-11T16:45:38.691461+01:00",
               "name": "postit",
               "description": "A label again"
             }
@@ -31855,6 +34012,8 @@
           "previous": null,
           "results": [
             {
+              "created_at": "2024-12-11T16:45:38.691439+01:00",
+              "updated_at": "2024-12-11T16:45:38.691461+01:00",
               "name": "postit",
               "description": "A label again"
             }
@@ -31884,6 +34043,8 @@
           "previous": null,
           "results": [
             {
+              "created_at": "2024-12-11T16:45:39.885936+01:00",
+              "updated_at": "2024-12-11T16:45:40.035819+01:00",
               "group": "mygroup",
               "range": "192.168.0.0/16",
               "regex": ".*",
@@ -31920,6 +34081,8 @@
           "previous": null,
           "results": [
             {
+              "created_at": "2024-12-11T16:45:39.885936+01:00",
+              "updated_at": "2024-12-11T16:45:40.035819+01:00",
               "group": "mygroup",
               "range": "192.168.0.0/16",
               "regex": ".*",
@@ -31941,6 +34104,8 @@
           "previous": null,
           "results": [
             {
+              "created_at": "2024-12-11T16:45:38.691439+01:00",
+              "updated_at": "2024-12-11T16:45:38.691461+01:00",
               "name": "postit",
               "description": "A label again"
             }
@@ -31961,6 +34126,8 @@
         "data": {},
         "status": 200,
         "response": {
+          "created_at": "2024-12-11T16:45:39.885936+01:00",
+          "updated_at": "2024-12-11T16:45:40.433444+01:00",
           "group": "mygroup",
           "range": "192.168.0.0/16",
           "regex": ".*",
@@ -31994,6 +34161,8 @@
           "previous": null,
           "results": [
             {
+              "created_at": "2024-12-11T16:45:39.885936+01:00",
+              "updated_at": "2024-12-11T16:45:40.433444+01:00",
               "group": "mygroup",
               "range": "192.168.0.0/16",
               "regex": ".*",
@@ -32013,6 +34182,8 @@
           "previous": null,
           "results": [
             {
+              "created_at": "2024-12-11T16:45:38.691439+01:00",
+              "updated_at": "2024-12-11T16:45:38.691461+01:00",
               "name": "postit",
               "description": "A label again"
             }
@@ -32045,6 +34216,8 @@
           "previous": null,
           "results": [
             {
+              "created_at": "2024-12-11T16:45:39.885936+01:00",
+              "updated_at": "2024-12-11T16:45:40.433444+01:00",
               "group": "mygroup",
               "range": "192.168.0.0/16",
               "regex": ".*",
@@ -32085,6 +34258,8 @@
           "previous": null,
           "results": [
             {
+              "created_at": "2024-12-11T16:45:38.691439+01:00",
+              "updated_at": "2024-12-11T16:45:38.691461+01:00",
               "name": "postit",
               "description": "A label again"
             }
@@ -32120,13 +34295,18 @@
         "response": {
           "nameservers": [
             {
+              "created_at": "2024-12-11T16:44:40.356452+01:00",
+              "updated_at": "2024-12-11T16:44:40.356481+01:00",
               "name": "ns2.example.org",
               "ttl": null
             }
           ],
+          "created_at": "2024-12-11T16:44:39.701254+01:00",
+          "updated_at": "2024-12-11T16:45:37.776064+01:00",
           "updated": true,
           "primary_ns": "ns2.example.org",
           "email": "hostperson@example.org",
+          "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
           "refresh": 360,
           "retry": 1800,
           "expire": 2400,

--- a/ci/testsuite-result.json
+++ b/ci/testsuite-result.json
@@ -95,7 +95,7 @@
               "ttl": null
             }
           ],
-          "updated": false,
+          "updated": true,
           "primary_ns": "ns1.example.org",
           "email": "hostmaster@example.org",
           "refresh": 10800,
@@ -143,7 +143,7 @@
               "ttl": null
             }
           ],
-          "updated": false,
+          "updated": true,
           "primary_ns": "ns1.example.org",
           "email": "hostmaster@example.org",
           "refresh": 10800,
@@ -187,7 +187,7 @@
                   "ttl": null
                 }
               ],
-              "updated": false,
+              "updated": true,
               "primary_ns": "ns1.example.org",
               "email": "hostmaster@example.org",
               "refresh": 10800,
@@ -227,7 +227,7 @@
               "ttl": null
             }
           ],
-          "updated": false,
+          "updated": true,
           "primary_ns": "ns1.example.org",
           "email": "hostmaster@example.org",
           "refresh": 10800,
@@ -283,7 +283,7 @@
               "ttl": null
             }
           ],
-          "updated": false,
+          "updated": true,
           "primary_ns": "ns1.example.org",
           "email": "hostmaster@example.org",
           "refresh": 10800,
@@ -14633,10 +14633,10 @@
               ],
               "owners": [
                 {
-                  "name": "anotherowner"
+                  "name": "myself"
                 },
                 {
-                  "name": "myself"
+                  "name": "anotherowner"
                 }
               ],
               "name": "mygroup",

--- a/mreg_cli/outputmanager.py
+++ b/mreg_cli/outputmanager.py
@@ -122,10 +122,7 @@ class OutputManager:
     COMMANDS_NOT_TO_RECORD = ["recording", "quit", "exit", "source"]
     KEYS_NOT_TO_RECORD = [
         "id",
-        "created_at",
-        "updated_at",
         "serialno",
-        "serialno_updated_at",
         "create_date",
     ]
 


### PR DESCRIPTION
This PR does two things:
- Test results for some API calls have changed slightly (the updated field is true for Zones, and the order of hostgroups changed) and we haven't been able to determine why this happened. This PR just accepts the changes into `testsuite-results.json` for now. e8b2c6d3f513174147e4cb10cc6eb71f7723396c
- Keep created and updated timestamps in the log. `diff.py` will ignore the contents of the fields, but it is nice to test that the fields are there and in the correct format. d24171f414923b5b7e3c92444912ecc7b04278f8