### PR TITLE
Upgrade syntax with pyupgade in 3.11 mode

### DIFF
--- a/mreg_cli/api/abstracts.py
+++ b/mreg_cli/api/abstracts.py
@@ -432,6 +432,7 @@ class APIMixin(ABC):
         :param fields: The values to patch.
         :param validate: Whether to validate the patched object.
         :returns: The object refetched from the server.
+
         """
         patch(self.endpoint().with_id(self.id_for_endpoint()), **fields)
         new_object = self.refetch()

--- a/mreg_cli/api/history.py
+++ b/mreg_cli/api/history.py
@@ -77,7 +77,7 @@ class HistoryItem(BaseModel):
         """Clean up the timestamp for output."""
         return self.timestamp.strftime("%Y-%m-%d %H:%M:%S")
 
-    def msg(self, basename: str) -> str:
+    def msg(self, basename: str) -> str:  # noqa: ARG002 # arg might be used in the future
         """Attempt to make a history item human readable."""
         msg = ""
         action = self.action

--- a/mreg_cli/api/history.py
+++ b/mreg_cli/api/history.py
@@ -77,7 +77,7 @@ class HistoryItem(BaseModel):
         """Clean up the timestamp for output."""
         return self.timestamp.strftime("%Y-%m-%d %H:%M:%S")
 
-    def msg(self, basename: str) -> str:  # noqa: ARG002 # arg might be used in the future
+    def msg(self, _basename: str) -> str:
         """Attempt to make a history item human readable."""
         msg = ""
         action = self.action

--- a/mreg_cli/api/models.py
+++ b/mreg_cli/api/models.py
@@ -6,7 +6,7 @@ import ipaddress
 import logging
 from datetime import date, datetime
 from functools import cached_property
-from typing import Any, Callable, ClassVar, Iterable, List, Literal, Self, cast, overload
+from typing import Any, Callable, ClassVar, Iterable, Literal, Self, cast, overload
 
 from pydantic import (
     AliasChoices,
@@ -3570,7 +3570,7 @@ class UserPermission(BaseModel):
     group: str
     range: str
     regex: str
-    labels: List[str]
+    labels: list[str]
 
     # NOTE: _needs_ to be a computed field in order to use it in
     # OutputManager.add_formatted_table, since we dump the model to a dict
@@ -3617,7 +3617,7 @@ class ServerVersion(BaseModel):
         return Endpoint.MetaVersion
 
     @classmethod
-    def fetch(cls, ignore_errors: bool = True) -> "ServerVersion":
+    def fetch(cls, ignore_errors: bool = True) -> ServerVersion:
         """Fetch the server version from the endpoint.
 
         :param ignore_errors: Whether to ignore errors.
@@ -3649,7 +3649,7 @@ class Library(BaseModel):
 class ServerLibraries(BaseModel):
     """Model for server libraries metadata."""
 
-    libraries: List[Library]
+    libraries: list[Library]
 
     @classmethod
     def endpoint(cls) -> str:
@@ -3657,7 +3657,7 @@ class ServerLibraries(BaseModel):
         return Endpoint.MetaLibraries
 
     @classmethod
-    def fetch(cls, ignore_errors: bool = True) -> "ServerLibraries":
+    def fetch(cls, ignore_errors: bool = True) -> ServerLibraries:
         """Fetch the server libraries from the endpoint.
 
         :param ignore_errors: Whether to ignore errors.
@@ -3667,7 +3667,7 @@ class ServerLibraries(BaseModel):
         """
         try:
             response = get(cls.endpoint())
-            libraries: List[Library] = []
+            libraries: list[Library] = []
 
             for name, version in response.json().items():
                 libraries.append(Library(name=name, version=version))
@@ -3694,8 +3694,8 @@ class UserInfo(BaseModel):
     username: str
     django_status: UserDjangoStatus
     mreg_status: UserMregStatus
-    groups: List[str]
-    permissions: List[UserPermission]
+    groups: list[str]
+    permissions: list[UserPermission]
 
     @classmethod
     def endpoint(cls) -> str:
@@ -3703,7 +3703,7 @@ class UserInfo(BaseModel):
         return Endpoint.MetaUser
 
     @classmethod
-    def fetch(cls, ignore_errors: bool = True, user: str | None = None) -> "UserInfo":
+    def fetch(cls, ignore_errors: bool = True, user: str | None = None) -> UserInfo:
         """Fetch the user information from the endpoint.
 
         :param ignore_errors: Whether to ignore errors.

--- a/mreg_cli/cli.py
+++ b/mreg_cli/cli.py
@@ -52,7 +52,7 @@ if TYPE_CHECKING:
     # which lets the type checker understand what kind of classes we are
     # trying to instantiate.
     class BaseCommandSubclass(Protocol):  # noqa: D101 (undocumented-public-class)
-        def __init__(self, cli: "Command") -> None: ...  # noqa: D107 (undocumented-public-init)
+        def __init__(self, cli: Command) -> None: ...  # noqa: D107 (undocumented-public-init)
         def register_all_commands(self) -> None: ...  # noqa: D102 (undocumented-public-method)
 
 
@@ -305,7 +305,7 @@ for command in commands:
     command(cli).register_all_commands()
 
 
-def source(files: list[str], ignore_errors: bool, verbose: bool) -> Generator[str, None, None]:
+def source(files: list[str], ignore_errors: bool, verbose: bool) -> Generator[str]:
     """Read commands from one or more source files and yield them.
 
     :param files: List of file paths to read commands from.

--- a/mreg_cli/commands/logging.py
+++ b/mreg_cli/commands/logging.py
@@ -104,7 +104,7 @@ def logging_status(_: argparse.Namespace):
     file = MregCliConfig().get_default_logfile()
 
     lines_in_logfile = 0
-    with open(file, "r") as f:
+    with open(file) as f:
         lines_in_logfile = sum(1 for _ in f)
 
     filesize = sizeof_fmt(os.path.getsize(file))

--- a/mreg_cli/prompt.py
+++ b/mreg_cli/prompt.py
@@ -1,10 +1,12 @@
+"""Prompt customization for the CLI."""
+
 from __future__ import annotations
 
 import argparse
 import functools
 import logging
 import re
-from typing import NamedTuple, Optional
+from typing import NamedTuple
 
 from prompt_toolkit import HTML
 
@@ -18,9 +20,9 @@ class ConnectionInfo(NamedTuple):
     """Connection information for a server."""
 
     protocol: str
-    host: Optional[str]
-    tld: Optional[str]
-    port: Optional[int]
+    host: str | None
+    tld: str | None
+    port: int | None
 
 
 @functools.lru_cache()

--- a/mreg_cli/tokenfile.py
+++ b/mreg_cli/tokenfile.py
@@ -6,7 +6,7 @@ import json
 import logging
 import os
 import sys
-from typing import ClassVar, Optional, Self
+from typing import ClassVar, Self
 
 from pydantic import BaseModel, ValidationError
 
@@ -57,7 +57,7 @@ class TokenFile(BaseModel):
     def load(cls) -> Self:
         """Load tokens from a JSON file, returning a new instance of TokenFile."""
         try:
-            with open(cls.tokens_path, "r") as file:
+            with open(cls.tokens_path) as file:
                 data = json.load(file)
                 return cls.model_validate(data)
         except (FileNotFoundError, KeyError, json.JSONDecodeError, ValidationError) as e:
@@ -72,7 +72,7 @@ class TokenFile(BaseModel):
         return cls()
 
     @classmethod
-    def get_entry(cls, username: str, url: str) -> Optional[Token]:
+    def get_entry(cls, username: str, url: str) -> Token | None:
         """Retrieve a token by username and URL."""
         tokens_file = cls.load()
         for token in tokens_file.tokens:


### PR DESCRIPTION
Also fixes linting errors found when running `ruff check --fix` (to remove redundant imports after upgrading syntax).