### PR TITLE
Allow `a(aaa)_add` with IP from non-existent network

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- `a_add` & `aaaa_add` `-force` option to force use an IP from a network that cannot be found in MREG.
+
+### Fixed
+
+- Commands that try to find networks by IP raising a 404 error instead of a proper error message when no network can be found with the given IP.
 
 ## [1.2.2](https://github.com/unioslo/mreg-cli/releases/tag/1.2.2) - 2024-12-09
 

--- a/mreg_cli/api/models.py
+++ b/mreg_cli/api/models.py
@@ -1658,7 +1658,7 @@ class Network(FrozenModelWithTimestamps, APIMixin):
         :returns: The network if found, None otherwise.
         :raises EntityNotFound: If the network is not found.
         """
-        resp = get(Endpoint.NetworksByIP.with_id(str(ip)))
+        resp = get(Endpoint.NetworksByIP.with_id(str(ip)), ok404=True)
         if not resp:
             return None
         return cls.model_validate_json(resp.text)

--- a/mreg_cli/commands/host_submodules/a_aaaa.py
+++ b/mreg_cli/commands/host_submodules/a_aaaa.py
@@ -181,6 +181,9 @@ def _add_ip(
         network = Network.get_by_ip(ip_or_net.as_ip())
         ip = ip_or_net.as_ip()
 
+    if not force and not network:
+        raise ForceMissing(f"Network for {ip} not found, must force")
+
     if not force and network and network.frozen:
         raise ForceMissing(f"Network {network.network} is frozen, must force")
 


### PR DESCRIPTION
Adds the ability for the commands `a_add` and `aaaa_add` to add an IP from a network that cannot be found with `-force`. Previously, trying to add an IP from a network that could not be found raised a 404 error, which is not something we intended. This PR fixes that by using `ok404=True` in `Network.get_by_ip()`.

All other calls to `Network.get_by_ip` expect it to return `None` when the network cannot be found:

https://github.com/unioslo/mreg-cli/blob/c2df7825ef96f5ca4f2482ae11d0e5377f0c1891/mreg_cli/commands/host_submodules/core.py#L138-L150

https://github.com/unioslo/mreg-cli/blob/c2df7825ef96f5ca4f2482ae11d0e5377f0c1891/mreg_cli/commands/host_submodules/core.py#L156-L163

https://github.com/unioslo/mreg-cli/blob/c2df7825ef96f5ca4f2482ae11d0e5377f0c1891/mreg_cli/commands/host_submodules/rr.py#L540-L542

This PR now ensures the 404 error is handled when the network does, in fact, not exist.
