### PR TITLE
Add `help health` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- `help health` command for checking the health of the server. The command will display "Unknown" for fields that are not implemented on the server.
 
 ## [1.2.3](https://github.com/unioslo/mreg-cli/releases/tag/1.2.3) - 2024-12-16
 

--- a/mreg_cli/api/endpoints.py
+++ b/mreg_cli/api/endpoints.py
@@ -82,7 +82,9 @@ class Endpoint(str, Enum):
     MetaUser = "/api/meta/user"
     MetaVersion = "/api/meta/version"
     MetaLibraries = "/api/meta/libraries"
-    MetaHeartbeat = "/api/meta/heartbeat"
+
+    HealthHeartbeat = "/api/meta/health/heartbeat"
+    HealthLDAP = "/api/meta/health/ldap"
 
     def __str__(self):
         """Prevent direct usage without parameters where needed."""

--- a/mreg_cli/commands/help.py
+++ b/mreg_cli/commands/help.py
@@ -6,7 +6,7 @@ import argparse
 from typing import Any
 
 from mreg_cli.__about__ import __version__ as mreg_cli_version
-from mreg_cli.api.models import ServerLibraries, ServerVersion, UserInfo
+from mreg_cli.api.models import HealthInfo, ServerLibraries, ServerVersion, UserInfo
 from mreg_cli.commands.base import BaseCommand
 from mreg_cli.commands.registry import CommandRegistry
 from mreg_cli.config import MregCliConfig
@@ -133,3 +133,17 @@ def whois_help(args: argparse.Namespace) -> None:
         UserInfo.fetch(ignore_errors=False, user=args.user).output(django=args.django)
     except Exception as e:
         raise CliError(f"Failed to display user info for {args.user!r}: {e}") from e
+
+
+@command_registry.register_command(
+    prog="health",
+    description="Show information about the health of the server",
+    short_desc="Show health info",
+)
+def meta_health(_: argparse.Namespace) -> None:
+    """Show information about the health of the server."""
+    try:
+        info = HealthInfo.fetch()
+        info.output()
+    except Exception as e:
+        raise CliError(f"Failed to display health info: {e}") from e

--- a/mreg_cli/exceptions.py
+++ b/mreg_cli/exceptions.py
@@ -14,6 +14,7 @@ from prompt_toolkit import print_formatted_text
 from prompt_toolkit.formatted_text import HTML
 from prompt_toolkit.formatted_text.html import html_escape
 from pydantic import ValidationError as PydanticValidationError
+from requests import Response
 
 logger = logging.getLogger(__name__)
 
@@ -195,7 +196,16 @@ class FileError(CliError):
 class APINotOk(CliWarning):
     """Warning class for API not returning OK."""
 
-    pass
+    response: Response
+
+    def __init__(self, message: str, response: Response):
+        """Initialize an APINotOk warning.
+
+        :param message: The warning message.
+        :param response: The response object that triggered the warning.
+        """
+        super().__init__(message)
+        self.response = response
 
 
 class TooManyResults(CliWarning):

--- a/mreg_cli/utilities/api.py
+++ b/mreg_cli/utilities/api.py
@@ -213,7 +213,7 @@ def result_check(result: Response, operation_type: str, url: str) -> None:
             pass
         else:
             message += f"\n{json.dumps(body, indent=2)}"
-        raise APINotOk(message)
+        raise APINotOk(message, result)
 
 
 def _strip_none(data: dict[str, Any]) -> dict[str, Any]:


### PR DESCRIPTION
Adds a new `help health` command utilizing the new `/meta/health` endpoints. Shows uptime and LDAP status currently:

```
> help health
Health Information:
  Uptime: 0:42:34
  LDAP: OK
```

Written in a way that makes it easy to expand if new health endpoints are added in the future.

If the server doesn't implement the endpoints, the message shows `Unknown`:

```
> help health
Health Information:
  Uptime: Unknown
  LDAP: Unknown
```

## Expanded `APINotOk` exception

The `result_check()` function is mandatory for all HTTP request made through `_request_wrapper`, but prior to this PR, all non-2xx responses would cause the response to be lost, as the function would raise a `APINotOK` exception - discarding the response. This PR adds the response to the raised exception, so that callers catching `APINotOk` can still access it.