### PR TITLE
Fix detection of reverse zones.

### DIFF
--- a/mreg_cli/api/models.py
+++ b/mreg_cli/api/models.py
@@ -588,7 +588,7 @@ class Zone(FrozenModelWithTimestamps, WithTTL, APIMixin):
 
     def is_reverse(self) -> bool:
         """Return True if the zone is a reverse zone."""
-        return False
+        return is_reverse_zone_name(self.name)
 
     # Default to forward zone endpoints for the base class
     # This can be overridden in the subclasses
@@ -1063,11 +1063,6 @@ class Delegation(FrozenModelWithTimestamps, WithZone):
         return True
 
     @classmethod
-    def is_reverse(cls) -> bool:
-        """Return True if the zone is a reverse zone."""
-        return False
-
-    @classmethod
     def type_by_zone(cls, zone: Zone) -> type[ForwardZoneDelegation | ReverseZoneDelegation]:
         """Get the delegation type for a zone."""
         if zone.is_reverse():
@@ -1091,11 +1086,6 @@ class ReverseZoneDelegation(Delegation, APIMixin):
     def endpoint(cls) -> Endpoint:
         """Return the endpoint for the class."""
         return Endpoint.ReverseZonesDelegations
-
-    @classmethod
-    def is_reverse(cls) -> bool:
-        """Return True if the zone is a reverse zone."""
-        return True
 
 
 class HostPolicy(FrozenModel, WithName):


### PR DESCRIPTION
  - Use the default way (the name ending in .arpa) to see if a zone is indeed a reverse zone.