### PR TITLE
Add support for expanded /hosts endpoint output

### DIFF
--- a/ci/testsuite-result.json
+++ b/ci/testsuite-result.json
@@ -611,8 +611,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:44:40.886409+01:00",
-          "updated_at": "2024-12-11T16:44:40.886433+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T10:10:42.905787+01:00",
+          "updated_at": "2025-03-19T10:10:42.905797+01:00",
           "network": "10.0.2.0/28",
           "description": "TinyNet",
           "vlan": null,
@@ -645,8 +647,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:44:40.886409+01:00",
-          "updated_at": "2024-12-11T16:44:40.886433+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T10:10:42.905787+01:00",
+          "updated_at": "2025-03-19T10:10:42.905797+01:00",
           "network": "10.0.2.0/28",
           "description": "TinyNet",
           "vlan": null,
@@ -703,8 +707,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:44:40.886409+01:00",
-          "updated_at": "2024-12-11T16:44:40.886433+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T10:10:42.905787+01:00",
+          "updated_at": "2025-03-19T10:10:42.905797+01:00",
           "network": "10.0.2.0/28",
           "description": "TinyNet",
           "vlan": null,
@@ -756,8 +762,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:44:40.886409+01:00",
-          "updated_at": "2024-12-11T16:44:40.886433+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T10:10:42.905787+01:00",
+          "updated_at": "2025-03-19T10:10:42.905797+01:00",
           "network": "10.0.2.0/28",
           "description": "TinyNet",
           "vlan": null,
@@ -788,8 +796,10 @@
           "results": [
             {
               "excluded_ranges": [],
-              "created_at": "2024-12-11T16:44:40.886409+01:00",
-              "updated_at": "2024-12-11T16:44:41.314670+01:00",
+              "policy": null,
+              "communities": [],
+              "created_at": "2025-03-19T10:10:42.905787+01:00",
+              "updated_at": "2025-03-19T10:10:43.080147+01:00",
               "network": "10.0.2.0/28",
               "description": "TinyNet",
               "vlan": null,
@@ -823,8 +833,8 @@
       "              10.0.2.9   <not set>   ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Thu Feb 27 10:47:36 2025",
-      "Updated:      Thu Feb 27 10:47:36 2025"
+      "Created:      Wed Mar 19 12:04:41 2025",
+      "Updated:      Wed Mar 19 12:04:41 2025"
     ],
     "api_requests": [
       {
@@ -854,18 +864,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2025-02-27T10:47:35.896278+01:00",
-                "updated_at": "2025-02-27T10:47:35.896293+01:00",
+                "created_at": "2025-03-19T12:04:41.191611+01:00",
+                "updated_at": "2025-03-19T12:04:41.191623+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-02-27T10:47:35.640608+01:00",
-            "updated_at": "2025-02-27T10:47:36.041302+01:00",
+            "created_at": "2025-03-19T12:04:40.912310+01:00",
+            "updated_at": "2025-03-19T12:04:41.355456+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-02-27T10:47:35.942147+01:00",
+            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -882,8 +892,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2025-02-27T10:47:36.116423+01:00",
-          "updated_at": "2025-02-27T10:47:36.424515+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:41.509492+01:00",
+          "updated_at": "2025-03-19T12:04:41.751198+01:00",
           "network": "10.0.2.0/28",
           "description": "TinyNet",
           "vlan": null,
@@ -913,8 +925,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-02-27T10:47:36.581235+01:00",
-              "updated_at": "2025-02-27T10:47:36.581241+01:00",
+              "created_at": "2025-03-19T12:04:41.978445+01:00",
+              "updated_at": "2025-03-19T12:04:41.978451+01:00",
               "ipaddress": "10.0.2.9",
               "host": 1
             }
@@ -923,18 +935,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-02-27T10:47:36.563994+01:00",
-              "updated_at": "2025-02-27T10:47:36.564001+01:00",
+              "created_at": "2025-03-19T12:04:41.956953+01:00",
+              "updated_at": "2025-03-19T12:04:41.956960+01:00",
               "txt": "v=spf1 -all",
               "host": 1
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2025-02-27T10:47:36.560910+01:00",
-          "updated_at": "2025-02-27T10:47:36.560926+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:41.954723+01:00",
+          "updated_at": "2025-03-19T12:04:41.954730+01:00",
           "name": "tinyhost.example.org",
           "contact": "tinyhost@example.org",
           "ttl": null,
@@ -949,8 +967,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2025-02-27T10:47:36.116423+01:00",
-          "updated_at": "2025-02-27T10:47:36.424515+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:41.509492+01:00",
+          "updated_at": "2025-03-19T12:04:41.751198+01:00",
           "network": "10.0.2.0/28",
           "description": "TinyNet",
           "vlan": null,
@@ -959,85 +979,6 @@
           "location": "",
           "frozen": false,
           "reserved": 8
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/ip/10.0.2.9",
-        "data": {},
-        "status": 200,
-        "response": {
-          "excluded_ranges": [],
-          "created_at": "2025-02-27T10:47:36.116423+01:00",
-          "updated_at": "2025-02-27T10:47:36.424515+01:00",
-          "network": "10.0.2.0/28",
-          "description": "TinyNet",
-          "vlan": null,
-          "dns_delegated": false,
-          "category": "",
-          "location": "",
-          "frozen": false,
-          "reserved": 8
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/srvs/?host=1",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/naptrs/?host=1",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/sshfps/?host=1",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hostpolicy/roles/?hosts=1",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hostgroups/?hosts=1",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
         }
       }
     ],
@@ -1062,8 +1003,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:44:40.886409+01:00",
-          "updated_at": "2024-12-11T16:44:41.314670+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T10:10:42.905787+01:00",
+          "updated_at": "2025-03-19T10:10:43.080147+01:00",
           "network": "10.0.2.0/28",
           "description": "TinyNet",
           "vlan": null,
@@ -1118,8 +1061,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:44:40.886409+01:00",
-          "updated_at": "2024-12-11T16:44:41.314670+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T10:10:42.905787+01:00",
+          "updated_at": "2025-03-19T10:10:43.080147+01:00",
           "network": "10.0.2.0/28",
           "description": "TinyNet",
           "vlan": null,
@@ -1167,8 +1112,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:44:41.709138+01:00",
-              "updated_at": "2024-12-11T16:44:41.709149+01:00",
+              "created_at": "2025-03-19T12:04:41.978445+01:00",
+              "updated_at": "2025-03-19T12:04:41.978451+01:00",
               "ipaddress": "10.0.2.9",
               "host": 1
             }
@@ -1177,47 +1122,29 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:44:41.688378+01:00",
-              "updated_at": "2024-12-11T16:44:41.688391+01:00",
+              "created_at": "2025-03-19T12:04:41.956953+01:00",
+              "updated_at": "2025-03-19T12:04:41.956960+01:00",
               "txt": "v=spf1 -all",
               "host": 1
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:44:41.683671+01:00",
-          "updated_at": "2024-12-11T16:44:41.683683+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:41.954723+01:00",
+          "updated_at": "2025-03-19T12:04:41.954730+01:00",
           "name": "tinyhost.example.org",
           "contact": "tinyhost@example.org",
           "ttl": null,
           "comment": "",
           "zone": 1
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/naptrs/?host=1",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/srvs/?host=1",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
         }
       },
       {
@@ -1248,8 +1175,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:44:40.886409+01:00",
-          "updated_at": "2024-12-11T16:44:41.314670+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T10:10:42.905787+01:00",
+          "updated_at": "2025-03-19T10:10:43.080147+01:00",
           "network": "10.0.2.0/28",
           "description": "TinyNet",
           "vlan": null,
@@ -1317,8 +1246,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:44:42.899068+01:00",
-          "updated_at": "2024-12-11T16:44:42.899085+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T10:10:43.865439+01:00",
+          "updated_at": "2025-03-19T10:10:43.865451+01:00",
           "network": "2001:db8::/64",
           "description": "Lorem ipsum dolor sit amet",
           "vlan": null,
@@ -1351,8 +1282,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:44:42.899068+01:00",
-          "updated_at": "2024-12-11T16:44:42.899085+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T10:10:43.865439+01:00",
+          "updated_at": "2025-03-19T10:10:43.865451+01:00",
           "network": "2001:db8::/64",
           "description": "Lorem ipsum dolor sit amet",
           "vlan": null,
@@ -5494,8 +5427,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:44:42.899068+01:00",
-          "updated_at": "2024-12-11T16:44:42.899085+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:42.522693+01:00",
+          "updated_at": "2025-03-19T12:04:42.522709+01:00",
           "network": "2001:db8::/64",
           "description": "Lorem ipsum dolor sit amet",
           "vlan": null,
@@ -9632,8 +9567,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:44:42.899068+01:00",
-          "updated_at": "2024-12-11T16:44:42.899085+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T10:10:43.865439+01:00",
+          "updated_at": "2025-03-19T10:10:43.865451+01:00",
           "network": "2001:db8::/64",
           "description": "Lorem ipsum dolor sit amet",
           "vlan": null,
@@ -9664,8 +9601,10 @@
           "results": [
             {
               "excluded_ranges": [],
-              "created_at": "2024-12-11T16:44:42.899068+01:00",
-              "updated_at": "2024-12-11T16:44:43.431469+01:00",
+              "policy": null,
+              "communities": [],
+              "created_at": "2025-03-19T10:10:43.865439+01:00",
+              "updated_at": "2025-03-19T10:10:44.125057+01:00",
               "network": "2001:db8::/64",
               "description": "Lorem ipsum dolor sit amet",
               "vlan": null,
@@ -9699,8 +9638,8 @@
       "              2001:db8::33   <not set>   ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Thu Feb 27 10:47:37 2025",
-      "Updated:      Thu Feb 27 10:47:37 2025"
+      "Created:      Wed Mar 19 12:04:42 2025",
+      "Updated:      Wed Mar 19 12:04:42 2025"
     ],
     "api_requests": [
       {
@@ -9730,18 +9669,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2025-02-27T10:47:35.896278+01:00",
-                "updated_at": "2025-02-27T10:47:35.896293+01:00",
+                "created_at": "2025-03-19T12:04:41.191611+01:00",
+                "updated_at": "2025-03-19T12:04:41.191623+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-02-27T10:47:35.640608+01:00",
-            "updated_at": "2025-02-27T10:47:37.231741+01:00",
+            "created_at": "2025-03-19T12:04:40.912310+01:00",
+            "updated_at": "2025-03-19T12:04:42.332125+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-02-27T10:47:35.942147+01:00",
+            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -9758,8 +9697,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2025-02-27T10:47:37.338923+01:00",
-          "updated_at": "2025-02-27T10:47:37.608587+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:42.522693+01:00",
+          "updated_at": "2025-03-19T12:04:42.777112+01:00",
           "network": "2001:db8::/64",
           "description": "Lorem ipsum dolor sit amet",
           "vlan": null,
@@ -9789,8 +9730,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-02-27T10:47:37.787407+01:00",
-              "updated_at": "2025-02-27T10:47:37.787415+01:00",
+              "created_at": "2025-03-19T12:04:42.941021+01:00",
+              "updated_at": "2025-03-19T12:04:42.941029+01:00",
               "ipaddress": "2001:db8::33",
               "host": 2
             }
@@ -9799,18 +9740,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-02-27T10:47:37.774163+01:00",
-              "updated_at": "2025-02-27T10:47:37.774170+01:00",
+              "created_at": "2025-03-19T12:04:42.918046+01:00",
+              "updated_at": "2025-03-19T12:04:42.918053+01:00",
               "txt": "v=spf1 -all",
               "host": 2
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2025-02-27T10:47:37.771675+01:00",
-          "updated_at": "2025-02-27T10:47:37.771685+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:42.915456+01:00",
+          "updated_at": "2025-03-19T12:04:42.915471+01:00",
           "name": "tinyhost.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -9825,8 +9772,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2025-02-27T10:47:37.338923+01:00",
-          "updated_at": "2025-02-27T10:47:37.608587+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:42.522693+01:00",
+          "updated_at": "2025-03-19T12:04:42.777112+01:00",
           "network": "2001:db8::/64",
           "description": "Lorem ipsum dolor sit amet",
           "vlan": null,
@@ -9835,85 +9784,6 @@
           "location": "",
           "frozen": false,
           "reserved": 50
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/ip/2001%3Adb8%3A%3A33",
-        "data": {},
-        "status": 200,
-        "response": {
-          "excluded_ranges": [],
-          "created_at": "2025-02-27T10:47:37.338923+01:00",
-          "updated_at": "2025-02-27T10:47:37.608587+01:00",
-          "network": "2001:db8::/64",
-          "description": "Lorem ipsum dolor sit amet",
-          "vlan": null,
-          "dns_delegated": false,
-          "category": "",
-          "location": "",
-          "frozen": false,
-          "reserved": 50
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/srvs/?host=2",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/naptrs/?host=2",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/sshfps/?host=2",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hostpolicy/roles/?hosts=2",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hostgroups/?hosts=2",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
         }
       }
     ],
@@ -9940,8 +9810,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-02-27T10:47:37.787407+01:00",
-              "updated_at": "2025-02-27T10:47:37.787415+01:00",
+              "created_at": "2025-03-19T12:04:42.941021+01:00",
+              "updated_at": "2025-03-19T12:04:42.941029+01:00",
               "ipaddress": "2001:db8::33",
               "host": 2
             }
@@ -9950,18 +9820,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-02-27T10:47:37.774163+01:00",
-              "updated_at": "2025-02-27T10:47:37.774170+01:00",
+              "created_at": "2025-03-19T12:04:42.918046+01:00",
+              "updated_at": "2025-03-19T12:04:42.918053+01:00",
               "txt": "v=spf1 -all",
               "host": 2
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2025-02-27T10:47:37.771675+01:00",
-          "updated_at": "2025-02-27T10:47:37.771685+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:42.915456+01:00",
+          "updated_at": "2025-03-19T12:04:42.915471+01:00",
           "name": "tinyhost.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -9976,8 +9852,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2025-02-27T10:47:37.338923+01:00",
-          "updated_at": "2025-02-27T10:47:37.608587+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:42.522693+01:00",
+          "updated_at": "2025-03-19T12:04:42.777112+01:00",
           "network": "2001:db8::/64",
           "description": "Lorem ipsum dolor sit amet",
           "vlan": null,
@@ -9986,85 +9864,6 @@
           "location": "",
           "frozen": false,
           "reserved": 50
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/ip/2001%3Adb8%3A%3A33",
-        "data": {},
-        "status": 200,
-        "response": {
-          "excluded_ranges": [],
-          "created_at": "2025-02-27T10:47:37.338923+01:00",
-          "updated_at": "2025-02-27T10:47:37.608587+01:00",
-          "network": "2001:db8::/64",
-          "description": "Lorem ipsum dolor sit amet",
-          "vlan": null,
-          "dns_delegated": false,
-          "category": "",
-          "location": "",
-          "frozen": false,
-          "reserved": 50
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/srvs/?host=2",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/naptrs/?host=2",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/sshfps/?host=2",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hostpolicy/roles/?hosts=2",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hostgroups/?hosts=2",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
         }
       }
     ],
@@ -10084,8 +9883,8 @@
       "              2001:db8::33   <not set>   ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Thu Feb 27 10:47:37 2025",
-      "Updated:      Thu Feb 27 10:47:37 2025"
+      "Created:      Wed Mar 19 12:04:42 2025",
+      "Updated:      Wed Mar 19 12:04:42 2025"
     ],
     "api_requests": [
       {
@@ -10097,8 +9896,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-02-27T10:47:37.787407+01:00",
-              "updated_at": "2025-02-27T10:47:37.787415+01:00",
+              "created_at": "2025-03-19T12:04:42.941021+01:00",
+              "updated_at": "2025-03-19T12:04:42.941029+01:00",
               "ipaddress": "2001:db8::33",
               "host": 2
             }
@@ -10107,18 +9906,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-02-27T10:47:37.774163+01:00",
-              "updated_at": "2025-02-27T10:47:37.774170+01:00",
+              "created_at": "2025-03-19T12:04:42.918046+01:00",
+              "updated_at": "2025-03-19T12:04:42.918053+01:00",
               "txt": "v=spf1 -all",
               "host": 2
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2025-02-27T10:47:37.771675+01:00",
-          "updated_at": "2025-02-27T10:47:37.771685+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:42.915456+01:00",
+          "updated_at": "2025-03-19T12:04:42.915471+01:00",
           "name": "tinyhost.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -10133,8 +9938,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2025-02-27T10:47:37.338923+01:00",
-          "updated_at": "2025-02-27T10:47:37.608587+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:42.522693+01:00",
+          "updated_at": "2025-03-19T12:04:42.777112+01:00",
           "network": "2001:db8::/64",
           "description": "Lorem ipsum dolor sit amet",
           "vlan": null,
@@ -10143,85 +9950,6 @@
           "location": "",
           "frozen": false,
           "reserved": 50
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/ip/2001%3Adb8%3A%3A33",
-        "data": {},
-        "status": 200,
-        "response": {
-          "excluded_ranges": [],
-          "created_at": "2025-02-27T10:47:37.338923+01:00",
-          "updated_at": "2025-02-27T10:47:37.608587+01:00",
-          "network": "2001:db8::/64",
-          "description": "Lorem ipsum dolor sit amet",
-          "vlan": null,
-          "dns_delegated": false,
-          "category": "",
-          "location": "",
-          "frozen": false,
-          "reserved": 50
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/srvs/?host=2",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/naptrs/?host=2",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/sshfps/?host=2",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hostpolicy/roles/?hosts=2",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hostgroups/?hosts=2",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
         }
       }
     ],
@@ -10248,8 +9976,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:44:43.799845+01:00",
-              "updated_at": "2024-12-11T16:44:43.799865+01:00",
+              "created_at": "2025-03-19T12:04:42.941021+01:00",
+              "updated_at": "2025-03-19T12:04:42.941029+01:00",
               "ipaddress": "2001:db8::33",
               "host": 2
             }
@@ -10258,47 +9986,29 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:44:43.765364+01:00",
-              "updated_at": "2024-12-11T16:44:43.765383+01:00",
+              "created_at": "2025-03-19T12:04:42.918046+01:00",
+              "updated_at": "2025-03-19T12:04:42.918053+01:00",
               "txt": "v=spf1 -all",
               "host": 2
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:44:43.759890+01:00",
-          "updated_at": "2024-12-11T16:44:43.759911+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:42.915456+01:00",
+          "updated_at": "2025-03-19T12:04:42.915471+01:00",
           "name": "tinyhost.example.org",
           "contact": "me@example.org",
           "ttl": null,
           "comment": "",
           "zone": 1
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/naptrs/?host=2",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/srvs/?host=2",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
         }
       },
       {
@@ -10329,8 +10039,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:44:42.899068+01:00",
-          "updated_at": "2024-12-11T16:44:43.431469+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T10:10:43.865439+01:00",
+          "updated_at": "2025-03-19T10:10:44.125057+01:00",
           "network": "2001:db8::/64",
           "description": "Lorem ipsum dolor sit amet",
           "vlan": null,
@@ -10398,8 +10110,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:44:45.393437+01:00",
-          "updated_at": "2024-12-11T16:44:45.393462+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T10:10:44.688196+01:00",
+          "updated_at": "2025-03-19T10:10:44.688206+01:00",
           "network": "10.0.1.0/24",
           "description": "Frozzzen",
           "vlan": null,
@@ -10432,8 +10146,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:44:45.393437+01:00",
-          "updated_at": "2024-12-11T16:44:45.393462+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T10:10:44.688196+01:00",
+          "updated_at": "2025-03-19T10:10:44.688206+01:00",
           "network": "10.0.1.0/24",
           "description": "Frozzzen",
           "vlan": null,
@@ -10464,8 +10180,10 @@
           "results": [
             {
               "excluded_ranges": [],
-              "created_at": "2024-12-11T16:44:45.393437+01:00",
-              "updated_at": "2024-12-11T16:44:45.582957+01:00",
+              "policy": null,
+              "communities": [],
+              "created_at": "2025-03-19T10:10:44.688196+01:00",
+              "updated_at": "2025-03-19T10:10:44.766999+01:00",
               "network": "10.0.1.0/24",
               "description": "Frozzzen",
               "vlan": null,
@@ -10520,18 +10238,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2024-12-11T16:44:40.356452+01:00",
-                "updated_at": "2024-12-11T16:44:40.356481+01:00",
+                "created_at": "2025-03-19T10:10:42.280399+01:00",
+                "updated_at": "2025-03-19T10:10:42.280412+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2024-12-11T16:44:39.701254+01:00",
-            "updated_at": "2024-12-11T16:44:45.067149+01:00",
+            "created_at": "2025-03-19T10:10:41.753629+01:00",
+            "updated_at": "2025-03-19T10:10:44.574286+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
+            "serialno_updated_at": "2025-03-19T10:10:42.331334+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -10548,8 +10266,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:44:45.393437+01:00",
-          "updated_at": "2024-12-11T16:44:45.582957+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T10:10:44.688196+01:00",
+          "updated_at": "2025-03-19T10:10:44.766999+01:00",
           "network": "10.0.1.0/24",
           "description": "Frozzzen",
           "vlan": null,
@@ -10582,8 +10302,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:44:45.393437+01:00",
-          "updated_at": "2024-12-11T16:44:45.582957+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T10:10:44.688196+01:00",
+          "updated_at": "2025-03-19T10:10:44.766999+01:00",
           "network": "10.0.1.0/24",
           "description": "Frozzzen",
           "vlan": null,
@@ -10646,18 +10368,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2024-12-11T16:44:40.356452+01:00",
-                "updated_at": "2024-12-11T16:44:40.356481+01:00",
+                "created_at": "2025-03-19T10:10:42.280399+01:00",
+                "updated_at": "2025-03-19T10:10:42.280412+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2024-12-11T16:44:39.701254+01:00",
-            "updated_at": "2024-12-11T16:44:45.067149+01:00",
+            "created_at": "2025-03-19T10:10:41.753629+01:00",
+            "updated_at": "2025-03-19T10:10:44.574286+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
+            "serialno_updated_at": "2025-03-19T10:10:42.331334+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -10675,15 +10397,17 @@
         "response": {
           "excluded_ranges": [
             {
-              "created_at": "2024-12-11T16:44:45.955630+01:00",
-              "updated_at": "2024-12-11T16:44:45.955656+01:00",
+              "created_at": "2025-03-19T10:10:44.935337+01:00",
+              "updated_at": "2025-03-19T10:10:44.935355+01:00",
               "start_ip": "10.0.1.20",
               "end_ip": "10.0.1.30",
               "network": 3
             }
           ],
-          "created_at": "2024-12-11T16:44:45.393437+01:00",
-          "updated_at": "2024-12-11T16:44:45.582957+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T10:10:44.688196+01:00",
+          "updated_at": "2025-03-19T10:10:44.766999+01:00",
           "network": "10.0.1.0/24",
           "description": "Frozzzen",
           "vlan": null,
@@ -10730,8 +10454,8 @@
       "              10.0.1.4   <not set>   ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Thu Feb 27 10:47:39 2025",
-      "Updated:      Thu Feb 27 10:47:39 2025"
+      "Created:      Wed Mar 19 12:04:43 2025",
+      "Updated:      Wed Mar 19 12:04:43 2025"
     ],
     "api_requests": [
       {
@@ -10761,18 +10485,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2025-02-27T10:47:35.896278+01:00",
-                "updated_at": "2025-02-27T10:47:35.896293+01:00",
+                "created_at": "2025-03-19T12:04:41.191611+01:00",
+                "updated_at": "2025-03-19T12:04:41.191623+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-02-27T10:47:35.640608+01:00",
-            "updated_at": "2025-02-27T10:47:38.729477+01:00",
+            "created_at": "2025-03-19T12:04:40.912310+01:00",
+            "updated_at": "2025-03-19T12:04:43.163803+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-02-27T10:47:35.942147+01:00",
+            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -10790,15 +10514,17 @@
         "response": {
           "excluded_ranges": [
             {
-              "created_at": "2025-02-27T10:47:39.105553+01:00",
-              "updated_at": "2025-02-27T10:47:39.105565+01:00",
+              "created_at": "2025-03-19T12:04:43.477741+01:00",
+              "updated_at": "2025-03-19T12:04:43.477754+01:00",
               "start_ip": "10.0.1.20",
               "end_ip": "10.0.1.30",
               "network": 3
             }
           ],
-          "created_at": "2025-02-27T10:47:38.858014+01:00",
-          "updated_at": "2025-02-27T10:47:38.921409+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:43.270431+01:00",
+          "updated_at": "2025-03-19T12:04:43.337782+01:00",
           "network": "10.0.1.0/24",
           "description": "Frozzzen",
           "vlan": null,
@@ -10828,8 +10554,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-02-27T10:47:39.653741+01:00",
-              "updated_at": "2025-02-27T10:47:39.653750+01:00",
+              "created_at": "2025-03-19T12:04:43.725495+01:00",
+              "updated_at": "2025-03-19T12:04:43.725508+01:00",
               "ipaddress": "10.0.1.4",
               "host": 4
             }
@@ -10838,18 +10564,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-02-27T10:47:39.626065+01:00",
-              "updated_at": "2025-02-27T10:47:39.626072+01:00",
+              "created_at": "2025-03-19T12:04:43.707238+01:00",
+              "updated_at": "2025-03-19T12:04:43.707244+01:00",
               "txt": "v=spf1 -all",
               "host": 4
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2025-02-27T10:47:39.622421+01:00",
-          "updated_at": "2025-02-27T10:47:39.622433+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:43.705544+01:00",
+          "updated_at": "2025-03-19T12:04:43.705553+01:00",
           "name": "somehost.example.org",
           "contact": "support@example.org",
           "ttl": null,
@@ -10865,15 +10597,17 @@
         "response": {
           "excluded_ranges": [
             {
-              "created_at": "2025-02-27T10:47:39.105553+01:00",
-              "updated_at": "2025-02-27T10:47:39.105565+01:00",
+              "created_at": "2025-03-19T12:04:43.477741+01:00",
+              "updated_at": "2025-03-19T12:04:43.477754+01:00",
               "start_ip": "10.0.1.20",
               "end_ip": "10.0.1.30",
               "network": 3
             }
           ],
-          "created_at": "2025-02-27T10:47:38.858014+01:00",
-          "updated_at": "2025-02-27T10:47:38.921409+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:43.270431+01:00",
+          "updated_at": "2025-03-19T12:04:43.337782+01:00",
           "network": "10.0.1.0/24",
           "description": "Frozzzen",
           "vlan": null,
@@ -10882,93 +10616,6 @@
           "location": "",
           "frozen": true,
           "reserved": 3
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/ip/10.0.1.4",
-        "data": {},
-        "status": 200,
-        "response": {
-          "excluded_ranges": [
-            {
-              "created_at": "2025-02-27T10:47:39.105553+01:00",
-              "updated_at": "2025-02-27T10:47:39.105565+01:00",
-              "start_ip": "10.0.1.20",
-              "end_ip": "10.0.1.30",
-              "network": 3
-            }
-          ],
-          "created_at": "2025-02-27T10:47:38.858014+01:00",
-          "updated_at": "2025-02-27T10:47:38.921409+01:00",
-          "network": "10.0.1.0/24",
-          "description": "Frozzzen",
-          "vlan": null,
-          "dns_delegated": false,
-          "category": "",
-          "location": "",
-          "frozen": true,
-          "reserved": 3
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/srvs/?host=4",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/naptrs/?host=4",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/sshfps/?host=4",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hostpolicy/roles/?hosts=4",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hostgroups/?hosts=4",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
         }
       }
     ],
@@ -10994,15 +10641,17 @@
         "response": {
           "excluded_ranges": [
             {
-              "created_at": "2024-12-11T16:44:45.955630+01:00",
-              "updated_at": "2024-12-11T16:44:45.955656+01:00",
+              "created_at": "2025-03-19T10:10:44.935337+01:00",
+              "updated_at": "2025-03-19T10:10:44.935355+01:00",
               "start_ip": "10.0.1.20",
               "end_ip": "10.0.1.30",
               "network": 3
             }
           ],
-          "created_at": "2024-12-11T16:44:45.393437+01:00",
-          "updated_at": "2024-12-11T16:44:45.582957+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T10:10:44.688196+01:00",
+          "updated_at": "2025-03-19T10:10:44.766999+01:00",
           "network": "10.0.1.0/24",
           "description": "Frozzzen",
           "vlan": null,
@@ -11054,15 +10703,17 @@
         "response": {
           "excluded_ranges": [
             {
-              "created_at": "2024-12-11T16:44:45.955630+01:00",
-              "updated_at": "2024-12-11T16:44:45.955656+01:00",
+              "created_at": "2025-03-19T10:10:44.935337+01:00",
+              "updated_at": "2025-03-19T10:10:44.935355+01:00",
               "start_ip": "10.0.1.20",
               "end_ip": "10.0.1.30",
               "network": 3
             }
           ],
-          "created_at": "2024-12-11T16:44:45.393437+01:00",
-          "updated_at": "2024-12-11T16:44:45.582957+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T10:10:44.688196+01:00",
+          "updated_at": "2025-03-19T10:10:44.766999+01:00",
           "network": "10.0.1.0/24",
           "description": "Frozzzen",
           "vlan": null,
@@ -11094,15 +10745,17 @@
             {
               "excluded_ranges": [
                 {
-                  "created_at": "2024-12-11T16:44:45.955630+01:00",
-                  "updated_at": "2024-12-11T16:44:45.955656+01:00",
+                  "created_at": "2025-03-19T10:10:44.935337+01:00",
+                  "updated_at": "2025-03-19T10:10:44.935355+01:00",
                   "start_ip": "10.0.1.20",
                   "end_ip": "10.0.1.30",
                   "network": 3
                 }
               ],
-              "created_at": "2024-12-11T16:44:45.393437+01:00",
-              "updated_at": "2024-12-11T16:44:47.108747+01:00",
+              "policy": null,
+              "communities": [],
+              "created_at": "2025-03-19T10:10:44.688196+01:00",
+              "updated_at": "2025-03-19T10:10:45.413979+01:00",
               "network": "10.0.1.0/24",
               "description": "Frozen but has one host",
               "vlan": null,
@@ -11138,15 +10791,17 @@
         "response": {
           "excluded_ranges": [
             {
-              "created_at": "2024-12-11T16:44:45.955630+01:00",
-              "updated_at": "2024-12-11T16:44:45.955656+01:00",
+              "created_at": "2025-03-19T10:10:44.935337+01:00",
+              "updated_at": "2025-03-19T10:10:44.935355+01:00",
               "start_ip": "10.0.1.20",
               "end_ip": "10.0.1.30",
               "network": 3
             }
           ],
-          "created_at": "2024-12-11T16:44:45.393437+01:00",
-          "updated_at": "2024-12-11T16:44:47.108747+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T10:10:44.688196+01:00",
+          "updated_at": "2025-03-19T10:10:45.413979+01:00",
           "network": "10.0.1.0/24",
           "description": "Frozen but has one host",
           "vlan": null,
@@ -11178,15 +10833,17 @@
             {
               "excluded_ranges": [
                 {
-                  "created_at": "2024-12-11T16:44:45.955630+01:00",
-                  "updated_at": "2024-12-11T16:44:45.955656+01:00",
+                  "created_at": "2025-03-19T10:10:44.935337+01:00",
+                  "updated_at": "2025-03-19T10:10:44.935355+01:00",
                   "start_ip": "10.0.1.20",
                   "end_ip": "10.0.1.30",
                   "network": 3
                 }
               ],
-              "created_at": "2024-12-11T16:44:45.393437+01:00",
-              "updated_at": "2024-12-11T16:44:47.307856+01:00",
+              "policy": null,
+              "communities": [],
+              "created_at": "2025-03-19T10:10:44.688196+01:00",
+              "updated_at": "2025-03-19T10:10:45.489029+01:00",
               "network": "10.0.1.0/24",
               "description": "Frozen but has one host",
               "vlan": null,
@@ -11222,15 +10879,17 @@
         "response": {
           "excluded_ranges": [
             {
-              "created_at": "2024-12-11T16:44:45.955630+01:00",
-              "updated_at": "2024-12-11T16:44:45.955656+01:00",
+              "created_at": "2025-03-19T10:10:44.935337+01:00",
+              "updated_at": "2025-03-19T10:10:44.935355+01:00",
               "start_ip": "10.0.1.20",
               "end_ip": "10.0.1.30",
               "network": 3
             }
           ],
-          "created_at": "2024-12-11T16:44:45.393437+01:00",
-          "updated_at": "2024-12-11T16:44:47.307856+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T10:10:44.688196+01:00",
+          "updated_at": "2025-03-19T10:10:45.489029+01:00",
           "network": "10.0.1.0/24",
           "description": "Frozen but has one host",
           "vlan": null,
@@ -11262,15 +10921,17 @@
             {
               "excluded_ranges": [
                 {
-                  "created_at": "2024-12-11T16:44:45.955630+01:00",
-                  "updated_at": "2024-12-11T16:44:45.955656+01:00",
+                  "created_at": "2025-03-19T10:10:44.935337+01:00",
+                  "updated_at": "2025-03-19T10:10:44.935355+01:00",
                   "start_ip": "10.0.1.20",
                   "end_ip": "10.0.1.30",
                   "network": 3
                 }
               ],
-              "created_at": "2024-12-11T16:44:45.393437+01:00",
-              "updated_at": "2024-12-11T16:44:47.505945+01:00",
+              "policy": null,
+              "communities": [],
+              "created_at": "2025-03-19T10:10:44.688196+01:00",
+              "updated_at": "2025-03-19T10:10:45.562172+01:00",
               "network": "10.0.1.0/24",
               "description": "Frozen but has one host",
               "vlan": null,
@@ -11306,15 +10967,17 @@
         "response": {
           "excluded_ranges": [
             {
-              "created_at": "2024-12-11T16:44:45.955630+01:00",
-              "updated_at": "2024-12-11T16:44:45.955656+01:00",
+              "created_at": "2025-03-19T10:10:44.935337+01:00",
+              "updated_at": "2025-03-19T10:10:44.935355+01:00",
               "start_ip": "10.0.1.20",
               "end_ip": "10.0.1.30",
               "network": 3
             }
           ],
-          "created_at": "2024-12-11T16:44:45.393437+01:00",
-          "updated_at": "2024-12-11T16:44:47.505945+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T10:10:44.688196+01:00",
+          "updated_at": "2025-03-19T10:10:45.562172+01:00",
           "network": "10.0.1.0/24",
           "description": "Frozen but has one host",
           "vlan": null,
@@ -11346,15 +11009,17 @@
             {
               "excluded_ranges": [
                 {
-                  "created_at": "2024-12-11T16:44:45.955630+01:00",
-                  "updated_at": "2024-12-11T16:44:45.955656+01:00",
+                  "created_at": "2025-03-19T10:10:44.935337+01:00",
+                  "updated_at": "2025-03-19T10:10:44.935355+01:00",
                   "start_ip": "10.0.1.20",
                   "end_ip": "10.0.1.30",
                   "network": 3
                 }
               ],
-              "created_at": "2024-12-11T16:44:45.393437+01:00",
-              "updated_at": "2024-12-11T16:44:47.698742+01:00",
+              "policy": null,
+              "communities": [],
+              "created_at": "2025-03-19T10:10:44.688196+01:00",
+              "updated_at": "2025-03-19T10:10:45.629603+01:00",
               "network": "10.0.1.0/24",
               "description": "Frozen but has one host",
               "vlan": 1234,
@@ -11410,15 +11075,17 @@
         "response": {
           "excluded_ranges": [
             {
-              "created_at": "2025-02-27T10:47:39.105553+01:00",
-              "updated_at": "2025-02-27T10:47:39.105565+01:00",
+              "created_at": "2025-03-19T10:10:44.935337+01:00",
+              "updated_at": "2025-03-19T10:10:44.935355+01:00",
               "start_ip": "10.0.1.20",
               "end_ip": "10.0.1.30",
               "network": 3
             }
           ],
-          "created_at": "2025-02-27T10:47:38.858014+01:00",
-          "updated_at": "2025-02-27T10:47:40.251653+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T10:10:44.688196+01:00",
+          "updated_at": "2025-03-19T10:10:45.629603+01:00",
           "network": "10.0.1.0/24",
           "description": "Frozen but has one host",
           "vlan": 1234,
@@ -11507,8 +11174,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:44:46.560426+01:00",
-              "updated_at": "2024-12-11T16:44:46.560441+01:00",
+              "created_at": "2025-03-19T12:04:43.725495+01:00",
+              "updated_at": "2025-03-19T12:04:43.725508+01:00",
               "ipaddress": "10.0.1.4",
               "host": 4
             }
@@ -11517,18 +11184,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:44:46.533402+01:00",
-              "updated_at": "2024-12-11T16:44:46.533419+01:00",
+              "created_at": "2025-03-19T12:04:43.707238+01:00",
+              "updated_at": "2025-03-19T12:04:43.707244+01:00",
               "txt": "v=spf1 -all",
               "host": 4
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:44:46.528383+01:00",
-          "updated_at": "2024-12-11T16:44:46.528401+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:43.705544+01:00",
+          "updated_at": "2025-03-19T12:04:43.705553+01:00",
           "name": "somehost.example.org",
           "contact": "support@example.org",
           "ttl": null,
@@ -11558,8 +11231,8 @@
               "ipaddresses": [
                 {
                   "macaddress": "",
-                  "created_at": "2024-12-11T16:44:46.560426+01:00",
-                  "updated_at": "2024-12-11T16:44:46.560441+01:00",
+                  "created_at": "2025-03-19T12:04:43.725495+01:00",
+                  "updated_at": "2025-03-19T12:04:43.725508+01:00",
                   "ipaddress": "10.0.1.4",
                   "host": 4
                 }
@@ -11568,18 +11241,24 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2024-12-11T16:44:46.533402+01:00",
-                  "updated_at": "2024-12-11T16:44:46.533419+01:00",
+                  "created_at": "2025-03-19T12:04:43.707238+01:00",
+                  "updated_at": "2025-03-19T12:04:43.707244+01:00",
                   "txt": "v=spf1 -all",
                   "host": 4
                 }
               ],
               "ptr_overrides": [],
+              "srvs": [],
+              "naptrs": [],
+              "sshfps": [],
+              "groups": [],
+              "roles": [],
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
-              "created_at": "2024-12-11T16:44:46.528383+01:00",
-              "updated_at": "2024-12-11T16:44:48.169499+01:00",
+              "communities": [],
+              "created_at": "2025-03-19T12:04:43.705544+01:00",
+              "updated_at": "2025-03-19T12:04:44.290099+01:00",
               "name": "somehost.example.org",
               "contact": "new-support@example.org",
               "ttl": null,
@@ -11601,10 +11280,10 @@
     "warning": [],
     "error": [],
     "output": [
-      "2024-10-08 15:31:15 [system-signals]: Txt create: txt = 'v=spf1 -all'",
-      "2024-10-08 15:31:15 [test]: Host create: name = 'somehost.example.org', contact = 'support@example.org'",
-      "2024-10-08 15:31:15 [test]: Ipaddress create: ipaddress = '10.0.1.4'",
-      "2024-10-08 15:31:15 [test]: Host update: contact: support@example.org -> new-support@example.org"
+      "2025-03-19 12:04:43 [system-signals]: Txt create: txt = 'v=spf1 -all'",
+      "2025-03-19 12:04:43 [test]: Host create: name = 'somehost.example.org', contact = 'support@example.org'",
+      "2025-03-19 12:04:43 [test]: Ipaddress create: ipaddress = '10.0.1.4'",
+      "2025-03-19 12:04:44 [test]: Host update: contact: support@example.org -> new-support@example.org"
     ],
     "api_requests": [
       {
@@ -11618,7 +11297,7 @@
           "previous": null,
           "results": [
             {
-              "timestamp": "2024-10-08T15:31:15.355797+02:00",
+              "timestamp": "2025-03-19T12:04:43.707643+01:00",
               "user": "system-signals",
               "resource": "host",
               "name": "somehost.example.org",
@@ -11630,7 +11309,7 @@
               }
             },
             {
-              "timestamp": "2024-10-08T15:31:15.357852+02:00",
+              "timestamp": "2025-03-19T12:04:43.717675+01:00",
               "user": "test",
               "resource": "host",
               "name": "somehost.example.org",
@@ -11640,7 +11319,7 @@
               "data": "{\"name\": \"somehost.example.org\", \"contact\": \"support@example.org\"}"
             },
             {
-              "timestamp": "2024-10-08T15:31:15.360417+02:00",
+              "timestamp": "2025-03-19T12:04:43.727304+01:00",
               "user": "test",
               "resource": "host",
               "name": "somehost.example.org",
@@ -11650,14 +11329,14 @@
               "data": "{\"ipaddress\": \"10.0.1.4\"}"
             },
             {
-              "timestamp": "2024-10-08T15:31:15.659869+02:00",
+              "timestamp": "2025-03-19T12:04:44.294647+01:00",
               "user": "test",
               "resource": "host",
               "name": "somehost.example.org",
               "model_id": 4,
               "model": "Host",
               "action": "update",
-              "data": "{\"current_data\": {\"id\": 4, \"ipaddresses\": [{\"id\": 3, \"macaddress\": \"\", \"created_at\": \"2024-10-08T15:31:15.360161+02:00\", \"updated_at\": \"2024-10-08T15:31:15.360164+02:00\", \"ipaddress\": \"10.0.1.4\", \"host\": 4}], \"cnames\": [], \"mxs\": [], \"txts\": [{\"id\": 4, \"created_at\": \"2024-10-08T15:31:15.355571+02:00\", \"updated_at\": \"2024-10-08T15:31:15.355574+02:00\", \"txt\": \"v=spf1 -all\", \"host\": 4}], \"ptr_overrides\": [], \"hinfo\": null, \"loc\": null, \"bacnetid\": null, \"created_at\": \"2024-10-08T15:31:15.354780+02:00\", \"updated_at\": \"2024-10-08T15:31:15.354784+02:00\", \"name\": \"somehost.example.org\", \"contact\": \"support@example.org\", \"ttl\": null, \"comment\": \"\", \"zone\": 1}, \"update\": {\"contact\": \"new-support@example.org\"}}"
+              "data": "{\"current_data\": {\"id\": 4, \"ipaddresses\": [{\"id\": 3, \"macaddress\": \"\", \"created_at\": \"2025-03-19T12:04:43.725495+01:00\", \"updated_at\": \"2025-03-19T12:04:43.725508+01:00\", \"ipaddress\": \"10.0.1.4\", \"host\": 4}], \"cnames\": [], \"mxs\": [], \"txts\": [{\"id\": 4, \"created_at\": \"2025-03-19T12:04:43.707238+01:00\", \"updated_at\": \"2025-03-19T12:04:43.707244+01:00\", \"txt\": \"v=spf1 -all\", \"host\": 4}], \"ptr_overrides\": [], \"srvs\": [], \"naptrs\": [], \"sshfps\": [], \"groups\": [], \"roles\": [], \"hinfo\": null, \"loc\": null, \"bacnetid\": null, \"communities\": [], \"created_at\": \"2025-03-19T12:04:43.705544+01:00\", \"updated_at\": \"2025-03-19T12:04:43.705553+01:00\", \"name\": \"somehost.example.org\", \"contact\": \"support@example.org\", \"ttl\": null, \"comment\": \"\", \"zone\": 1}, \"update\": {\"contact\": \"new-support@example.org\"}}"
             }
           ]
         }
@@ -11673,7 +11352,7 @@
           "previous": null,
           "results": [
             {
-              "timestamp": "2024-10-08T15:31:15.355797+02:00",
+              "timestamp": "2025-03-19T12:04:43.707643+01:00",
               "user": "system-signals",
               "resource": "host",
               "name": "somehost.example.org",
@@ -11685,7 +11364,7 @@
               }
             },
             {
-              "timestamp": "2024-10-08T15:31:15.357852+02:00",
+              "timestamp": "2025-03-19T12:04:43.717675+01:00",
               "user": "test",
               "resource": "host",
               "name": "somehost.example.org",
@@ -11695,7 +11374,7 @@
               "data": "{\"name\": \"somehost.example.org\", \"contact\": \"support@example.org\"}"
             },
             {
-              "timestamp": "2024-10-08T15:31:15.360417+02:00",
+              "timestamp": "2025-03-19T12:04:43.727304+01:00",
               "user": "test",
               "resource": "host",
               "name": "somehost.example.org",
@@ -11705,14 +11384,14 @@
               "data": "{\"ipaddress\": \"10.0.1.4\"}"
             },
             {
-              "timestamp": "2024-10-08T15:31:15.659869+02:00",
+              "timestamp": "2025-03-19T12:04:44.294647+01:00",
               "user": "test",
               "resource": "host",
               "name": "somehost.example.org",
               "model_id": 4,
               "model": "Host",
               "action": "update",
-              "data": "{\"current_data\": {\"id\": 4, \"ipaddresses\": [{\"id\": 3, \"macaddress\": \"\", \"created_at\": \"2024-10-08T15:31:15.360161+02:00\", \"updated_at\": \"2024-10-08T15:31:15.360164+02:00\", \"ipaddress\": \"10.0.1.4\", \"host\": 4}], \"cnames\": [], \"mxs\": [], \"txts\": [{\"id\": 4, \"created_at\": \"2024-10-08T15:31:15.355571+02:00\", \"updated_at\": \"2024-10-08T15:31:15.355574+02:00\", \"txt\": \"v=spf1 -all\", \"host\": 4}], \"ptr_overrides\": [], \"hinfo\": null, \"loc\": null, \"bacnetid\": null, \"created_at\": \"2024-10-08T15:31:15.354780+02:00\", \"updated_at\": \"2024-10-08T15:31:15.354784+02:00\", \"name\": \"somehost.example.org\", \"contact\": \"support@example.org\", \"ttl\": null, \"comment\": \"\", \"zone\": 1}, \"update\": {\"contact\": \"new-support@example.org\"}}"
+              "data": "{\"current_data\": {\"id\": 4, \"ipaddresses\": [{\"id\": 3, \"macaddress\": \"\", \"created_at\": \"2025-03-19T12:04:43.725495+01:00\", \"updated_at\": \"2025-03-19T12:04:43.725508+01:00\", \"ipaddress\": \"10.0.1.4\", \"host\": 4}], \"cnames\": [], \"mxs\": [], \"txts\": [{\"id\": 4, \"created_at\": \"2025-03-19T12:04:43.707238+01:00\", \"updated_at\": \"2025-03-19T12:04:43.707244+01:00\", \"txt\": \"v=spf1 -all\", \"host\": 4}], \"ptr_overrides\": [], \"srvs\": [], \"naptrs\": [], \"sshfps\": [], \"groups\": [], \"roles\": [], \"hinfo\": null, \"loc\": null, \"bacnetid\": null, \"communities\": [], \"created_at\": \"2025-03-19T12:04:43.705544+01:00\", \"updated_at\": \"2025-03-19T12:04:43.705553+01:00\", \"name\": \"somehost.example.org\", \"contact\": \"support@example.org\", \"ttl\": null, \"comment\": \"\", \"zone\": 1}, \"update\": {\"contact\": \"new-support@example.org\"}}"
             }
           ]
         }
@@ -11753,8 +11432,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:44:46.560426+01:00",
-              "updated_at": "2024-12-11T16:44:46.560441+01:00",
+              "created_at": "2025-03-19T12:04:43.725495+01:00",
+              "updated_at": "2025-03-19T12:04:43.725508+01:00",
               "ipaddress": "10.0.1.4",
               "host": 4
             }
@@ -11763,18 +11442,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:44:46.533402+01:00",
-              "updated_at": "2024-12-11T16:44:46.533419+01:00",
+              "created_at": "2025-03-19T12:04:43.707238+01:00",
+              "updated_at": "2025-03-19T12:04:43.707244+01:00",
               "txt": "v=spf1 -all",
               "host": 4
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:44:46.528383+01:00",
-          "updated_at": "2024-12-11T16:44:48.169499+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:43.705544+01:00",
+          "updated_at": "2025-03-19T12:04:44.290099+01:00",
           "name": "somehost.example.org",
           "contact": "new-support@example.org",
           "ttl": null,
@@ -11790,15 +11475,17 @@
         "response": {
           "excluded_ranges": [
             {
-              "created_at": "2024-12-11T16:44:45.955630+01:00",
-              "updated_at": "2024-12-11T16:44:45.955656+01:00",
+              "created_at": "2025-03-19T12:04:43.477741+01:00",
+              "updated_at": "2025-03-19T12:04:43.477754+01:00",
               "start_ip": "10.0.1.20",
               "end_ip": "10.0.1.30",
               "network": 3
             }
           ],
-          "created_at": "2024-12-11T16:44:45.393437+01:00",
-          "updated_at": "2024-12-11T16:44:47.698742+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:43.270431+01:00",
+          "updated_at": "2025-03-19T12:04:44.091558+01:00",
           "network": "10.0.1.0/24",
           "description": "Frozen but has one host",
           "vlan": 1234,
@@ -11840,8 +11527,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:44:46.560426+01:00",
-              "updated_at": "2024-12-11T16:44:46.560441+01:00",
+              "created_at": "2025-03-19T12:04:43.725495+01:00",
+              "updated_at": "2025-03-19T12:04:43.725508+01:00",
               "ipaddress": "10.0.1.4",
               "host": 4
             }
@@ -11850,18 +11537,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:44:46.533402+01:00",
-              "updated_at": "2024-12-11T16:44:46.533419+01:00",
+              "created_at": "2025-03-19T12:04:43.707238+01:00",
+              "updated_at": "2025-03-19T12:04:43.707244+01:00",
               "txt": "v=spf1 -all",
               "host": 4
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:44:46.528383+01:00",
-          "updated_at": "2024-12-11T16:44:48.169499+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:43.705544+01:00",
+          "updated_at": "2025-03-19T12:04:44.290099+01:00",
           "name": "somehost.example.org",
           "contact": "new-support@example.org",
           "ttl": null,
@@ -11877,15 +11570,17 @@
         "response": {
           "excluded_ranges": [
             {
-              "created_at": "2024-12-11T16:44:45.955630+01:00",
-              "updated_at": "2024-12-11T16:44:45.955656+01:00",
+              "created_at": "2025-03-19T12:04:43.477741+01:00",
+              "updated_at": "2025-03-19T12:04:43.477754+01:00",
               "start_ip": "10.0.1.20",
               "end_ip": "10.0.1.30",
               "network": 3
             }
           ],
-          "created_at": "2024-12-11T16:44:45.393437+01:00",
-          "updated_at": "2024-12-11T16:44:47.698742+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:43.270431+01:00",
+          "updated_at": "2025-03-19T12:04:44.091558+01:00",
           "network": "10.0.1.0/24",
           "description": "Frozen but has one host",
           "vlan": 1234,
@@ -11913,8 +11608,8 @@
         "status": 201,
         "response": {
           "macaddress": "",
-          "created_at": "2024-12-11T16:44:48.833137+01:00",
-          "updated_at": "2024-12-11T16:44:48.833158+01:00",
+          "created_at": "2025-03-19T12:04:44.602604+01:00",
+          "updated_at": "2025-03-19T12:04:44.602610+01:00",
           "ipaddress": "10.0.1.5",
           "host": 4
         }
@@ -11933,15 +11628,15 @@
               "ipaddresses": [
                 {
                   "macaddress": "",
-                  "created_at": "2024-12-11T16:44:46.560426+01:00",
-                  "updated_at": "2024-12-11T16:44:46.560441+01:00",
+                  "created_at": "2025-03-19T12:04:43.725495+01:00",
+                  "updated_at": "2025-03-19T12:04:43.725508+01:00",
                   "ipaddress": "10.0.1.4",
                   "host": 4
                 },
                 {
                   "macaddress": "",
-                  "created_at": "2024-12-11T16:44:48.833137+01:00",
-                  "updated_at": "2024-12-11T16:44:48.833158+01:00",
+                  "created_at": "2025-03-19T12:04:44.602604+01:00",
+                  "updated_at": "2025-03-19T12:04:44.602610+01:00",
                   "ipaddress": "10.0.1.5",
                   "host": 4
                 }
@@ -11950,18 +11645,24 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2024-12-11T16:44:46.533402+01:00",
-                  "updated_at": "2024-12-11T16:44:46.533419+01:00",
+                  "created_at": "2025-03-19T12:04:43.707238+01:00",
+                  "updated_at": "2025-03-19T12:04:43.707244+01:00",
                   "txt": "v=spf1 -all",
                   "host": 4
                 }
               ],
               "ptr_overrides": [],
+              "srvs": [],
+              "naptrs": [],
+              "sshfps": [],
+              "groups": [],
+              "roles": [],
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
-              "created_at": "2024-12-11T16:44:46.528383+01:00",
-              "updated_at": "2024-12-11T16:44:48.169499+01:00",
+              "communities": [],
+              "created_at": "2025-03-19T12:04:43.705544+01:00",
+              "updated_at": "2025-03-19T12:04:44.290099+01:00",
               "name": "somehost.example.org",
               "contact": "new-support@example.org",
               "ttl": null,
@@ -11995,15 +11696,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:44:46.560426+01:00",
-              "updated_at": "2024-12-11T16:44:46.560441+01:00",
+              "created_at": "2025-03-19T12:04:43.725495+01:00",
+              "updated_at": "2025-03-19T12:04:43.725508+01:00",
               "ipaddress": "10.0.1.4",
               "host": 4
             },
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:44:48.833137+01:00",
-              "updated_at": "2024-12-11T16:44:48.833158+01:00",
+              "created_at": "2025-03-19T12:04:44.602604+01:00",
+              "updated_at": "2025-03-19T12:04:44.602610+01:00",
               "ipaddress": "10.0.1.5",
               "host": 4
             }
@@ -12012,18 +11713,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:44:46.533402+01:00",
-              "updated_at": "2024-12-11T16:44:46.533419+01:00",
+              "created_at": "2025-03-19T12:04:43.707238+01:00",
+              "updated_at": "2025-03-19T12:04:43.707244+01:00",
               "txt": "v=spf1 -all",
               "host": 4
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:44:46.528383+01:00",
-          "updated_at": "2024-12-11T16:44:48.169499+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:43.705544+01:00",
+          "updated_at": "2025-03-19T12:04:44.290099+01:00",
           "name": "somehost.example.org",
           "contact": "new-support@example.org",
           "ttl": null,
@@ -12039,15 +11746,17 @@
         "response": {
           "excluded_ranges": [
             {
-              "created_at": "2024-12-11T16:44:45.955630+01:00",
-              "updated_at": "2024-12-11T16:44:45.955656+01:00",
+              "created_at": "2025-03-19T12:04:43.477741+01:00",
+              "updated_at": "2025-03-19T12:04:43.477754+01:00",
               "start_ip": "10.0.1.20",
               "end_ip": "10.0.1.30",
               "network": 3
             }
           ],
-          "created_at": "2024-12-11T16:44:45.393437+01:00",
-          "updated_at": "2024-12-11T16:44:47.698742+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:43.270431+01:00",
+          "updated_at": "2025-03-19T12:04:44.091558+01:00",
           "network": "10.0.1.0/24",
           "description": "Frozen but has one host",
           "vlan": 1234,
@@ -12066,15 +11775,17 @@
         "response": {
           "excluded_ranges": [
             {
-              "created_at": "2024-12-11T16:44:45.955630+01:00",
-              "updated_at": "2024-12-11T16:44:45.955656+01:00",
+              "created_at": "2025-03-19T12:04:43.477741+01:00",
+              "updated_at": "2025-03-19T12:04:43.477754+01:00",
               "start_ip": "10.0.1.20",
               "end_ip": "10.0.1.30",
               "network": 3
             }
           ],
-          "created_at": "2024-12-11T16:44:45.393437+01:00",
-          "updated_at": "2024-12-11T16:44:47.698742+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:43.270431+01:00",
+          "updated_at": "2025-03-19T12:04:44.091558+01:00",
           "network": "10.0.1.0/24",
           "description": "Frozen but has one host",
           "vlan": 1234,
@@ -12083,30 +11794,6 @@
           "location": "loc1",
           "frozen": true,
           "reserved": 3
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/naptrs/?host=4",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/srvs/?host=4",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
         }
       }
     ],
@@ -12133,15 +11820,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:44:46.560426+01:00",
-              "updated_at": "2024-12-11T16:44:46.560441+01:00",
+              "created_at": "2025-03-19T12:04:43.725495+01:00",
+              "updated_at": "2025-03-19T12:04:43.725508+01:00",
               "ipaddress": "10.0.1.4",
               "host": 4
             },
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:44:48.833137+01:00",
-              "updated_at": "2024-12-11T16:44:48.833158+01:00",
+              "created_at": "2025-03-19T12:04:44.602604+01:00",
+              "updated_at": "2025-03-19T12:04:44.602610+01:00",
               "ipaddress": "10.0.1.5",
               "host": 4
             }
@@ -12150,18 +11837,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:44:46.533402+01:00",
-              "updated_at": "2024-12-11T16:44:46.533419+01:00",
+              "created_at": "2025-03-19T12:04:43.707238+01:00",
+              "updated_at": "2025-03-19T12:04:43.707244+01:00",
               "txt": "v=spf1 -all",
               "host": 4
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:44:46.528383+01:00",
-          "updated_at": "2024-12-11T16:44:48.169499+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:43.705544+01:00",
+          "updated_at": "2025-03-19T12:04:44.290099+01:00",
           "name": "somehost.example.org",
           "contact": "new-support@example.org",
           "ttl": null,
@@ -12177,15 +11870,17 @@
         "response": {
           "excluded_ranges": [
             {
-              "created_at": "2024-12-11T16:44:45.955630+01:00",
-              "updated_at": "2024-12-11T16:44:45.955656+01:00",
+              "created_at": "2025-03-19T12:04:43.477741+01:00",
+              "updated_at": "2025-03-19T12:04:43.477754+01:00",
               "start_ip": "10.0.1.20",
               "end_ip": "10.0.1.30",
               "network": 3
             }
           ],
-          "created_at": "2024-12-11T16:44:45.393437+01:00",
-          "updated_at": "2024-12-11T16:44:47.698742+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:43.270431+01:00",
+          "updated_at": "2025-03-19T12:04:44.091558+01:00",
           "network": "10.0.1.0/24",
           "description": "Frozen but has one host",
           "vlan": 1234,
@@ -12204,15 +11899,17 @@
         "response": {
           "excluded_ranges": [
             {
-              "created_at": "2024-12-11T16:44:45.955630+01:00",
-              "updated_at": "2024-12-11T16:44:45.955656+01:00",
+              "created_at": "2025-03-19T12:04:43.477741+01:00",
+              "updated_at": "2025-03-19T12:04:43.477754+01:00",
               "start_ip": "10.0.1.20",
               "end_ip": "10.0.1.30",
               "network": 3
             }
           ],
-          "created_at": "2024-12-11T16:44:45.393437+01:00",
-          "updated_at": "2024-12-11T16:44:47.698742+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:43.270431+01:00",
+          "updated_at": "2025-03-19T12:04:44.091558+01:00",
           "network": "10.0.1.0/24",
           "description": "Frozen but has one host",
           "vlan": 1234,
@@ -12221,30 +11918,6 @@
           "location": "loc1",
           "frozen": true,
           "reserved": 3
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/naptrs/?host=4",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/srvs/?host=4",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
         }
       },
       {
@@ -12276,15 +11949,17 @@
         "response": {
           "excluded_ranges": [
             {
-              "created_at": "2024-12-11T16:44:45.955630+01:00",
-              "updated_at": "2024-12-11T16:44:45.955656+01:00",
+              "created_at": "2025-03-19T10:10:44.935337+01:00",
+              "updated_at": "2025-03-19T10:10:44.935355+01:00",
               "start_ip": "10.0.1.20",
               "end_ip": "10.0.1.30",
               "network": 3
             }
           ],
-          "created_at": "2024-12-11T16:44:45.393437+01:00",
-          "updated_at": "2024-12-11T16:44:47.698742+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T10:10:44.688196+01:00",
+          "updated_at": "2025-03-19T10:10:45.629603+01:00",
           "network": "10.0.1.0/24",
           "description": "Frozen but has one host",
           "vlan": 1234,
@@ -12316,15 +11991,17 @@
             {
               "excluded_ranges": [
                 {
-                  "created_at": "2024-12-11T16:44:45.955630+01:00",
-                  "updated_at": "2024-12-11T16:44:45.955656+01:00",
+                  "created_at": "2025-03-19T10:10:44.935337+01:00",
+                  "updated_at": "2025-03-19T10:10:44.935355+01:00",
                   "start_ip": "10.0.1.20",
                   "end_ip": "10.0.1.30",
                   "network": 3
                 }
               ],
-              "created_at": "2024-12-11T16:44:45.393437+01:00",
-              "updated_at": "2024-12-11T16:44:49.759182+01:00",
+              "policy": null,
+              "communities": [],
+              "created_at": "2025-03-19T10:10:44.688196+01:00",
+              "updated_at": "2025-03-19T10:10:46.452187+01:00",
               "network": "10.0.1.0/24",
               "description": "Frozen but has one host",
               "vlan": 1234,
@@ -12379,18 +12056,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2024-12-11T16:44:40.356452+01:00",
-                "updated_at": "2024-12-11T16:44:40.356481+01:00",
+                "created_at": "2025-03-19T10:10:42.280399+01:00",
+                "updated_at": "2025-03-19T10:10:42.280412+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2024-12-11T16:44:39.701254+01:00",
-            "updated_at": "2024-12-11T16:44:49.630468+01:00",
+            "created_at": "2025-03-19T10:10:41.753629+01:00",
+            "updated_at": "2025-03-19T10:10:46.390763+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
+            "serialno_updated_at": "2025-03-19T10:10:42.331334+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -12408,15 +12085,17 @@
         "response": {
           "excluded_ranges": [
             {
-              "created_at": "2024-12-11T16:44:45.955630+01:00",
-              "updated_at": "2024-12-11T16:44:45.955656+01:00",
+              "created_at": "2025-03-19T10:10:44.935337+01:00",
+              "updated_at": "2025-03-19T10:10:44.935355+01:00",
               "start_ip": "10.0.1.20",
               "end_ip": "10.0.1.30",
               "network": 3
             }
           ],
-          "created_at": "2024-12-11T16:44:45.393437+01:00",
-          "updated_at": "2024-12-11T16:44:49.759182+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T10:10:44.688196+01:00",
+          "updated_at": "2025-03-19T10:10:46.452187+01:00",
           "network": "10.0.1.0/24",
           "description": "Frozen but has one host",
           "vlan": 1234,
@@ -12465,15 +12144,17 @@
         "response": {
           "excluded_ranges": [
             {
-              "created_at": "2024-12-11T16:44:45.955630+01:00",
-              "updated_at": "2024-12-11T16:44:45.955656+01:00",
+              "created_at": "2025-03-19T10:10:44.935337+01:00",
+              "updated_at": "2025-03-19T10:10:44.935355+01:00",
               "start_ip": "10.0.1.20",
               "end_ip": "10.0.1.30",
               "network": 3
             }
           ],
-          "created_at": "2024-12-11T16:44:45.393437+01:00",
-          "updated_at": "2024-12-11T16:44:49.759182+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T10:10:44.688196+01:00",
+          "updated_at": "2025-03-19T10:10:46.452187+01:00",
           "network": "10.0.1.0/24",
           "description": "Frozen but has one host",
           "vlan": 1234,
@@ -12511,8 +12192,8 @@
       "              10.0.1.20   <not set>   ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Thu Feb 27 10:47:41 2025",
-      "Updated:      Thu Feb 27 10:47:41 2025"
+      "Created:      Wed Mar 19 12:04:45 2025",
+      "Updated:      Wed Mar 19 12:04:45 2025"
     ],
     "api_requests": [
       {
@@ -12542,18 +12223,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2025-02-27T10:47:35.896278+01:00",
-                "updated_at": "2025-02-27T10:47:35.896293+01:00",
+                "created_at": "2025-03-19T12:04:41.191611+01:00",
+                "updated_at": "2025-03-19T12:04:41.191623+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-02-27T10:47:35.640608+01:00",
-            "updated_at": "2025-02-27T10:47:41.152196+01:00",
+            "created_at": "2025-03-19T12:04:40.912310+01:00",
+            "updated_at": "2025-03-19T12:04:44.816296+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-02-27T10:47:35.942147+01:00",
+            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -12570,8 +12251,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2025-02-27T10:47:38.858014+01:00",
-          "updated_at": "2025-02-27T10:47:41.202143+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:43.270431+01:00",
+          "updated_at": "2025-03-19T12:04:44.855926+01:00",
           "network": "10.0.1.0/24",
           "description": "Frozen but has one host",
           "vlan": 1234,
@@ -12601,8 +12284,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-02-27T10:47:41.530816+01:00",
-              "updated_at": "2025-02-27T10:47:41.530824+01:00",
+              "created_at": "2025-03-19T12:04:45.160723+01:00",
+              "updated_at": "2025-03-19T12:04:45.160729+01:00",
               "ipaddress": "10.0.1.20",
               "host": 6
             }
@@ -12611,18 +12294,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-02-27T10:47:41.518064+01:00",
-              "updated_at": "2025-02-27T10:47:41.518070+01:00",
+              "created_at": "2025-03-19T12:04:45.143284+01:00",
+              "updated_at": "2025-03-19T12:04:45.143292+01:00",
               "txt": "v=spf1 -all",
               "host": 6
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2025-02-27T10:47:41.516269+01:00",
-          "updated_at": "2025-02-27T10:47:41.516278+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:45.141574+01:00",
+          "updated_at": "2025-03-19T12:04:45.141583+01:00",
           "name": "otherhost.example.org",
           "contact": "support@example.org",
           "ttl": null,
@@ -12637,8 +12326,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2025-02-27T10:47:38.858014+01:00",
-          "updated_at": "2025-02-27T10:47:41.202143+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:43.270431+01:00",
+          "updated_at": "2025-03-19T12:04:44.855926+01:00",
           "network": "10.0.1.0/24",
           "description": "Frozen but has one host",
           "vlan": 1234,
@@ -12647,85 +12338,6 @@
           "location": "loc1",
           "frozen": false,
           "reserved": 3
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/ip/10.0.1.20",
-        "data": {},
-        "status": 200,
-        "response": {
-          "excluded_ranges": [],
-          "created_at": "2025-02-27T10:47:38.858014+01:00",
-          "updated_at": "2025-02-27T10:47:41.202143+01:00",
-          "network": "10.0.1.0/24",
-          "description": "Frozen but has one host",
-          "vlan": 1234,
-          "dns_delegated": false,
-          "category": "cat1",
-          "location": "loc1",
-          "frozen": false,
-          "reserved": 3
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/srvs/?host=6",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/naptrs/?host=6",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/sshfps/?host=6",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hostpolicy/roles/?hosts=6",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hostgroups/?hosts=6",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
         }
       }
     ],
@@ -12752,8 +12364,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:44:50.481015+01:00",
-              "updated_at": "2024-12-11T16:44:50.481025+01:00",
+              "created_at": "2025-03-19T12:04:45.160723+01:00",
+              "updated_at": "2025-03-19T12:04:45.160729+01:00",
               "ipaddress": "10.0.1.20",
               "host": 6
             }
@@ -12762,47 +12374,29 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:44:50.463021+01:00",
-              "updated_at": "2024-12-11T16:44:50.463029+01:00",
+              "created_at": "2025-03-19T12:04:45.143284+01:00",
+              "updated_at": "2025-03-19T12:04:45.143292+01:00",
               "txt": "v=spf1 -all",
               "host": 6
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:44:50.460417+01:00",
-          "updated_at": "2024-12-11T16:44:50.460427+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:45.141574+01:00",
+          "updated_at": "2025-03-19T12:04:45.141583+01:00",
           "name": "otherhost.example.org",
           "contact": "support@example.org",
           "ttl": null,
           "comment": "",
           "zone": 1
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/naptrs/?host=6",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/srvs/?host=6",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
         }
       },
       {
@@ -12833,8 +12427,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:44:45.393437+01:00",
-          "updated_at": "2024-12-11T16:44:49.759182+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T10:10:44.688196+01:00",
+          "updated_at": "2025-03-19T10:10:46.452187+01:00",
           "network": "10.0.1.0/24",
           "description": "Frozen but has one host",
           "vlan": 1234,
@@ -12902,8 +12498,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:44:51.283232+01:00",
-          "updated_at": "2024-12-11T16:44:51.283253+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T10:10:47.081912+01:00",
+          "updated_at": "2025-03-19T10:10:47.081925+01:00",
           "network": "2001:db8::/64",
           "description": "Lorem ipsum dolor sit amet",
           "vlan": null,
@@ -12936,8 +12534,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:44:51.283232+01:00",
-          "updated_at": "2024-12-11T16:44:51.283253+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T10:10:47.081912+01:00",
+          "updated_at": "2025-03-19T10:10:47.081925+01:00",
           "network": "2001:db8::/64",
           "description": "Lorem ipsum dolor sit amet",
           "vlan": null,
@@ -12968,8 +12568,10 @@
           "results": [
             {
               "excluded_ranges": [],
-              "created_at": "2024-12-11T16:44:51.283232+01:00",
-              "updated_at": "2024-12-11T16:44:51.463783+01:00",
+              "policy": null,
+              "communities": [],
+              "created_at": "2025-03-19T10:10:47.081912+01:00",
+              "updated_at": "2025-03-19T10:10:47.145114+01:00",
               "network": "2001:db8::/64",
               "description": "Lorem ipsum dolor sit amet",
               "vlan": null,
@@ -13024,18 +12626,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2024-12-11T16:44:40.356452+01:00",
-                "updated_at": "2024-12-11T16:44:40.356481+01:00",
+                "created_at": "2025-03-19T10:10:42.280399+01:00",
+                "updated_at": "2025-03-19T10:10:42.280412+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2024-12-11T16:44:39.701254+01:00",
-            "updated_at": "2024-12-11T16:44:51.003885+01:00",
+            "created_at": "2025-03-19T10:10:41.753629+01:00",
+            "updated_at": "2025-03-19T10:10:46.964566+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
+            "serialno_updated_at": "2025-03-19T10:10:42.331334+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -13052,8 +12654,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:44:51.283232+01:00",
-          "updated_at": "2024-12-11T16:44:51.463783+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T10:10:47.081912+01:00",
+          "updated_at": "2025-03-19T10:10:47.145114+01:00",
           "network": "2001:db8::/64",
           "description": "Lorem ipsum dolor sit amet",
           "vlan": null,
@@ -13086,8 +12690,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:44:51.283232+01:00",
-          "updated_at": "2024-12-11T16:44:51.463783+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T10:10:47.081912+01:00",
+          "updated_at": "2025-03-19T10:10:47.145114+01:00",
           "network": "2001:db8::/64",
           "description": "Lorem ipsum dolor sit amet",
           "vlan": null,
@@ -13150,18 +12756,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2024-12-11T16:44:40.356452+01:00",
-                "updated_at": "2024-12-11T16:44:40.356481+01:00",
+                "created_at": "2025-03-19T10:10:42.280399+01:00",
+                "updated_at": "2025-03-19T10:10:42.280412+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2024-12-11T16:44:39.701254+01:00",
-            "updated_at": "2024-12-11T16:44:51.003885+01:00",
+            "created_at": "2025-03-19T10:10:41.753629+01:00",
+            "updated_at": "2025-03-19T10:10:46.964566+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
+            "serialno_updated_at": "2025-03-19T10:10:42.331334+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -13179,15 +12785,17 @@
         "response": {
           "excluded_ranges": [
             {
-              "created_at": "2024-12-11T16:44:51.818052+01:00",
-              "updated_at": "2024-12-11T16:44:51.818069+01:00",
+              "created_at": "2025-03-19T10:10:47.320972+01:00",
+              "updated_at": "2025-03-19T10:10:47.321020+01:00",
               "start_ip": "2001:db8::20",
               "end_ip": "2001:db8::30",
               "network": 4
             }
           ],
-          "created_at": "2024-12-11T16:44:51.283232+01:00",
-          "updated_at": "2024-12-11T16:44:51.463783+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T10:10:47.081912+01:00",
+          "updated_at": "2025-03-19T10:10:47.145114+01:00",
           "network": "2001:db8::/64",
           "description": "Lorem ipsum dolor sit amet",
           "vlan": null,
@@ -13234,8 +12842,8 @@
       "              2001:db8::4   <not set>   ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Thu Feb 27 10:47:42 2025",
-      "Updated:      Thu Feb 27 10:47:42 2025"
+      "Created:      Wed Mar 19 12:04:45 2025",
+      "Updated:      Wed Mar 19 12:04:45 2025"
     ],
     "api_requests": [
       {
@@ -13265,18 +12873,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2025-02-27T10:47:35.896278+01:00",
-                "updated_at": "2025-02-27T10:47:35.896293+01:00",
+                "created_at": "2025-03-19T12:04:41.191611+01:00",
+                "updated_at": "2025-03-19T12:04:41.191623+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-02-27T10:47:35.640608+01:00",
-            "updated_at": "2025-02-27T10:47:41.870511+01:00",
+            "created_at": "2025-03-19T12:04:40.912310+01:00",
+            "updated_at": "2025-03-19T12:04:45.286162+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-02-27T10:47:35.942147+01:00",
+            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -13294,15 +12902,17 @@
         "response": {
           "excluded_ranges": [
             {
-              "created_at": "2025-02-27T10:47:42.187674+01:00",
-              "updated_at": "2025-02-27T10:47:42.187683+01:00",
+              "created_at": "2025-03-19T12:04:45.667602+01:00",
+              "updated_at": "2025-03-19T12:04:45.667611+01:00",
               "start_ip": "2001:db8::20",
               "end_ip": "2001:db8::30",
               "network": 4
             }
           ],
-          "created_at": "2025-02-27T10:47:41.987873+01:00",
-          "updated_at": "2025-02-27T10:47:42.048751+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:45.415701+01:00",
+          "updated_at": "2025-03-19T12:04:45.480137+01:00",
           "network": "2001:db8::/64",
           "description": "Lorem ipsum dolor sit amet",
           "vlan": null,
@@ -13332,8 +12942,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-02-27T10:47:42.422192+01:00",
-              "updated_at": "2025-02-27T10:47:42.422199+01:00",
+              "created_at": "2025-03-19T12:04:45.940471+01:00",
+              "updated_at": "2025-03-19T12:04:45.940476+01:00",
               "ipaddress": "2001:db8::4",
               "host": 8
             }
@@ -13342,18 +12952,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-02-27T10:47:42.410850+01:00",
-              "updated_at": "2025-02-27T10:47:42.410856+01:00",
+              "created_at": "2025-03-19T12:04:45.923544+01:00",
+              "updated_at": "2025-03-19T12:04:45.923555+01:00",
               "txt": "v=spf1 -all",
               "host": 8
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2025-02-27T10:47:42.409227+01:00",
-          "updated_at": "2025-02-27T10:47:42.409234+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:45.921732+01:00",
+          "updated_at": "2025-03-19T12:04:45.921739+01:00",
           "name": "somehost.example.org",
           "contact": "support@example.org",
           "ttl": null,
@@ -13369,15 +12985,17 @@
         "response": {
           "excluded_ranges": [
             {
-              "created_at": "2025-02-27T10:47:42.187674+01:00",
-              "updated_at": "2025-02-27T10:47:42.187683+01:00",
+              "created_at": "2025-03-19T12:04:45.667602+01:00",
+              "updated_at": "2025-03-19T12:04:45.667611+01:00",
               "start_ip": "2001:db8::20",
               "end_ip": "2001:db8::30",
               "network": 4
             }
           ],
-          "created_at": "2025-02-27T10:47:41.987873+01:00",
-          "updated_at": "2025-02-27T10:47:42.048751+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:45.415701+01:00",
+          "updated_at": "2025-03-19T12:04:45.480137+01:00",
           "network": "2001:db8::/64",
           "description": "Lorem ipsum dolor sit amet",
           "vlan": null,
@@ -13386,93 +13004,6 @@
           "location": "",
           "frozen": true,
           "reserved": 3
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/ip/2001%3Adb8%3A%3A4",
-        "data": {},
-        "status": 200,
-        "response": {
-          "excluded_ranges": [
-            {
-              "created_at": "2025-02-27T10:47:42.187674+01:00",
-              "updated_at": "2025-02-27T10:47:42.187683+01:00",
-              "start_ip": "2001:db8::20",
-              "end_ip": "2001:db8::30",
-              "network": 4
-            }
-          ],
-          "created_at": "2025-02-27T10:47:41.987873+01:00",
-          "updated_at": "2025-02-27T10:47:42.048751+01:00",
-          "network": "2001:db8::/64",
-          "description": "Lorem ipsum dolor sit amet",
-          "vlan": null,
-          "dns_delegated": false,
-          "category": "",
-          "location": "",
-          "frozen": true,
-          "reserved": 3
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/srvs/?host=8",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/naptrs/?host=8",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/sshfps/?host=8",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hostpolicy/roles/?hosts=8",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hostgroups/?hosts=8",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
         }
       }
     ],
@@ -13498,15 +13029,17 @@
         "response": {
           "excluded_ranges": [
             {
-              "created_at": "2024-12-11T16:44:51.818052+01:00",
-              "updated_at": "2024-12-11T16:44:51.818069+01:00",
+              "created_at": "2025-03-19T10:10:47.320972+01:00",
+              "updated_at": "2025-03-19T10:10:47.321020+01:00",
               "start_ip": "2001:db8::20",
               "end_ip": "2001:db8::30",
               "network": 4
             }
           ],
-          "created_at": "2024-12-11T16:44:51.283232+01:00",
-          "updated_at": "2024-12-11T16:44:51.463783+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T10:10:47.081912+01:00",
+          "updated_at": "2025-03-19T10:10:47.145114+01:00",
           "network": "2001:db8::/64",
           "description": "Lorem ipsum dolor sit amet",
           "vlan": null,
@@ -13538,15 +13071,17 @@
             {
               "excluded_ranges": [
                 {
-                  "created_at": "2024-12-11T16:44:51.818052+01:00",
-                  "updated_at": "2024-12-11T16:44:51.818069+01:00",
+                  "created_at": "2025-03-19T10:10:47.320972+01:00",
+                  "updated_at": "2025-03-19T10:10:47.321020+01:00",
                   "start_ip": "2001:db8::20",
                   "end_ip": "2001:db8::30",
                   "network": 4
                 }
               ],
-              "created_at": "2024-12-11T16:44:51.283232+01:00",
-              "updated_at": "2024-12-11T16:44:52.806494+01:00",
+              "policy": null,
+              "communities": [],
+              "created_at": "2025-03-19T10:10:47.081912+01:00",
+              "updated_at": "2025-03-19T10:10:47.678770+01:00",
               "network": "2001:db8::/64",
               "description": "Frozen but has one host",
               "vlan": null,
@@ -13601,15 +13136,17 @@
         "response": {
           "excluded_ranges": [
             {
-              "created_at": "2025-02-27T10:47:42.187674+01:00",
-              "updated_at": "2025-02-27T10:47:42.187683+01:00",
+              "created_at": "2025-03-19T10:10:47.320972+01:00",
+              "updated_at": "2025-03-19T10:10:47.321020+01:00",
               "start_ip": "2001:db8::20",
               "end_ip": "2001:db8::30",
               "network": 4
             }
           ],
-          "created_at": "2025-02-27T10:47:41.987873+01:00",
-          "updated_at": "2025-02-27T10:47:42.696981+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T10:10:47.081912+01:00",
+          "updated_at": "2025-03-19T10:10:47.678770+01:00",
           "network": "2001:db8::/64",
           "description": "Frozen but has one host",
           "vlan": null,
@@ -13670,8 +13207,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:44:52.291402+01:00",
-              "updated_at": "2024-12-11T16:44:52.291419+01:00",
+              "created_at": "2025-03-19T12:04:45.940471+01:00",
+              "updated_at": "2025-03-19T12:04:45.940476+01:00",
               "ipaddress": "2001:db8::4",
               "host": 8
             }
@@ -13680,18 +13217,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:44:52.260029+01:00",
-              "updated_at": "2024-12-11T16:44:52.260048+01:00",
+              "created_at": "2025-03-19T12:04:45.923544+01:00",
+              "updated_at": "2025-03-19T12:04:45.923555+01:00",
               "txt": "v=spf1 -all",
               "host": 8
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:44:52.254284+01:00",
-          "updated_at": "2024-12-11T16:44:52.254305+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:45.921732+01:00",
+          "updated_at": "2025-03-19T12:04:45.921739+01:00",
           "name": "somehost.example.org",
           "contact": "support@example.org",
           "ttl": null,
@@ -13707,15 +13250,17 @@
         "response": {
           "excluded_ranges": [
             {
-              "created_at": "2024-12-11T16:44:51.818052+01:00",
-              "updated_at": "2024-12-11T16:44:51.818069+01:00",
+              "created_at": "2025-03-19T12:04:45.667602+01:00",
+              "updated_at": "2025-03-19T12:04:45.667611+01:00",
               "start_ip": "2001:db8::20",
               "end_ip": "2001:db8::30",
               "network": 4
             }
           ],
-          "created_at": "2024-12-11T16:44:51.283232+01:00",
-          "updated_at": "2024-12-11T16:44:52.806494+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:45.415701+01:00",
+          "updated_at": "2025-03-19T12:04:46.028978+01:00",
           "network": "2001:db8::/64",
           "description": "Frozen but has one host",
           "vlan": null,
@@ -13757,8 +13302,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:44:52.291402+01:00",
-              "updated_at": "2024-12-11T16:44:52.291419+01:00",
+              "created_at": "2025-03-19T12:04:45.940471+01:00",
+              "updated_at": "2025-03-19T12:04:45.940476+01:00",
               "ipaddress": "2001:db8::4",
               "host": 8
             }
@@ -13767,18 +13312,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:44:52.260029+01:00",
-              "updated_at": "2024-12-11T16:44:52.260048+01:00",
+              "created_at": "2025-03-19T12:04:45.923544+01:00",
+              "updated_at": "2025-03-19T12:04:45.923555+01:00",
               "txt": "v=spf1 -all",
               "host": 8
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:44:52.254284+01:00",
-          "updated_at": "2024-12-11T16:44:52.254305+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:45.921732+01:00",
+          "updated_at": "2025-03-19T12:04:45.921739+01:00",
           "name": "somehost.example.org",
           "contact": "support@example.org",
           "ttl": null,
@@ -13794,15 +13345,17 @@
         "response": {
           "excluded_ranges": [
             {
-              "created_at": "2024-12-11T16:44:51.818052+01:00",
-              "updated_at": "2024-12-11T16:44:51.818069+01:00",
+              "created_at": "2025-03-19T12:04:45.667602+01:00",
+              "updated_at": "2025-03-19T12:04:45.667611+01:00",
               "start_ip": "2001:db8::20",
               "end_ip": "2001:db8::30",
               "network": 4
             }
           ],
-          "created_at": "2024-12-11T16:44:51.283232+01:00",
-          "updated_at": "2024-12-11T16:44:52.806494+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:45.415701+01:00",
+          "updated_at": "2025-03-19T12:04:46.028978+01:00",
           "network": "2001:db8::/64",
           "description": "Frozen but has one host",
           "vlan": null,
@@ -13830,8 +13383,8 @@
         "status": 201,
         "response": {
           "macaddress": "",
-          "created_at": "2024-12-11T16:44:53.390254+01:00",
-          "updated_at": "2024-12-11T16:44:53.390276+01:00",
+          "created_at": "2025-03-19T12:04:46.283013+01:00",
+          "updated_at": "2025-03-19T12:04:46.283020+01:00",
           "ipaddress": "2001:db8::5",
           "host": 8
         }
@@ -13850,15 +13403,15 @@
               "ipaddresses": [
                 {
                   "macaddress": "",
-                  "created_at": "2024-12-11T16:44:52.291402+01:00",
-                  "updated_at": "2024-12-11T16:44:52.291419+01:00",
+                  "created_at": "2025-03-19T12:04:45.940471+01:00",
+                  "updated_at": "2025-03-19T12:04:45.940476+01:00",
                   "ipaddress": "2001:db8::4",
                   "host": 8
                 },
                 {
                   "macaddress": "",
-                  "created_at": "2024-12-11T16:44:53.390254+01:00",
-                  "updated_at": "2024-12-11T16:44:53.390276+01:00",
+                  "created_at": "2025-03-19T12:04:46.283013+01:00",
+                  "updated_at": "2025-03-19T12:04:46.283020+01:00",
                   "ipaddress": "2001:db8::5",
                   "host": 8
                 }
@@ -13867,18 +13420,24 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2024-12-11T16:44:52.260029+01:00",
-                  "updated_at": "2024-12-11T16:44:52.260048+01:00",
+                  "created_at": "2025-03-19T12:04:45.923544+01:00",
+                  "updated_at": "2025-03-19T12:04:45.923555+01:00",
                   "txt": "v=spf1 -all",
                   "host": 8
                 }
               ],
               "ptr_overrides": [],
+              "srvs": [],
+              "naptrs": [],
+              "sshfps": [],
+              "groups": [],
+              "roles": [],
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
-              "created_at": "2024-12-11T16:44:52.254284+01:00",
-              "updated_at": "2024-12-11T16:44:52.254305+01:00",
+              "communities": [],
+              "created_at": "2025-03-19T12:04:45.921732+01:00",
+              "updated_at": "2025-03-19T12:04:45.921739+01:00",
               "name": "somehost.example.org",
               "contact": "support@example.org",
               "ttl": null,
@@ -13912,15 +13471,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:44:52.291402+01:00",
-              "updated_at": "2024-12-11T16:44:52.291419+01:00",
+              "created_at": "2025-03-19T12:04:45.940471+01:00",
+              "updated_at": "2025-03-19T12:04:45.940476+01:00",
               "ipaddress": "2001:db8::4",
               "host": 8
             },
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:44:53.390254+01:00",
-              "updated_at": "2024-12-11T16:44:53.390276+01:00",
+              "created_at": "2025-03-19T12:04:46.283013+01:00",
+              "updated_at": "2025-03-19T12:04:46.283020+01:00",
               "ipaddress": "2001:db8::5",
               "host": 8
             }
@@ -13929,18 +13488,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:44:52.260029+01:00",
-              "updated_at": "2024-12-11T16:44:52.260048+01:00",
+              "created_at": "2025-03-19T12:04:45.923544+01:00",
+              "updated_at": "2025-03-19T12:04:45.923555+01:00",
               "txt": "v=spf1 -all",
               "host": 8
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:44:52.254284+01:00",
-          "updated_at": "2024-12-11T16:44:52.254305+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:45.921732+01:00",
+          "updated_at": "2025-03-19T12:04:45.921739+01:00",
           "name": "somehost.example.org",
           "contact": "support@example.org",
           "ttl": null,
@@ -13956,15 +13521,17 @@
         "response": {
           "excluded_ranges": [
             {
-              "created_at": "2024-12-11T16:44:51.818052+01:00",
-              "updated_at": "2024-12-11T16:44:51.818069+01:00",
+              "created_at": "2025-03-19T12:04:45.667602+01:00",
+              "updated_at": "2025-03-19T12:04:45.667611+01:00",
               "start_ip": "2001:db8::20",
               "end_ip": "2001:db8::30",
               "network": 4
             }
           ],
-          "created_at": "2024-12-11T16:44:51.283232+01:00",
-          "updated_at": "2024-12-11T16:44:52.806494+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:45.415701+01:00",
+          "updated_at": "2025-03-19T12:04:46.028978+01:00",
           "network": "2001:db8::/64",
           "description": "Frozen but has one host",
           "vlan": null,
@@ -13983,15 +13550,17 @@
         "response": {
           "excluded_ranges": [
             {
-              "created_at": "2024-12-11T16:44:51.818052+01:00",
-              "updated_at": "2024-12-11T16:44:51.818069+01:00",
+              "created_at": "2025-03-19T12:04:45.667602+01:00",
+              "updated_at": "2025-03-19T12:04:45.667611+01:00",
               "start_ip": "2001:db8::20",
               "end_ip": "2001:db8::30",
               "network": 4
             }
           ],
-          "created_at": "2024-12-11T16:44:51.283232+01:00",
-          "updated_at": "2024-12-11T16:44:52.806494+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:45.415701+01:00",
+          "updated_at": "2025-03-19T12:04:46.028978+01:00",
           "network": "2001:db8::/64",
           "description": "Frozen but has one host",
           "vlan": null,
@@ -14000,30 +13569,6 @@
           "location": "",
           "frozen": true,
           "reserved": 3
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/naptrs/?host=8",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/srvs/?host=8",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
         }
       },
       {
@@ -14055,15 +13600,17 @@
         "response": {
           "excluded_ranges": [
             {
-              "created_at": "2024-12-11T16:44:51.818052+01:00",
-              "updated_at": "2024-12-11T16:44:51.818069+01:00",
+              "created_at": "2025-03-19T10:10:47.320972+01:00",
+              "updated_at": "2025-03-19T10:10:47.321020+01:00",
               "start_ip": "2001:db8::20",
               "end_ip": "2001:db8::30",
               "network": 4
             }
           ],
-          "created_at": "2024-12-11T16:44:51.283232+01:00",
-          "updated_at": "2024-12-11T16:44:52.806494+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T10:10:47.081912+01:00",
+          "updated_at": "2025-03-19T10:10:47.678770+01:00",
           "network": "2001:db8::/64",
           "description": "Frozen but has one host",
           "vlan": null,
@@ -14154,8 +13701,8 @@
       "Contact:      ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Wed Dec 11 16:44:54 2024",
-      "Updated:      Wed Dec 11 16:44:54 2024"
+      "Created:      Wed Mar 19 12:04:46 2025",
+      "Updated:      Wed Mar 19 12:04:46 2025"
     ],
     "api_requests": [
       {
@@ -14185,18 +13732,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2024-12-11T16:44:40.356452+01:00",
-                "updated_at": "2024-12-11T16:44:40.356481+01:00",
+                "created_at": "2025-03-19T12:04:41.191611+01:00",
+                "updated_at": "2025-03-19T12:04:41.191623+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2024-12-11T16:44:39.701254+01:00",
-            "updated_at": "2024-12-11T16:44:53.798307+01:00",
+            "created_at": "2025-03-19T12:04:40.912310+01:00",
+            "updated_at": "2025-03-19T12:04:46.454935+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
+            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -14225,83 +13772,29 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:44:54.399698+01:00",
-              "updated_at": "2024-12-11T16:44:54.399718+01:00",
+              "created_at": "2025-03-19T12:04:46.959322+01:00",
+              "updated_at": "2025-03-19T12:04:46.959341+01:00",
               "txt": "v=spf1 -all",
               "host": 9
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:44:54.385177+01:00",
-          "updated_at": "2024-12-11T16:44:54.385200+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:46.950645+01:00",
+          "updated_at": "2025-03-19T12:04:46.950663+01:00",
           "name": "testhost1.example.org",
           "contact": "",
           "ttl": null,
           "comment": "",
           "zone": 1
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/srvs/?host=9",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/naptrs/?host=9",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/sshfps/?host=9",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hostpolicy/roles/?hosts=9",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hostgroups/?hosts=9",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
         }
       }
     ],
@@ -14322,8 +13815,8 @@
       "Contact:      ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Wed Dec 11 16:44:54 2024",
-      "Updated:      Wed Dec 11 16:44:54 2024"
+      "Created:      Wed Mar 19 12:04:47 2025",
+      "Updated:      Wed Mar 19 12:04:47 2025"
     ],
     "api_requests": [
       {
@@ -14353,18 +13846,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2024-12-11T16:44:40.356452+01:00",
-                "updated_at": "2024-12-11T16:44:40.356481+01:00",
+                "created_at": "2025-03-19T12:04:41.191611+01:00",
+                "updated_at": "2025-03-19T12:04:41.191623+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2024-12-11T16:44:39.701254+01:00",
-            "updated_at": "2024-12-11T16:44:54.393800+01:00",
+            "created_at": "2025-03-19T12:04:40.912310+01:00",
+            "updated_at": "2025-03-19T12:04:46.958007+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
+            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -14393,83 +13886,29 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:44:54.968112+01:00",
-              "updated_at": "2024-12-11T16:44:54.968130+01:00",
+              "created_at": "2025-03-19T12:04:47.130016+01:00",
+              "updated_at": "2025-03-19T12:04:47.130026+01:00",
               "txt": "v=spf1 -all",
               "host": 10
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:44:54.954097+01:00",
-          "updated_at": "2024-12-11T16:44:54.954110+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:47.127495+01:00",
+          "updated_at": "2025-03-19T12:04:47.127508+01:00",
           "name": "testhost2.example.org",
           "contact": "",
           "ttl": null,
           "comment": "",
           "zone": 1
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/srvs/?host=10",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/naptrs/?host=10",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/sshfps/?host=10",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hostpolicy/roles/?hosts=10",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hostgroups/?hosts=10",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
         }
       }
     ],
@@ -14497,8 +13936,8 @@
           "groups": [],
           "hosts": [],
           "owners": [],
-          "created_at": "2024-12-11T16:44:54.078203+01:00",
-          "updated_at": "2024-12-11T16:44:54.078229+01:00",
+          "created_at": "2025-03-19T12:04:46.675213+01:00",
+          "updated_at": "2025-03-19T12:04:46.675238+01:00",
           "name": "mygroup",
           "description": "This describes the group"
         }
@@ -14514,18 +13953,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:44:54.399698+01:00",
-              "updated_at": "2024-12-11T16:44:54.399718+01:00",
+              "created_at": "2025-03-19T12:04:46.959322+01:00",
+              "updated_at": "2025-03-19T12:04:46.959341+01:00",
               "txt": "v=spf1 -all",
               "host": 9
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:44:54.385177+01:00",
-          "updated_at": "2024-12-11T16:44:54.385200+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:46.950645+01:00",
+          "updated_at": "2025-03-19T12:04:46.950663+01:00",
           "name": "testhost1.example.org",
           "contact": "",
           "ttl": null,
@@ -14560,8 +14005,8 @@
                 }
               ],
               "owners": [],
-              "created_at": "2024-12-11T16:44:54.078203+01:00",
-              "updated_at": "2024-12-11T16:44:55.500110+01:00",
+              "created_at": "2025-03-19T12:04:46.675213+01:00",
+              "updated_at": "2025-03-19T12:04:47.283942+01:00",
               "name": "mygroup",
               "description": "This describes the group"
             }
@@ -14597,8 +14042,8 @@
             }
           ],
           "owners": [],
-          "created_at": "2024-12-11T16:44:54.078203+01:00",
-          "updated_at": "2024-12-11T16:44:55.500110+01:00",
+          "created_at": "2025-03-19T12:04:46.675213+01:00",
+          "updated_at": "2025-03-19T12:04:47.283942+01:00",
           "name": "mygroup",
           "description": "This describes the group"
         }
@@ -14614,18 +14059,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:44:54.968112+01:00",
-              "updated_at": "2024-12-11T16:44:54.968130+01:00",
+              "created_at": "2025-03-19T12:04:47.130016+01:00",
+              "updated_at": "2025-03-19T12:04:47.130026+01:00",
               "txt": "v=spf1 -all",
               "host": 10
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:44:54.954097+01:00",
-          "updated_at": "2024-12-11T16:44:54.954110+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:47.127495+01:00",
+          "updated_at": "2025-03-19T12:04:47.127508+01:00",
           "name": "testhost2.example.org",
           "contact": "",
           "ttl": null,
@@ -14663,8 +14114,8 @@
                 }
               ],
               "owners": [],
-              "created_at": "2024-12-11T16:44:54.078203+01:00",
-              "updated_at": "2024-12-11T16:44:55.692565+01:00",
+              "created_at": "2025-03-19T12:04:46.675213+01:00",
+              "updated_at": "2025-03-19T12:04:47.424796+01:00",
               "name": "mygroup",
               "description": "This describes the group"
             }
@@ -14787,8 +14238,8 @@
               "name": "myself"
             }
           ],
-          "created_at": "2024-12-11T16:44:54.078203+01:00",
-          "updated_at": "2024-12-11T16:44:55.692565+01:00",
+          "created_at": "2025-03-19T12:04:46.675213+01:00",
+          "updated_at": "2025-03-19T12:04:47.424796+01:00",
           "name": "mygroup",
           "description": "This describes the group"
         }
@@ -14804,18 +14255,26 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:44:54.968112+01:00",
-              "updated_at": "2024-12-11T16:44:54.968130+01:00",
+              "created_at": "2025-03-19T12:04:47.130016+01:00",
+              "updated_at": "2025-03-19T12:04:47.130026+01:00",
               "txt": "v=spf1 -all",
               "host": 10
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [
+            "mygroup"
+          ],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:44:54.954097+01:00",
-          "updated_at": "2024-12-11T16:44:54.954110+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:47.127495+01:00",
+          "updated_at": "2025-03-19T12:04:47.127508+01:00",
           "name": "testhost2.example.org",
           "contact": "",
           "ttl": null,
@@ -14852,8 +14311,8 @@
                   "name": "myself"
                 }
               ],
-              "created_at": "2024-12-11T16:44:54.078203+01:00",
-              "updated_at": "2024-12-11T16:44:56.044625+01:00",
+              "created_at": "2025-03-19T12:04:46.675213+01:00",
+              "updated_at": "2025-03-19T12:04:47.654971+01:00",
               "name": "mygroup",
               "description": "This describes the group"
             }
@@ -15960,47 +15419,29 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:44:54.399698+01:00",
-              "updated_at": "2024-12-11T16:44:54.399718+01:00",
+              "created_at": "2025-03-19T12:04:46.959322+01:00",
+              "updated_at": "2025-03-19T12:04:46.959341+01:00",
               "txt": "v=spf1 -all",
               "host": 9
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:44:54.385177+01:00",
-          "updated_at": "2024-12-11T16:44:54.385200+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:46.950645+01:00",
+          "updated_at": "2025-03-19T12:04:46.950663+01:00",
           "name": "testhost1.example.org",
           "contact": "",
           "ttl": null,
           "comment": "",
           "zone": 1
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/naptrs/?host=9",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/srvs/?host=9",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
         }
       },
       {
@@ -16035,47 +15476,29 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:44:54.968112+01:00",
-              "updated_at": "2024-12-11T16:44:54.968130+01:00",
+              "created_at": "2025-03-19T12:04:47.130016+01:00",
+              "updated_at": "2025-03-19T12:04:47.130026+01:00",
               "txt": "v=spf1 -all",
               "host": 10
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:44:54.954097+01:00",
-          "updated_at": "2024-12-11T16:44:54.954110+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:47.127495+01:00",
+          "updated_at": "2025-03-19T12:04:47.127508+01:00",
           "name": "testhost2.example.org",
           "contact": "",
           "ttl": null,
           "comment": "",
           "zone": 1
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/naptrs/?host=10",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/srvs/?host=10",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
         }
       },
       {
@@ -16406,8 +15829,8 @@
       "Name:         testhost.wut.example.org",
       "Contact:      ",
       "TTL:          (Default)",
-      "Created:      Wed Dec 11 16:44:59 2024",
-      "Updated:      Wed Dec 11 16:44:59 2024"
+      "Created:      Wed Mar 19 12:04:49 2025",
+      "Updated:      Wed Mar 19 12:04:49 2025"
     ],
     "api_requests": [
       {
@@ -16437,14 +15860,14 @@
           "delegation": {
             "nameservers": [
               {
-                "created_at": "2024-12-11T16:44:40.356452+01:00",
-                "updated_at": "2024-12-11T16:44:40.356481+01:00",
+                "created_at": "2025-03-19T12:04:41.191611+01:00",
+                "updated_at": "2025-03-19T12:04:41.191623+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2024-12-11T16:44:58.566491+01:00",
-            "updated_at": "2024-12-11T16:44:58.811285+01:00",
+            "created_at": "2025-03-19T12:04:49.143150+01:00",
+            "updated_at": "2025-03-19T12:04:49.244747+01:00",
             "name": "wut.example.org",
             "comment": "This is a comment",
             "zone": 1
@@ -16470,76 +15893,22 @@
           "mxs": [],
           "txts": [],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:44:59.243214+01:00",
-          "updated_at": "2024-12-11T16:44:59.243232+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:49.514185+01:00",
+          "updated_at": "2025-03-19T12:04:49.514199+01:00",
           "name": "testhost.wut.example.org",
           "contact": "",
           "ttl": null,
           "comment": "",
           "zone": null
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/srvs/?host=11",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/naptrs/?host=11",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/sshfps/?host=11",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hostpolicy/roles/?hosts=11",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hostgroups/?hosts=11",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
         }
       }
     ],
@@ -16568,40 +15937,22 @@
           "mxs": [],
           "txts": [],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:44:59.243214+01:00",
-          "updated_at": "2024-12-11T16:44:59.243232+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:49.514185+01:00",
+          "updated_at": "2025-03-19T12:04:49.514199+01:00",
           "name": "testhost.wut.example.org",
           "contact": "",
           "ttl": null,
           "comment": "",
           "zone": null
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/naptrs/?host=11",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/srvs/?host=11",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
         }
       },
       {
@@ -17763,8 +17114,8 @@
       "Contact:      ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Wed Dec 11 16:45:02 2024",
-      "Updated:      Wed Dec 11 16:45:02 2024"
+      "Created:      Wed Mar 19 12:04:50 2025",
+      "Updated:      Wed Mar 19 12:04:50 2025"
     ],
     "api_requests": [
       {
@@ -17794,18 +17145,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2024-12-11T16:44:40.356452+01:00",
-                "updated_at": "2024-12-11T16:44:40.356481+01:00",
+                "created_at": "2025-03-19T12:04:41.191611+01:00",
+                "updated_at": "2025-03-19T12:04:41.191623+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2024-12-11T16:44:39.701254+01:00",
-            "updated_at": "2024-12-11T16:45:00.157412+01:00",
+            "created_at": "2025-03-19T12:04:40.912310+01:00",
+            "updated_at": "2025-03-19T12:04:49.780924+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
+            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -17834,83 +17185,29 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:02.958146+01:00",
-              "updated_at": "2024-12-11T16:45:02.958166+01:00",
+              "created_at": "2025-03-19T12:04:50.904251+01:00",
+              "updated_at": "2025-03-19T12:04:50.904256+01:00",
               "txt": "v=spf1 -all",
               "host": 12
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:02.933960+01:00",
-          "updated_at": "2024-12-11T16:45:02.933976+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:50.902521+01:00",
+          "updated_at": "2025-03-19T12:04:50.902527+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
           "comment": "",
           "zone": 1
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/srvs/?host=12",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/naptrs/?host=12",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/sshfps/?host=12",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hostpolicy/roles/?hosts=12",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hostgroups/?hosts=12",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
         }
       }
     ],
@@ -17929,8 +17226,8 @@
       "Contact:      ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Wed Dec 11 16:45:02 2024",
-      "Updated:      Wed Dec 11 16:45:02 2024"
+      "Created:      Wed Mar 19 12:04:50 2025",
+      "Updated:      Wed Mar 19 12:04:50 2025"
     ],
     "api_requests": [
       {
@@ -17944,83 +17241,29 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:02.958146+01:00",
-              "updated_at": "2024-12-11T16:45:02.958166+01:00",
+              "created_at": "2025-03-19T12:04:50.904251+01:00",
+              "updated_at": "2025-03-19T12:04:50.904256+01:00",
               "txt": "v=spf1 -all",
               "host": 12
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:02.933960+01:00",
-          "updated_at": "2024-12-11T16:45:02.933976+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:50.902521+01:00",
+          "updated_at": "2025-03-19T12:04:50.902527+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
           "comment": "",
           "zone": 1
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/srvs/?host=12",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/naptrs/?host=12",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/sshfps/?host=12",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hostpolicy/roles/?hosts=12",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hostgroups/?hosts=12",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
         }
       }
     ],
@@ -18074,7 +17317,7 @@
               "name": "tangerine"
             }
           ],
-          "updated_at": "2024-12-11T16:45:02.648865+01:00",
+          "updated_at": "2025-03-19T12:04:50.804103+01:00",
           "description": "5 a day",
           "name": "fruit",
           "labels": []
@@ -18091,18 +17334,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:02.958146+01:00",
-              "updated_at": "2024-12-11T16:45:02.958166+01:00",
+              "created_at": "2025-03-19T12:04:50.904251+01:00",
+              "updated_at": "2025-03-19T12:04:50.904256+01:00",
               "txt": "v=spf1 -all",
               "host": 12
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:02.933960+01:00",
-          "updated_at": "2024-12-11T16:45:02.933976+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:50.902521+01:00",
+          "updated_at": "2025-03-19T12:04:50.902527+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -18183,52 +17432,31 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:02.958146+01:00",
-              "updated_at": "2024-12-11T16:45:02.958166+01:00",
+              "created_at": "2025-03-19T12:04:50.904251+01:00",
+              "updated_at": "2025-03-19T12:04:50.904256+01:00",
               "txt": "v=spf1 -all",
               "host": 12
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [
+            "fruit"
+          ],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:02.933960+01:00",
-          "updated_at": "2024-12-11T16:45:02.933976+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:50.902521+01:00",
+          "updated_at": "2025-03-19T12:04:50.902527+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
           "comment": "",
           "zone": 1
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hostpolicy/roles/?hosts=12",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
-            {
-              "hosts": [
-                {
-                  "name": "foo.example.org"
-                }
-              ],
-              "atoms": [
-                {
-                  "name": "tangerine"
-                }
-              ],
-              "updated_at": "2024-12-11T16:45:03.805072+01:00",
-              "description": "5 a day",
-              "name": "fruit",
-              "labels": []
-            }
-          ]
         }
       }
     ],
@@ -18248,8 +17476,8 @@
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
       "Roles:        fruit",
-      "Created:      Wed Dec 11 16:45:02 2024",
-      "Updated:      Wed Dec 11 16:45:02 2024"
+      "Created:      Wed Mar 19 12:04:50 2025",
+      "Updated:      Wed Mar 19 12:04:50 2025"
     ],
     "api_requests": [
       {
@@ -18263,100 +17491,31 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:02.958146+01:00",
-              "updated_at": "2024-12-11T16:45:02.958166+01:00",
+              "created_at": "2025-03-19T12:04:50.904251+01:00",
+              "updated_at": "2025-03-19T12:04:50.904256+01:00",
               "txt": "v=spf1 -all",
               "host": 12
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [
+            "fruit"
+          ],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:02.933960+01:00",
-          "updated_at": "2024-12-11T16:45:02.933976+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:50.902521+01:00",
+          "updated_at": "2025-03-19T12:04:50.902527+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
           "comment": "",
           "zone": 1
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/srvs/?host=12",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/naptrs/?host=12",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/sshfps/?host=12",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hostpolicy/roles/?hosts=12",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
-            {
-              "hosts": [
-                {
-                  "name": "foo.example.org"
-                }
-              ],
-              "atoms": [
-                {
-                  "name": "tangerine"
-                }
-              ],
-              "updated_at": "2024-12-11T16:45:03.805072+01:00",
-              "description": "5 a day",
-              "name": "fruit",
-              "labels": []
-            }
-          ]
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hostgroups/?hosts=12",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
         }
       }
     ],
@@ -18390,7 +17549,7 @@
               "name": "tangerine"
             }
           ],
-          "updated_at": "2024-12-11T16:45:03.805072+01:00",
+          "updated_at": "2025-03-19T12:04:51.045576+01:00",
           "description": "5 a day",
           "name": "fruit",
           "labels": []
@@ -18407,18 +17566,26 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:02.958146+01:00",
-              "updated_at": "2024-12-11T16:45:02.958166+01:00",
+              "created_at": "2025-03-19T12:04:50.904251+01:00",
+              "updated_at": "2025-03-19T12:04:50.904256+01:00",
               "txt": "v=spf1 -all",
               "host": 12
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [
+            "fruit"
+          ],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:02.933960+01:00",
-          "updated_at": "2024-12-11T16:45:02.933976+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:50.902521+01:00",
+          "updated_at": "2025-03-19T12:04:50.902527+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -18869,47 +18036,29 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:02.958146+01:00",
-              "updated_at": "2024-12-11T16:45:02.958166+01:00",
+              "created_at": "2025-03-19T12:04:50.904251+01:00",
+              "updated_at": "2025-03-19T12:04:50.904256+01:00",
               "txt": "v=spf1 -all",
               "host": 12
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:02.933960+01:00",
-          "updated_at": "2024-12-11T16:45:02.933976+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:50.902521+01:00",
+          "updated_at": "2025-03-19T12:04:50.902527+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
           "comment": "",
           "zone": 1
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/naptrs/?host=12",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/srvs/?host=12",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
         }
       },
       {
@@ -19126,8 +18275,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:45:05.867822+01:00",
-          "updated_at": "2024-12-11T16:45:05.867856+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T10:10:54.577597+01:00",
+          "updated_at": "2025-03-19T10:10:54.577613+01:00",
           "network": "10.0.0.0/24",
           "description": "foo",
           "vlan": 1234,
@@ -19156,8 +18307,8 @@
       "Contact:      ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Wed Dec 11 16:45:06 2024",
-      "Updated:      Wed Dec 11 16:45:06 2024"
+      "Created:      Wed Mar 19 12:04:51 2025",
+      "Updated:      Wed Mar 19 12:04:51 2025"
     ],
     "api_requests": [
       {
@@ -19187,18 +18338,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2024-12-11T16:44:40.356452+01:00",
-                "updated_at": "2024-12-11T16:44:40.356481+01:00",
+                "created_at": "2025-03-19T12:04:41.191611+01:00",
+                "updated_at": "2025-03-19T12:04:41.191623+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2024-12-11T16:44:39.701254+01:00",
-            "updated_at": "2024-12-11T16:45:05.293515+01:00",
+            "created_at": "2025-03-19T12:04:40.912310+01:00",
+            "updated_at": "2025-03-19T12:04:51.510406+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
+            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -19227,83 +18378,29 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:06.156299+01:00",
-              "updated_at": "2024-12-11T16:45:06.156320+01:00",
+              "created_at": "2025-03-19T12:04:51.792606+01:00",
+              "updated_at": "2025-03-19T12:04:51.792612+01:00",
               "txt": "v=spf1 -all",
               "host": 13
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:06.137012+01:00",
-          "updated_at": "2024-12-11T16:45:06.137037+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:51.790986+01:00",
+          "updated_at": "2025-03-19T12:04:51.790994+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
           "comment": "",
           "zone": 1
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/srvs/?host=13",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/naptrs/?host=13",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/sshfps/?host=13",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hostpolicy/roles/?hosts=13",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hostgroups/?hosts=13",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
         }
       }
     ],
@@ -19332,18 +18429,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:06.156299+01:00",
-              "updated_at": "2024-12-11T16:45:06.156320+01:00",
+              "created_at": "2025-03-19T12:04:51.792606+01:00",
+              "updated_at": "2025-03-19T12:04:51.792612+01:00",
               "txt": "v=spf1 -all",
               "host": 13
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:06.137012+01:00",
-          "updated_at": "2024-12-11T16:45:06.137037+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:51.790986+01:00",
+          "updated_at": "2025-03-19T12:04:51.790994+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -19358,8 +18461,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:45:05.867822+01:00",
-          "updated_at": "2024-12-11T16:45:05.867856+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:51.700856+01:00",
+          "updated_at": "2025-03-19T12:04:51.700881+01:00",
           "network": "10.0.0.0/24",
           "description": "foo",
           "vlan": 1234,
@@ -19392,8 +18497,8 @@
         "status": 201,
         "response": {
           "macaddress": "",
-          "created_at": "2024-12-11T16:45:06.825644+01:00",
-          "updated_at": "2024-12-11T16:45:06.825657+01:00",
+          "created_at": "2025-03-19T12:04:51.972611+01:00",
+          "updated_at": "2025-03-19T12:04:51.972618+01:00",
           "ipaddress": "10.0.0.5",
           "host": 13
         }
@@ -19412,8 +18517,8 @@
               "ipaddresses": [
                 {
                   "macaddress": "",
-                  "created_at": "2024-12-11T16:45:06.825644+01:00",
-                  "updated_at": "2024-12-11T16:45:06.825657+01:00",
+                  "created_at": "2025-03-19T12:04:51.972611+01:00",
+                  "updated_at": "2025-03-19T12:04:51.972618+01:00",
                   "ipaddress": "10.0.0.5",
                   "host": 13
                 }
@@ -19422,18 +18527,24 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2024-12-11T16:45:06.156299+01:00",
-                  "updated_at": "2024-12-11T16:45:06.156320+01:00",
+                  "created_at": "2025-03-19T12:04:51.792606+01:00",
+                  "updated_at": "2025-03-19T12:04:51.792612+01:00",
                   "txt": "v=spf1 -all",
                   "host": 13
                 }
               ],
               "ptr_overrides": [],
+              "srvs": [],
+              "naptrs": [],
+              "sshfps": [],
+              "groups": [],
+              "roles": [],
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
-              "created_at": "2024-12-11T16:45:06.137012+01:00",
-              "updated_at": "2024-12-11T16:45:06.137037+01:00",
+              "communities": [],
+              "created_at": "2025-03-19T12:04:51.790986+01:00",
+              "updated_at": "2025-03-19T12:04:51.790994+01:00",
               "name": "foo.example.org",
               "contact": "",
               "ttl": null,
@@ -19714,8 +18825,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:06.825644+01:00",
-              "updated_at": "2024-12-11T16:45:07.470501+01:00",
+              "created_at": "2025-03-19T12:04:51.972611+01:00",
+              "updated_at": "2025-03-19T12:04:52.329514+01:00",
               "ipaddress": "10.0.0.5",
               "host": 13
             }
@@ -19724,18 +18835,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:06.156299+01:00",
-              "updated_at": "2024-12-11T16:45:06.156320+01:00",
+              "created_at": "2025-03-19T12:04:51.792606+01:00",
+              "updated_at": "2025-03-19T12:04:51.792612+01:00",
               "txt": "v=spf1 -all",
               "host": 13
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:06.137012+01:00",
-          "updated_at": "2024-12-11T16:45:06.137037+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:51.790986+01:00",
+          "updated_at": "2025-03-19T12:04:51.790994+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -19758,8 +18875,8 @@
         "status": 200,
         "response": {
           "macaddress": "aa:bb:cc:dd:ee:ff",
-          "created_at": "2024-12-11T16:45:06.825644+01:00",
-          "updated_at": "2024-12-11T16:45:07.909151+01:00",
+          "created_at": "2025-03-19T12:04:51.972611+01:00",
+          "updated_at": "2025-03-19T12:04:52.507441+01:00",
           "ipaddress": "10.0.0.5",
           "host": 13
         }
@@ -19788,8 +18905,8 @@
           "ipaddresses": [
             {
               "macaddress": "aa:bb:cc:dd:ee:ff",
-              "created_at": "2024-12-11T16:45:06.825644+01:00",
-              "updated_at": "2024-12-11T16:45:07.909151+01:00",
+              "created_at": "2025-03-19T12:04:51.972611+01:00",
+              "updated_at": "2025-03-19T12:04:52.507441+01:00",
               "ipaddress": "10.0.0.5",
               "host": 13
             }
@@ -19798,18 +18915,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:06.156299+01:00",
-              "updated_at": "2024-12-11T16:45:06.156320+01:00",
+              "created_at": "2025-03-19T12:04:51.792606+01:00",
+              "updated_at": "2025-03-19T12:04:51.792612+01:00",
               "txt": "v=spf1 -all",
               "host": 13
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:06.137012+01:00",
-          "updated_at": "2024-12-11T16:45:06.137037+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:51.790986+01:00",
+          "updated_at": "2025-03-19T12:04:51.790994+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -19832,8 +18955,8 @@
         "status": 200,
         "response": {
           "macaddress": "",
-          "created_at": "2024-12-11T16:45:06.825644+01:00",
-          "updated_at": "2024-12-11T16:45:08.135007+01:00",
+          "created_at": "2025-03-19T12:04:51.972611+01:00",
+          "updated_at": "2025-03-19T12:04:52.583974+01:00",
           "ipaddress": "10.0.0.5",
           "host": 13
         }
@@ -19895,8 +19018,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:06.825644+01:00",
-              "updated_at": "2024-12-11T16:45:08.135007+01:00",
+              "created_at": "2025-03-19T12:04:51.972611+01:00",
+              "updated_at": "2025-03-19T12:04:52.583974+01:00",
               "ipaddress": "10.0.0.5",
               "host": 13
             }
@@ -19905,18 +19028,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:06.156299+01:00",
-              "updated_at": "2024-12-11T16:45:06.156320+01:00",
+              "created_at": "2025-03-19T12:04:51.792606+01:00",
+              "updated_at": "2025-03-19T12:04:51.792612+01:00",
               "txt": "v=spf1 -all",
               "host": 13
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:06.137012+01:00",
-          "updated_at": "2024-12-11T16:45:06.137037+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:51.790986+01:00",
+          "updated_at": "2025-03-19T12:04:51.790994+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -19968,18 +19097,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:06.156299+01:00",
-              "updated_at": "2024-12-11T16:45:06.156320+01:00",
+              "created_at": "2025-03-19T12:04:51.792606+01:00",
+              "updated_at": "2025-03-19T12:04:51.792612+01:00",
               "txt": "v=spf1 -all",
               "host": 13
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:06.137012+01:00",
-          "updated_at": "2024-12-11T16:45:06.137037+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:51.790986+01:00",
+          "updated_at": "2025-03-19T12:04:51.790994+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -20013,18 +19148,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:06.156299+01:00",
-              "updated_at": "2024-12-11T16:45:06.156320+01:00",
+              "created_at": "2025-03-19T12:04:51.792606+01:00",
+              "updated_at": "2025-03-19T12:04:51.792612+01:00",
               "txt": "v=spf1 -all",
               "host": 13
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:06.137012+01:00",
-          "updated_at": "2024-12-11T16:45:06.137037+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:51.790986+01:00",
+          "updated_at": "2025-03-19T12:04:51.790994+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -20039,8 +19180,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:45:05.867822+01:00",
-          "updated_at": "2024-12-11T16:45:05.867856+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:51.700856+01:00",
+          "updated_at": "2025-03-19T12:04:51.700881+01:00",
           "network": "10.0.0.0/24",
           "description": "foo",
           "vlan": 1234,
@@ -20073,8 +19216,8 @@
         "status": 201,
         "response": {
           "macaddress": "",
-          "created_at": "2024-12-11T16:45:08.679831+01:00",
-          "updated_at": "2024-12-11T16:45:08.679843+01:00",
+          "created_at": "2025-03-19T12:04:52.903980+01:00",
+          "updated_at": "2025-03-19T12:04:52.903987+01:00",
           "ipaddress": "10.0.0.5",
           "host": 13
         }
@@ -20093,8 +19236,8 @@
               "ipaddresses": [
                 {
                   "macaddress": "",
-                  "created_at": "2024-12-11T16:45:08.679831+01:00",
-                  "updated_at": "2024-12-11T16:45:08.679843+01:00",
+                  "created_at": "2025-03-19T12:04:52.903980+01:00",
+                  "updated_at": "2025-03-19T12:04:52.903987+01:00",
                   "ipaddress": "10.0.0.5",
                   "host": 13
                 }
@@ -20103,18 +19246,24 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2024-12-11T16:45:06.156299+01:00",
-                  "updated_at": "2024-12-11T16:45:06.156320+01:00",
+                  "created_at": "2025-03-19T12:04:51.792606+01:00",
+                  "updated_at": "2025-03-19T12:04:51.792612+01:00",
                   "txt": "v=spf1 -all",
                   "host": 13
                 }
               ],
               "ptr_overrides": [],
+              "srvs": [],
+              "naptrs": [],
+              "sshfps": [],
+              "groups": [],
+              "roles": [],
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
-              "created_at": "2024-12-11T16:45:06.137012+01:00",
-              "updated_at": "2024-12-11T16:45:06.137037+01:00",
+              "communities": [],
+              "created_at": "2025-03-19T12:04:51.790986+01:00",
+              "updated_at": "2025-03-19T12:04:51.790994+01:00",
               "name": "foo.example.org",
               "contact": "",
               "ttl": null,
@@ -20148,8 +19297,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:08.679831+01:00",
-              "updated_at": "2024-12-11T16:45:08.679843+01:00",
+              "created_at": "2025-03-19T12:04:52.903980+01:00",
+              "updated_at": "2025-03-19T12:04:52.903987+01:00",
               "ipaddress": "10.0.0.5",
               "host": 13
             }
@@ -20158,18 +19307,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:06.156299+01:00",
-              "updated_at": "2024-12-11T16:45:06.156320+01:00",
+              "created_at": "2025-03-19T12:04:51.792606+01:00",
+              "updated_at": "2025-03-19T12:04:51.792612+01:00",
               "txt": "v=spf1 -all",
               "host": 13
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:06.137012+01:00",
-          "updated_at": "2024-12-11T16:45:06.137037+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:51.790986+01:00",
+          "updated_at": "2025-03-19T12:04:51.790994+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -20184,8 +19339,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:45:05.867822+01:00",
-          "updated_at": "2024-12-11T16:45:05.867856+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:51.700856+01:00",
+          "updated_at": "2025-03-19T12:04:51.700881+01:00",
           "network": "10.0.0.0/24",
           "description": "foo",
           "vlan": 1234,
@@ -20206,8 +19363,8 @@
         "status": 201,
         "response": {
           "macaddress": "",
-          "created_at": "2024-12-11T16:45:08.962896+01:00",
-          "updated_at": "2024-12-11T16:45:08.962917+01:00",
+          "created_at": "2025-03-19T12:04:53.022387+01:00",
+          "updated_at": "2025-03-19T12:04:53.022394+01:00",
           "ipaddress": "10.0.0.6",
           "host": 13
         }
@@ -20226,15 +19383,15 @@
               "ipaddresses": [
                 {
                   "macaddress": "",
-                  "created_at": "2024-12-11T16:45:08.679831+01:00",
-                  "updated_at": "2024-12-11T16:45:08.679843+01:00",
+                  "created_at": "2025-03-19T12:04:52.903980+01:00",
+                  "updated_at": "2025-03-19T12:04:52.903987+01:00",
                   "ipaddress": "10.0.0.5",
                   "host": 13
                 },
                 {
                   "macaddress": "",
-                  "created_at": "2024-12-11T16:45:08.962896+01:00",
-                  "updated_at": "2024-12-11T16:45:08.962917+01:00",
+                  "created_at": "2025-03-19T12:04:53.022387+01:00",
+                  "updated_at": "2025-03-19T12:04:53.022394+01:00",
                   "ipaddress": "10.0.0.6",
                   "host": 13
                 }
@@ -20243,18 +19400,24 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2024-12-11T16:45:06.156299+01:00",
-                  "updated_at": "2024-12-11T16:45:06.156320+01:00",
+                  "created_at": "2025-03-19T12:04:51.792606+01:00",
+                  "updated_at": "2025-03-19T12:04:51.792612+01:00",
                   "txt": "v=spf1 -all",
                   "host": 13
                 }
               ],
               "ptr_overrides": [],
+              "srvs": [],
+              "naptrs": [],
+              "sshfps": [],
+              "groups": [],
+              "roles": [],
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
-              "created_at": "2024-12-11T16:45:06.137012+01:00",
-              "updated_at": "2024-12-11T16:45:06.137037+01:00",
+              "communities": [],
+              "created_at": "2025-03-19T12:04:51.790986+01:00",
+              "updated_at": "2025-03-19T12:04:51.790994+01:00",
               "name": "foo.example.org",
               "contact": "",
               "ttl": null,
@@ -20300,15 +19463,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:08.679831+01:00",
-              "updated_at": "2024-12-11T16:45:08.679843+01:00",
+              "created_at": "2025-03-19T12:04:52.903980+01:00",
+              "updated_at": "2025-03-19T12:04:52.903987+01:00",
               "ipaddress": "10.0.0.5",
               "host": 13
             },
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:08.962896+01:00",
-              "updated_at": "2024-12-11T16:45:08.962917+01:00",
+              "created_at": "2025-03-19T12:04:53.022387+01:00",
+              "updated_at": "2025-03-19T12:04:53.022394+01:00",
               "ipaddress": "10.0.0.6",
               "host": 13
             }
@@ -20317,18 +19480,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:06.156299+01:00",
-              "updated_at": "2024-12-11T16:45:06.156320+01:00",
+              "created_at": "2025-03-19T12:04:51.792606+01:00",
+              "updated_at": "2025-03-19T12:04:51.792612+01:00",
               "txt": "v=spf1 -all",
               "host": 13
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:06.137012+01:00",
-          "updated_at": "2024-12-11T16:45:06.137037+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:51.790986+01:00",
+          "updated_at": "2025-03-19T12:04:51.790994+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -20360,15 +19529,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:08.679831+01:00",
-              "updated_at": "2024-12-11T16:45:08.679843+01:00",
+              "created_at": "2025-03-19T12:04:52.903980+01:00",
+              "updated_at": "2025-03-19T12:04:52.903987+01:00",
               "ipaddress": "10.0.0.5",
               "host": 13
             },
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:08.962896+01:00",
-              "updated_at": "2024-12-11T16:45:08.962917+01:00",
+              "created_at": "2025-03-19T12:04:53.022387+01:00",
+              "updated_at": "2025-03-19T12:04:53.022394+01:00",
               "ipaddress": "10.0.0.6",
               "host": 13
             }
@@ -20377,18 +19546,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:06.156299+01:00",
-              "updated_at": "2024-12-11T16:45:06.156320+01:00",
+              "created_at": "2025-03-19T12:04:51.792606+01:00",
+              "updated_at": "2025-03-19T12:04:51.792612+01:00",
               "txt": "v=spf1 -all",
               "host": 13
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:06.137012+01:00",
-          "updated_at": "2024-12-11T16:45:06.137037+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:51.790986+01:00",
+          "updated_at": "2025-03-19T12:04:51.790994+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -20429,8 +19604,10 @@
           "results": [
             {
               "excluded_ranges": [],
-              "created_at": "2024-12-11T16:45:05.867822+01:00",
-              "updated_at": "2024-12-11T16:45:05.867856+01:00",
+              "policy": null,
+              "communities": [],
+              "created_at": "2025-03-19T10:10:54.577597+01:00",
+              "updated_at": "2025-03-19T10:10:54.577613+01:00",
               "network": "10.0.0.0/24",
               "description": "foo",
               "vlan": 1234,
@@ -20461,8 +19638,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:45:09.480471+01:00",
-          "updated_at": "2024-12-11T16:45:09.480495+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T10:10:56.614500+01:00",
+          "updated_at": "2025-03-19T10:10:56.614509+01:00",
           "network": "2001:db8::/64",
           "description": "foo_ipv6",
           "vlan": 1234,
@@ -20500,8 +19679,10 @@
           "results": [
             {
               "excluded_ranges": [],
-              "created_at": "2024-12-11T16:45:05.867822+01:00",
-              "updated_at": "2024-12-11T16:45:05.867856+01:00",
+              "policy": null,
+              "communities": [],
+              "created_at": "2025-03-19T10:10:54.577597+01:00",
+              "updated_at": "2025-03-19T10:10:54.577613+01:00",
               "network": "10.0.0.0/24",
               "description": "foo",
               "vlan": 1234,
@@ -20513,8 +19694,10 @@
             },
             {
               "excluded_ranges": [],
-              "created_at": "2024-12-11T16:45:09.480471+01:00",
-              "updated_at": "2024-12-11T16:45:09.480495+01:00",
+              "policy": null,
+              "communities": [],
+              "created_at": "2025-03-19T10:10:56.614500+01:00",
+              "updated_at": "2025-03-19T10:10:56.614509+01:00",
               "network": "2001:db8::/64",
               "description": "foo_ipv6",
               "vlan": 1234,
@@ -20545,8 +19728,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:45:09.641456+01:00",
-          "updated_at": "2024-12-11T16:45:09.641474+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T10:10:56.681621+01:00",
+          "updated_at": "2025-03-19T10:10:56.681633+01:00",
           "network": "2001:db9::/64",
           "description": "notfoo_ipv6",
           "vlan": 1235,
@@ -20581,8 +19766,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:08.679831+01:00",
-              "updated_at": "2024-12-11T16:45:08.679843+01:00",
+              "created_at": "2025-03-19T12:04:52.903980+01:00",
+              "updated_at": "2025-03-19T12:04:52.903987+01:00",
               "ipaddress": "10.0.0.5",
               "host": 13
             }
@@ -20591,18 +19776,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:06.156299+01:00",
-              "updated_at": "2024-12-11T16:45:06.156320+01:00",
+              "created_at": "2025-03-19T12:04:51.792606+01:00",
+              "updated_at": "2025-03-19T12:04:51.792612+01:00",
               "txt": "v=spf1 -all",
               "host": 13
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:06.137012+01:00",
-          "updated_at": "2024-12-11T16:45:06.137037+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:51.790986+01:00",
+          "updated_at": "2025-03-19T12:04:51.790994+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -20617,8 +19808,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:45:09.641456+01:00",
-          "updated_at": "2024-12-11T16:45:09.641474+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:53.282328+01:00",
+          "updated_at": "2025-03-19T12:04:53.282340+01:00",
           "network": "2001:db9::/64",
           "description": "notfoo_ipv6",
           "vlan": 1235,
@@ -20639,8 +19832,8 @@
         "status": 201,
         "response": {
           "macaddress": "",
-          "created_at": "2024-12-11T16:45:09.887479+01:00",
-          "updated_at": "2024-12-11T16:45:09.887503+01:00",
+          "created_at": "2025-03-19T12:04:53.389192+01:00",
+          "updated_at": "2025-03-19T12:04:53.389197+01:00",
           "ipaddress": "2001:db9::5",
           "host": 13
         }
@@ -20659,15 +19852,15 @@
               "ipaddresses": [
                 {
                   "macaddress": "",
-                  "created_at": "2024-12-11T16:45:08.679831+01:00",
-                  "updated_at": "2024-12-11T16:45:08.679843+01:00",
+                  "created_at": "2025-03-19T12:04:52.903980+01:00",
+                  "updated_at": "2025-03-19T12:04:52.903987+01:00",
                   "ipaddress": "10.0.0.5",
                   "host": 13
                 },
                 {
                   "macaddress": "",
-                  "created_at": "2024-12-11T16:45:09.887479+01:00",
-                  "updated_at": "2024-12-11T16:45:09.887503+01:00",
+                  "created_at": "2025-03-19T12:04:53.389192+01:00",
+                  "updated_at": "2025-03-19T12:04:53.389197+01:00",
                   "ipaddress": "2001:db9::5",
                   "host": 13
                 }
@@ -20676,18 +19869,24 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2024-12-11T16:45:06.156299+01:00",
-                  "updated_at": "2024-12-11T16:45:06.156320+01:00",
+                  "created_at": "2025-03-19T12:04:51.792606+01:00",
+                  "updated_at": "2025-03-19T12:04:51.792612+01:00",
                   "txt": "v=spf1 -all",
                   "host": 13
                 }
               ],
               "ptr_overrides": [],
+              "srvs": [],
+              "naptrs": [],
+              "sshfps": [],
+              "groups": [],
+              "roles": [],
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
-              "created_at": "2024-12-11T16:45:06.137012+01:00",
-              "updated_at": "2024-12-11T16:45:06.137037+01:00",
+              "communities": [],
+              "created_at": "2025-03-19T12:04:51.790986+01:00",
+              "updated_at": "2025-03-19T12:04:51.790994+01:00",
               "name": "foo.example.org",
               "contact": "",
               "ttl": null,
@@ -20733,15 +19932,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:08.679831+01:00",
-              "updated_at": "2024-12-11T16:45:08.679843+01:00",
+              "created_at": "2025-03-19T12:04:52.903980+01:00",
+              "updated_at": "2025-03-19T12:04:52.903987+01:00",
               "ipaddress": "10.0.0.5",
               "host": 13
             },
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:09.887479+01:00",
-              "updated_at": "2024-12-11T16:45:09.887503+01:00",
+              "created_at": "2025-03-19T12:04:53.389192+01:00",
+              "updated_at": "2025-03-19T12:04:53.389197+01:00",
               "ipaddress": "2001:db9::5",
               "host": 13
             }
@@ -20750,18 +19949,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:06.156299+01:00",
-              "updated_at": "2024-12-11T16:45:06.156320+01:00",
+              "created_at": "2025-03-19T12:04:51.792606+01:00",
+              "updated_at": "2025-03-19T12:04:51.792612+01:00",
               "txt": "v=spf1 -all",
               "host": 13
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:06.137012+01:00",
-          "updated_at": "2024-12-11T16:45:06.137037+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:51.790986+01:00",
+          "updated_at": "2025-03-19T12:04:51.790994+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -20776,8 +19981,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:45:05.867822+01:00",
-          "updated_at": "2024-12-11T16:45:05.867856+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:51.700856+01:00",
+          "updated_at": "2025-03-19T12:04:51.700881+01:00",
           "network": "10.0.0.0/24",
           "description": "foo",
           "vlan": 1234,
@@ -20795,8 +20002,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:45:09.641456+01:00",
-          "updated_at": "2024-12-11T16:45:09.641474+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:53.282328+01:00",
+          "updated_at": "2025-03-19T12:04:53.282340+01:00",
           "network": "2001:db9::/64",
           "description": "notfoo_ipv6",
           "vlan": 1235,
@@ -20831,15 +20040,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:08.679831+01:00",
-              "updated_at": "2024-12-11T16:45:08.679843+01:00",
+              "created_at": "2025-03-19T12:04:52.903980+01:00",
+              "updated_at": "2025-03-19T12:04:52.903987+01:00",
               "ipaddress": "10.0.0.5",
               "host": 13
             },
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:09.887479+01:00",
-              "updated_at": "2024-12-11T16:45:09.887503+01:00",
+              "created_at": "2025-03-19T12:04:53.389192+01:00",
+              "updated_at": "2025-03-19T12:04:53.389197+01:00",
               "ipaddress": "2001:db9::5",
               "host": 13
             }
@@ -20848,18 +20057,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:06.156299+01:00",
-              "updated_at": "2024-12-11T16:45:06.156320+01:00",
+              "created_at": "2025-03-19T12:04:51.792606+01:00",
+              "updated_at": "2025-03-19T12:04:51.792612+01:00",
               "txt": "v=spf1 -all",
               "host": 13
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:06.137012+01:00",
-          "updated_at": "2024-12-11T16:45:06.137037+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:51.790986+01:00",
+          "updated_at": "2025-03-19T12:04:51.790994+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -20897,8 +20112,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:08.679831+01:00",
-              "updated_at": "2024-12-11T16:45:08.679843+01:00",
+              "created_at": "2025-03-19T12:04:52.903980+01:00",
+              "updated_at": "2025-03-19T12:04:52.903987+01:00",
               "ipaddress": "10.0.0.5",
               "host": 13
             }
@@ -20907,18 +20122,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:06.156299+01:00",
-              "updated_at": "2024-12-11T16:45:06.156320+01:00",
+              "created_at": "2025-03-19T12:04:51.792606+01:00",
+              "updated_at": "2025-03-19T12:04:51.792612+01:00",
               "txt": "v=spf1 -all",
               "host": 13
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:06.137012+01:00",
-          "updated_at": "2024-12-11T16:45:06.137037+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:51.790986+01:00",
+          "updated_at": "2025-03-19T12:04:51.790994+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -20933,8 +20154,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:45:09.480471+01:00",
-          "updated_at": "2024-12-11T16:45:09.480495+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:53.207389+01:00",
+          "updated_at": "2025-03-19T12:04:53.207398+01:00",
           "network": "2001:db8::/64",
           "description": "foo_ipv6",
           "vlan": 1234,
@@ -20955,8 +20178,8 @@
         "status": 201,
         "response": {
           "macaddress": "",
-          "created_at": "2024-12-11T16:45:10.531279+01:00",
-          "updated_at": "2024-12-11T16:45:10.531300+01:00",
+          "created_at": "2025-03-19T12:04:53.799713+01:00",
+          "updated_at": "2025-03-19T12:04:53.799719+01:00",
           "ipaddress": "2001:db8::5",
           "host": 13
         }
@@ -20975,15 +20198,15 @@
               "ipaddresses": [
                 {
                   "macaddress": "",
-                  "created_at": "2024-12-11T16:45:08.679831+01:00",
-                  "updated_at": "2024-12-11T16:45:08.679843+01:00",
+                  "created_at": "2025-03-19T12:04:52.903980+01:00",
+                  "updated_at": "2025-03-19T12:04:52.903987+01:00",
                   "ipaddress": "10.0.0.5",
                   "host": 13
                 },
                 {
                   "macaddress": "",
-                  "created_at": "2024-12-11T16:45:10.531279+01:00",
-                  "updated_at": "2024-12-11T16:45:10.531300+01:00",
+                  "created_at": "2025-03-19T12:04:53.799713+01:00",
+                  "updated_at": "2025-03-19T12:04:53.799719+01:00",
                   "ipaddress": "2001:db8::5",
                   "host": 13
                 }
@@ -20992,18 +20215,24 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2024-12-11T16:45:06.156299+01:00",
-                  "updated_at": "2024-12-11T16:45:06.156320+01:00",
+                  "created_at": "2025-03-19T12:04:51.792606+01:00",
+                  "updated_at": "2025-03-19T12:04:51.792612+01:00",
                   "txt": "v=spf1 -all",
                   "host": 13
                 }
               ],
               "ptr_overrides": [],
+              "srvs": [],
+              "naptrs": [],
+              "sshfps": [],
+              "groups": [],
+              "roles": [],
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
-              "created_at": "2024-12-11T16:45:06.137012+01:00",
-              "updated_at": "2024-12-11T16:45:06.137037+01:00",
+              "communities": [],
+              "created_at": "2025-03-19T12:04:51.790986+01:00",
+              "updated_at": "2025-03-19T12:04:51.790994+01:00",
               "name": "foo.example.org",
               "contact": "",
               "ttl": null,
@@ -21049,15 +20278,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:08.679831+01:00",
-              "updated_at": "2024-12-11T16:45:08.679843+01:00",
+              "created_at": "2025-03-19T12:04:52.903980+01:00",
+              "updated_at": "2025-03-19T12:04:52.903987+01:00",
               "ipaddress": "10.0.0.5",
               "host": 13
             },
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:10.531279+01:00",
-              "updated_at": "2024-12-11T16:45:10.531300+01:00",
+              "created_at": "2025-03-19T12:04:53.799713+01:00",
+              "updated_at": "2025-03-19T12:04:53.799719+01:00",
               "ipaddress": "2001:db8::5",
               "host": 13
             }
@@ -21066,18 +20295,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:06.156299+01:00",
-              "updated_at": "2024-12-11T16:45:06.156320+01:00",
+              "created_at": "2025-03-19T12:04:51.792606+01:00",
+              "updated_at": "2025-03-19T12:04:51.792612+01:00",
               "txt": "v=spf1 -all",
               "host": 13
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:06.137012+01:00",
-          "updated_at": "2024-12-11T16:45:06.137037+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:51.790986+01:00",
+          "updated_at": "2025-03-19T12:04:51.790994+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -21092,8 +20327,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:45:05.867822+01:00",
-          "updated_at": "2024-12-11T16:45:05.867856+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:51.700856+01:00",
+          "updated_at": "2025-03-19T12:04:51.700881+01:00",
           "network": "10.0.0.0/24",
           "description": "foo",
           "vlan": 1234,
@@ -21111,8 +20348,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:45:09.480471+01:00",
-          "updated_at": "2024-12-11T16:45:09.480495+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:53.207389+01:00",
+          "updated_at": "2025-03-19T12:04:53.207398+01:00",
           "network": "2001:db8::/64",
           "description": "foo_ipv6",
           "vlan": 1234,
@@ -21138,8 +20377,8 @@
         "status": 200,
         "response": {
           "macaddress": "aa:bb:cc:dd:ee:ff",
-          "created_at": "2024-12-11T16:45:08.679831+01:00",
-          "updated_at": "2024-12-11T16:45:11.011903+01:00",
+          "created_at": "2025-03-19T12:04:52.903980+01:00",
+          "updated_at": "2025-03-19T12:04:54.012531+01:00",
           "ipaddress": "10.0.0.5",
           "host": 13
         }
@@ -21166,8 +20405,8 @@
       "              2001:db8::5   <not set>   ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Thu Feb 27 10:47:50 2025",
-      "Updated:      Thu Feb 27 10:47:50 2025"
+      "Created:      Wed Mar 19 12:04:51 2025",
+      "Updated:      Wed Mar 19 12:04:51 2025"
     ],
     "api_requests": [
       {
@@ -21179,15 +20418,15 @@
           "ipaddresses": [
             {
               "macaddress": "aa:bb:cc:dd:ee:ff",
-              "created_at": "2025-02-27T10:47:51.466457+01:00",
-              "updated_at": "2025-02-27T10:47:52.361649+01:00",
+              "created_at": "2025-03-19T12:04:52.903980+01:00",
+              "updated_at": "2025-03-19T12:04:54.012531+01:00",
               "ipaddress": "10.0.0.5",
               "host": 13
             },
             {
               "macaddress": "",
-              "created_at": "2025-02-27T10:47:52.194835+01:00",
-              "updated_at": "2025-02-27T10:47:52.194841+01:00",
+              "created_at": "2025-03-19T12:04:53.799713+01:00",
+              "updated_at": "2025-03-19T12:04:53.799719+01:00",
               "ipaddress": "2001:db8::5",
               "host": 13
             }
@@ -21196,18 +20435,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-02-27T10:47:50.070902+01:00",
-              "updated_at": "2025-02-27T10:47:50.070909+01:00",
+              "created_at": "2025-03-19T12:04:51.792606+01:00",
+              "updated_at": "2025-03-19T12:04:51.792612+01:00",
               "txt": "v=spf1 -all",
               "host": 13
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2025-02-27T10:47:50.068401+01:00",
-          "updated_at": "2025-02-27T10:47:50.068410+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:51.790986+01:00",
+          "updated_at": "2025-03-19T12:04:51.790994+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -21222,8 +20467,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2025-02-27T10:47:49.959274+01:00",
-          "updated_at": "2025-02-27T10:47:49.959289+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:51.700856+01:00",
+          "updated_at": "2025-03-19T12:04:51.700881+01:00",
           "network": "10.0.0.0/24",
           "description": "foo",
           "vlan": 1234,
@@ -21241,8 +20488,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2025-02-27T10:47:51.776136+01:00",
-          "updated_at": "2025-02-27T10:47:51.776146+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:53.207389+01:00",
+          "updated_at": "2025-03-19T12:04:53.207398+01:00",
           "network": "2001:db8::/64",
           "description": "foo_ipv6",
           "vlan": 1234,
@@ -21251,104 +20500,6 @@
           "location": "",
           "frozen": false,
           "reserved": 3
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/ip/10.0.0.5",
-        "data": {},
-        "status": 200,
-        "response": {
-          "excluded_ranges": [],
-          "created_at": "2025-02-27T10:47:49.959274+01:00",
-          "updated_at": "2025-02-27T10:47:49.959289+01:00",
-          "network": "10.0.0.0/24",
-          "description": "foo",
-          "vlan": 1234,
-          "dns_delegated": false,
-          "category": "",
-          "location": "",
-          "frozen": false,
-          "reserved": 3
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/ip/2001%3Adb8%3A%3A5",
-        "data": {},
-        "status": 200,
-        "response": {
-          "excluded_ranges": [],
-          "created_at": "2025-02-27T10:47:51.776136+01:00",
-          "updated_at": "2025-02-27T10:47:51.776146+01:00",
-          "network": "2001:db8::/64",
-          "description": "foo_ipv6",
-          "vlan": 1234,
-          "dns_delegated": false,
-          "category": "",
-          "location": "",
-          "frozen": false,
-          "reserved": 3
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/srvs/?host=13",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/naptrs/?host=13",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/sshfps/?host=13",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hostpolicy/roles/?hosts=13",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hostgroups/?hosts=13",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
         }
       }
     ],
@@ -21375,15 +20526,15 @@
           "ipaddresses": [
             {
               "macaddress": "aa:bb:cc:dd:ee:ff",
-              "created_at": "2024-12-11T16:45:08.679831+01:00",
-              "updated_at": "2024-12-11T16:45:11.011903+01:00",
+              "created_at": "2025-03-19T12:04:52.903980+01:00",
+              "updated_at": "2025-03-19T12:04:54.012531+01:00",
               "ipaddress": "10.0.0.5",
               "host": 13
             },
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:10.531279+01:00",
-              "updated_at": "2024-12-11T16:45:10.531300+01:00",
+              "created_at": "2025-03-19T12:04:53.799713+01:00",
+              "updated_at": "2025-03-19T12:04:53.799719+01:00",
               "ipaddress": "2001:db8::5",
               "host": 13
             }
@@ -21392,18 +20543,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:06.156299+01:00",
-              "updated_at": "2024-12-11T16:45:06.156320+01:00",
+              "created_at": "2025-03-19T12:04:51.792606+01:00",
+              "updated_at": "2025-03-19T12:04:51.792612+01:00",
               "txt": "v=spf1 -all",
               "host": 13
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:06.137012+01:00",
-          "updated_at": "2024-12-11T16:45:06.137037+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:51.790986+01:00",
+          "updated_at": "2025-03-19T12:04:51.790994+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -21418,8 +20575,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:45:05.867822+01:00",
-          "updated_at": "2024-12-11T16:45:05.867856+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:51.700856+01:00",
+          "updated_at": "2025-03-19T12:04:51.700881+01:00",
           "network": "10.0.0.0/24",
           "description": "foo",
           "vlan": 1234,
@@ -21437,8 +20596,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:45:09.480471+01:00",
-          "updated_at": "2024-12-11T16:45:09.480495+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:53.207389+01:00",
+          "updated_at": "2025-03-19T12:04:53.207398+01:00",
           "network": "2001:db8::/64",
           "description": "foo_ipv6",
           "vlan": 1234,
@@ -21447,30 +20608,6 @@
           "location": "",
           "frozen": false,
           "reserved": 3
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/naptrs/?host=13",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/srvs/?host=13",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
         }
       },
       {
@@ -21501,8 +20638,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:45:05.867822+01:00",
-          "updated_at": "2024-12-11T16:45:05.867856+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T10:10:54.577597+01:00",
+          "updated_at": "2025-03-19T10:10:54.577613+01:00",
           "network": "10.0.0.0/24",
           "description": "foo",
           "vlan": 1234,
@@ -21548,8 +20687,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:45:09.480471+01:00",
-          "updated_at": "2024-12-11T16:45:09.480495+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T10:10:56.614500+01:00",
+          "updated_at": "2025-03-19T10:10:56.614509+01:00",
           "network": "2001:db8::/64",
           "description": "foo_ipv6",
           "vlan": 1234,
@@ -21595,8 +20736,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:45:09.641456+01:00",
-          "updated_at": "2024-12-11T16:45:09.641474+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T10:10:56.681621+01:00",
+          "updated_at": "2025-03-19T10:10:56.681633+01:00",
           "network": "2001:db9::/64",
           "description": "notfoo_ipv6",
           "vlan": 1235,
@@ -21664,8 +20807,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:45:12.363738+01:00",
-          "updated_at": "2024-12-11T16:45:12.363771+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T10:10:58.258082+01:00",
+          "updated_at": "2025-03-19T10:10:58.258094+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -21703,8 +20848,10 @@
           "results": [
             {
               "excluded_ranges": [],
-              "created_at": "2024-12-11T16:45:12.363738+01:00",
-              "updated_at": "2024-12-11T16:45:12.363771+01:00",
+              "policy": null,
+              "communities": [],
+              "created_at": "2025-03-19T10:10:58.258082+01:00",
+              "updated_at": "2025-03-19T10:10:58.258094+01:00",
               "network": "10.0.0.0/24",
               "description": "lorem ipsum",
               "vlan": null,
@@ -21734,8 +20881,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:45:12.555848+01:00",
-          "updated_at": "2024-12-11T16:45:12.555870+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T10:10:58.349561+01:00",
+          "updated_at": "2025-03-19T10:10:58.349577+01:00",
           "network": "2001:db8::/64",
           "description": "dolor sit amet",
           "vlan": null,
@@ -21768,8 +20917,8 @@
       "              10.0.0.10   11:22:33:aa:bb:cc   ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Thu Feb 27 10:47:53 2025",
-      "Updated:      Thu Feb 27 10:47:53 2025"
+      "Created:      Wed Mar 19 12:04:54 2025",
+      "Updated:      Wed Mar 19 12:04:54 2025"
     ],
     "api_requests": [
       {
@@ -21811,18 +20960,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2025-02-27T10:47:35.896278+01:00",
-                "updated_at": "2025-02-27T10:47:35.896293+01:00",
+                "created_at": "2025-03-19T12:04:41.191611+01:00",
+                "updated_at": "2025-03-19T12:04:41.191623+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-02-27T10:47:35.640608+01:00",
-            "updated_at": "2025-02-27T10:47:52.831487+01:00",
+            "created_at": "2025-03-19T12:04:40.912310+01:00",
+            "updated_at": "2025-03-19T12:04:54.213585+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-02-27T10:47:35.942147+01:00",
+            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -21839,8 +20988,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2025-02-27T10:47:53.101849+01:00",
-          "updated_at": "2025-02-27T10:47:53.101861+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.460376+01:00",
+          "updated_at": "2025-03-19T12:04:54.460385+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -21871,8 +21022,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-02-27T10:47:53.357063+01:00",
-              "updated_at": "2025-02-27T10:47:53.357069+01:00",
+              "created_at": "2025-03-19T12:04:54.729053+01:00",
+              "updated_at": "2025-03-19T12:04:54.729059+01:00",
               "ipaddress": "10.0.0.10",
               "host": 14
             }
@@ -21881,18 +21032,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-02-27T10:47:53.344695+01:00",
-              "updated_at": "2025-02-27T10:47:53.344701+01:00",
+              "created_at": "2025-03-19T12:04:54.711653+01:00",
+              "updated_at": "2025-03-19T12:04:54.711661+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2025-02-27T10:47:53.342871+01:00",
-          "updated_at": "2025-02-27T10:47:53.342878+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.709550+01:00",
+          "updated_at": "2025-03-19T12:04:54.709558+01:00",
           "name": "foo.example.org",
           "contact": "hi@ho.com",
           "ttl": null,
@@ -21927,8 +21084,8 @@
         "status": 200,
         "response": {
           "macaddress": "11:22:33:aa:bb:cc",
-          "created_at": "2025-02-27T10:47:53.357063+01:00",
-          "updated_at": "2025-02-27T10:47:53.440537+01:00",
+          "created_at": "2025-03-19T12:04:54.729053+01:00",
+          "updated_at": "2025-03-19T12:04:54.811998+01:00",
           "ipaddress": "10.0.0.10",
           "host": 14
         }
@@ -21947,8 +21104,8 @@
               "ipaddresses": [
                 {
                   "macaddress": "11:22:33:aa:bb:cc",
-                  "created_at": "2025-02-27T10:47:53.357063+01:00",
-                  "updated_at": "2025-02-27T10:47:53.440537+01:00",
+                  "created_at": "2025-03-19T12:04:54.729053+01:00",
+                  "updated_at": "2025-03-19T12:04:54.811998+01:00",
                   "ipaddress": "10.0.0.10",
                   "host": 14
                 }
@@ -21957,18 +21114,24 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2025-02-27T10:47:53.344695+01:00",
-                  "updated_at": "2025-02-27T10:47:53.344701+01:00",
+                  "created_at": "2025-03-19T12:04:54.711653+01:00",
+                  "updated_at": "2025-03-19T12:04:54.711661+01:00",
                   "txt": "v=spf1 -all",
                   "host": 14
                 }
               ],
               "ptr_overrides": [],
+              "srvs": [],
+              "naptrs": [],
+              "sshfps": [],
+              "groups": [],
+              "roles": [],
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
-              "created_at": "2025-02-27T10:47:53.342871+01:00",
-              "updated_at": "2025-02-27T10:47:53.342878+01:00",
+              "communities": [],
+              "created_at": "2025-03-19T12:04:54.709550+01:00",
+              "updated_at": "2025-03-19T12:04:54.709558+01:00",
               "name": "foo.example.org",
               "contact": "hi@ho.com",
               "ttl": null,
@@ -21985,8 +21148,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2025-02-27T10:47:53.101849+01:00",
-          "updated_at": "2025-02-27T10:47:53.101861+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.460376+01:00",
+          "updated_at": "2025-03-19T12:04:54.460385+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -21995,85 +21160,6 @@
           "location": "",
           "frozen": false,
           "reserved": 3
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/ip/10.0.0.10",
-        "data": {},
-        "status": 200,
-        "response": {
-          "excluded_ranges": [],
-          "created_at": "2025-02-27T10:47:53.101849+01:00",
-          "updated_at": "2025-02-27T10:47:53.101861+01:00",
-          "network": "10.0.0.0/24",
-          "description": "lorem ipsum",
-          "vlan": null,
-          "dns_delegated": false,
-          "category": "",
-          "location": "",
-          "frozen": false,
-          "reserved": 3
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/srvs/?host=14",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/naptrs/?host=14",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/sshfps/?host=14",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hostpolicy/roles/?hosts=14",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hostgroups/?hosts=14",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
         }
       }
     ],
@@ -22096,8 +21182,8 @@
       "              10.0.0.10   11:22:33:aa:bb:cc   ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Thu Feb 27 10:47:53 2025",
-      "Updated:      Thu Feb 27 10:47:53 2025"
+      "Created:      Wed Mar 19 12:04:54 2025",
+      "Updated:      Wed Mar 19 12:04:54 2025"
     ],
     "api_requests": [
       {
@@ -22109,8 +21195,8 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2025-02-27T10:47:53.357063+01:00",
-              "updated_at": "2025-02-27T10:47:53.440537+01:00",
+              "created_at": "2025-03-19T12:04:54.729053+01:00",
+              "updated_at": "2025-03-19T12:04:54.811998+01:00",
               "ipaddress": "10.0.0.10",
               "host": 14
             }
@@ -22119,18 +21205,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-02-27T10:47:53.344695+01:00",
-              "updated_at": "2025-02-27T10:47:53.344701+01:00",
+              "created_at": "2025-03-19T12:04:54.711653+01:00",
+              "updated_at": "2025-03-19T12:04:54.711661+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2025-02-27T10:47:53.342871+01:00",
-          "updated_at": "2025-02-27T10:47:53.342878+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.709550+01:00",
+          "updated_at": "2025-03-19T12:04:54.709558+01:00",
           "name": "foo.example.org",
           "contact": "hi@ho.com",
           "ttl": null,
@@ -22145,8 +21237,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2025-02-27T10:47:53.101849+01:00",
-          "updated_at": "2025-02-27T10:47:53.101861+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.460376+01:00",
+          "updated_at": "2025-03-19T12:04:54.460385+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -22155,85 +21249,6 @@
           "location": "",
           "frozen": false,
           "reserved": 3
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/ip/10.0.0.10",
-        "data": {},
-        "status": 200,
-        "response": {
-          "excluded_ranges": [],
-          "created_at": "2025-02-27T10:47:53.101849+01:00",
-          "updated_at": "2025-02-27T10:47:53.101861+01:00",
-          "network": "10.0.0.0/24",
-          "description": "lorem ipsum",
-          "vlan": null,
-          "dns_delegated": false,
-          "category": "",
-          "location": "",
-          "frozen": false,
-          "reserved": 3
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/srvs/?host=14",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/naptrs/?host=14",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/sshfps/?host=14",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hostpolicy/roles/?hosts=14",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hostgroups/?hosts=14",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
         }
       }
     ],
@@ -22266,8 +21281,8 @@
               "ipaddresses": [
                 {
                   "macaddress": "11:22:33:aa:bb:cc",
-                  "created_at": "2024-12-11T16:45:12.965204+01:00",
-                  "updated_at": "2024-12-11T16:45:13.218208+01:00",
+                  "created_at": "2025-03-19T12:04:54.729053+01:00",
+                  "updated_at": "2025-03-19T12:04:54.811998+01:00",
                   "ipaddress": "10.0.0.10",
                   "host": 14
                 }
@@ -22276,18 +21291,24 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2024-12-11T16:45:12.938227+01:00",
-                  "updated_at": "2024-12-11T16:45:12.938240+01:00",
+                  "created_at": "2025-03-19T12:04:54.711653+01:00",
+                  "updated_at": "2025-03-19T12:04:54.711661+01:00",
                   "txt": "v=spf1 -all",
                   "host": 14
                 }
               ],
               "ptr_overrides": [],
+              "srvs": [],
+              "naptrs": [],
+              "sshfps": [],
+              "groups": [],
+              "roles": [],
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
-              "created_at": "2024-12-11T16:45:12.933964+01:00",
-              "updated_at": "2024-12-11T16:45:12.933979+01:00",
+              "communities": [],
+              "created_at": "2025-03-19T12:04:54.709550+01:00",
+              "updated_at": "2025-03-19T12:04:54.709558+01:00",
               "name": "foo.example.org",
               "contact": "hi@ho.com",
               "ttl": null,
@@ -22327,8 +21348,8 @@
               "ipaddresses": [
                 {
                   "macaddress": "11:22:33:aa:bb:cc",
-                  "created_at": "2024-12-11T16:45:12.965204+01:00",
-                  "updated_at": "2024-12-11T16:45:13.218208+01:00",
+                  "created_at": "2025-03-19T12:04:54.729053+01:00",
+                  "updated_at": "2025-03-19T12:04:54.811998+01:00",
                   "ipaddress": "10.0.0.10",
                   "host": 14
                 }
@@ -22337,18 +21358,24 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2024-12-11T16:45:12.938227+01:00",
-                  "updated_at": "2024-12-11T16:45:12.938240+01:00",
+                  "created_at": "2025-03-19T12:04:54.711653+01:00",
+                  "updated_at": "2025-03-19T12:04:54.711661+01:00",
                   "txt": "v=spf1 -all",
                   "host": 14
                 }
               ],
               "ptr_overrides": [],
+              "srvs": [],
+              "naptrs": [],
+              "sshfps": [],
+              "groups": [],
+              "roles": [],
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
-              "created_at": "2024-12-11T16:45:12.933964+01:00",
-              "updated_at": "2024-12-11T16:45:12.933979+01:00",
+              "communities": [],
+              "created_at": "2025-03-19T12:04:54.709550+01:00",
+              "updated_at": "2025-03-19T12:04:54.709558+01:00",
               "name": "foo.example.org",
               "contact": "hi@ho.com",
               "ttl": null,
@@ -22388,8 +21415,8 @@
               "ipaddresses": [
                 {
                   "macaddress": "11:22:33:aa:bb:cc",
-                  "created_at": "2024-12-11T16:45:12.965204+01:00",
-                  "updated_at": "2024-12-11T16:45:13.218208+01:00",
+                  "created_at": "2025-03-19T12:04:54.729053+01:00",
+                  "updated_at": "2025-03-19T12:04:54.811998+01:00",
                   "ipaddress": "10.0.0.10",
                   "host": 14
                 }
@@ -22398,18 +21425,24 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2024-12-11T16:45:12.938227+01:00",
-                  "updated_at": "2024-12-11T16:45:12.938240+01:00",
+                  "created_at": "2025-03-19T12:04:54.711653+01:00",
+                  "updated_at": "2025-03-19T12:04:54.711661+01:00",
                   "txt": "v=spf1 -all",
                   "host": 14
                 }
               ],
               "ptr_overrides": [],
+              "srvs": [],
+              "naptrs": [],
+              "sshfps": [],
+              "groups": [],
+              "roles": [],
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
-              "created_at": "2024-12-11T16:45:12.933964+01:00",
-              "updated_at": "2024-12-11T16:45:12.933979+01:00",
+              "communities": [],
+              "created_at": "2025-03-19T12:04:54.709550+01:00",
+              "updated_at": "2025-03-19T12:04:54.709558+01:00",
               "name": "foo.example.org",
               "contact": "hi@ho.com",
               "ttl": null,
@@ -22449,8 +21482,8 @@
               "ipaddresses": [
                 {
                   "macaddress": "11:22:33:aa:bb:cc",
-                  "created_at": "2024-12-11T16:45:12.965204+01:00",
-                  "updated_at": "2024-12-11T16:45:13.218208+01:00",
+                  "created_at": "2025-03-19T12:04:54.729053+01:00",
+                  "updated_at": "2025-03-19T12:04:54.811998+01:00",
                   "ipaddress": "10.0.0.10",
                   "host": 14
                 }
@@ -22459,18 +21492,24 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2024-12-11T16:45:12.938227+01:00",
-                  "updated_at": "2024-12-11T16:45:12.938240+01:00",
+                  "created_at": "2025-03-19T12:04:54.711653+01:00",
+                  "updated_at": "2025-03-19T12:04:54.711661+01:00",
                   "txt": "v=spf1 -all",
                   "host": 14
                 }
               ],
               "ptr_overrides": [],
+              "srvs": [],
+              "naptrs": [],
+              "sshfps": [],
+              "groups": [],
+              "roles": [],
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
-              "created_at": "2024-12-11T16:45:12.933964+01:00",
-              "updated_at": "2024-12-11T16:45:12.933979+01:00",
+              "communities": [],
+              "created_at": "2025-03-19T12:04:54.709550+01:00",
+              "updated_at": "2025-03-19T12:04:54.709558+01:00",
               "name": "foo.example.org",
               "contact": "hi@ho.com",
               "ttl": null,
@@ -22504,8 +21543,8 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2024-12-11T16:45:12.965204+01:00",
-              "updated_at": "2024-12-11T16:45:13.218208+01:00",
+              "created_at": "2025-03-19T12:04:54.729053+01:00",
+              "updated_at": "2025-03-19T12:04:54.811998+01:00",
               "ipaddress": "10.0.0.10",
               "host": 14
             }
@@ -22514,18 +21553,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:12.938227+01:00",
-              "updated_at": "2024-12-11T16:45:12.938240+01:00",
+              "created_at": "2025-03-19T12:04:54.711653+01:00",
+              "updated_at": "2025-03-19T12:04:54.711661+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:12.933964+01:00",
-          "updated_at": "2024-12-11T16:45:12.933979+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.709550+01:00",
+          "updated_at": "2025-03-19T12:04:54.709558+01:00",
           "name": "foo.example.org",
           "contact": "hi@ho.com",
           "ttl": null,
@@ -22560,18 +21605,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2024-12-11T16:44:40.356452+01:00",
-                "updated_at": "2024-12-11T16:44:40.356481+01:00",
+                "created_at": "2025-03-19T12:04:41.191611+01:00",
+                "updated_at": "2025-03-19T12:04:41.191623+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2024-12-11T16:44:39.701254+01:00",
-            "updated_at": "2024-12-11T16:45:13.207899+01:00",
+            "created_at": "2025-03-19T12:04:40.912310+01:00",
+            "updated_at": "2025-03-19T12:04:54.811424+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
+            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -22603,8 +21648,8 @@
               "ipaddresses": [
                 {
                   "macaddress": "11:22:33:aa:bb:cc",
-                  "created_at": "2024-12-11T16:45:12.965204+01:00",
-                  "updated_at": "2024-12-11T16:45:13.218208+01:00",
+                  "created_at": "2025-03-19T12:04:54.729053+01:00",
+                  "updated_at": "2025-03-19T12:04:54.811998+01:00",
                   "ipaddress": "10.0.0.10",
                   "host": 14
                 }
@@ -22613,18 +21658,24 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2024-12-11T16:45:12.938227+01:00",
-                  "updated_at": "2024-12-11T16:45:12.938240+01:00",
+                  "created_at": "2025-03-19T12:04:54.711653+01:00",
+                  "updated_at": "2025-03-19T12:04:54.711661+01:00",
                   "txt": "v=spf1 -all",
                   "host": 14
                 }
               ],
               "ptr_overrides": [],
+              "srvs": [],
+              "naptrs": [],
+              "sshfps": [],
+              "groups": [],
+              "roles": [],
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
-              "created_at": "2024-12-11T16:45:12.933964+01:00",
-              "updated_at": "2024-12-11T16:45:14.695886+01:00",
+              "communities": [],
+              "created_at": "2025-03-19T12:04:54.709550+01:00",
+              "updated_at": "2025-03-19T12:04:55.346834+01:00",
               "name": "bar.example.org",
               "contact": "hi@ho.com",
               "ttl": null,
@@ -22658,8 +21709,8 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2024-12-11T16:45:12.965204+01:00",
-              "updated_at": "2024-12-11T16:45:13.218208+01:00",
+              "created_at": "2025-03-19T12:04:54.729053+01:00",
+              "updated_at": "2025-03-19T12:04:54.811998+01:00",
               "ipaddress": "10.0.0.10",
               "host": 14
             }
@@ -22668,18 +21719,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:12.938227+01:00",
-              "updated_at": "2024-12-11T16:45:12.938240+01:00",
+              "created_at": "2025-03-19T12:04:54.711653+01:00",
+              "updated_at": "2025-03-19T12:04:54.711661+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:12.933964+01:00",
-          "updated_at": "2024-12-11T16:45:14.695886+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.709550+01:00",
+          "updated_at": "2025-03-19T12:04:55.346834+01:00",
           "name": "bar.example.org",
           "contact": "hi@ho.com",
           "ttl": null,
@@ -22709,8 +21766,8 @@
               "ipaddresses": [
                 {
                   "macaddress": "11:22:33:aa:bb:cc",
-                  "created_at": "2024-12-11T16:45:12.965204+01:00",
-                  "updated_at": "2024-12-11T16:45:13.218208+01:00",
+                  "created_at": "2025-03-19T12:04:54.729053+01:00",
+                  "updated_at": "2025-03-19T12:04:54.811998+01:00",
                   "ipaddress": "10.0.0.10",
                   "host": 14
                 }
@@ -22719,18 +21776,24 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2024-12-11T16:45:12.938227+01:00",
-                  "updated_at": "2024-12-11T16:45:12.938240+01:00",
+                  "created_at": "2025-03-19T12:04:54.711653+01:00",
+                  "updated_at": "2025-03-19T12:04:54.711661+01:00",
                   "txt": "v=spf1 -all",
                   "host": 14
                 }
               ],
               "ptr_overrides": [],
+              "srvs": [],
+              "naptrs": [],
+              "sshfps": [],
+              "groups": [],
+              "roles": [],
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
-              "created_at": "2024-12-11T16:45:12.933964+01:00",
-              "updated_at": "2024-12-11T16:45:15.002679+01:00",
+              "communities": [],
+              "created_at": "2025-03-19T12:04:54.709550+01:00",
+              "updated_at": "2025-03-19T12:04:55.483308+01:00",
               "name": "bar.example.org",
               "contact": "hi@ho.com",
               "ttl": null,
@@ -22764,8 +21827,8 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2024-12-11T16:45:12.965204+01:00",
-              "updated_at": "2024-12-11T16:45:13.218208+01:00",
+              "created_at": "2025-03-19T12:04:54.729053+01:00",
+              "updated_at": "2025-03-19T12:04:54.811998+01:00",
               "ipaddress": "10.0.0.10",
               "host": 14
             }
@@ -22774,18 +21837,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:12.938227+01:00",
-              "updated_at": "2024-12-11T16:45:12.938240+01:00",
+              "created_at": "2025-03-19T12:04:54.711653+01:00",
+              "updated_at": "2025-03-19T12:04:54.711661+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:12.933964+01:00",
-          "updated_at": "2024-12-11T16:45:15.002679+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.709550+01:00",
+          "updated_at": "2025-03-19T12:04:55.483308+01:00",
           "name": "bar.example.org",
           "contact": "hi@ho.com",
           "ttl": null,
@@ -22830,8 +21899,8 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2024-12-11T16:45:12.965204+01:00",
-              "updated_at": "2024-12-11T16:45:13.218208+01:00",
+              "created_at": "2025-03-19T12:04:54.729053+01:00",
+              "updated_at": "2025-03-19T12:04:54.811998+01:00",
               "ipaddress": "10.0.0.10",
               "host": 14
             }
@@ -22840,18 +21909,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:12.938227+01:00",
-              "updated_at": "2024-12-11T16:45:12.938240+01:00",
+              "created_at": "2025-03-19T12:04:54.711653+01:00",
+              "updated_at": "2025-03-19T12:04:54.711661+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:12.933964+01:00",
-          "updated_at": "2024-12-11T16:45:15.002679+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.709550+01:00",
+          "updated_at": "2025-03-19T12:04:55.483308+01:00",
           "name": "bar.example.org",
           "contact": "hi@ho.com",
           "ttl": null,
@@ -22881,8 +21956,8 @@
               "ipaddresses": [
                 {
                   "macaddress": "11:22:33:aa:bb:cc",
-                  "created_at": "2024-12-11T16:45:12.965204+01:00",
-                  "updated_at": "2024-12-11T16:45:13.218208+01:00",
+                  "created_at": "2025-03-19T12:04:54.729053+01:00",
+                  "updated_at": "2025-03-19T12:04:54.811998+01:00",
                   "ipaddress": "10.0.0.10",
                   "host": 14
                 }
@@ -22891,18 +21966,24 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2024-12-11T16:45:12.938227+01:00",
-                  "updated_at": "2024-12-11T16:45:12.938240+01:00",
+                  "created_at": "2025-03-19T12:04:54.711653+01:00",
+                  "updated_at": "2025-03-19T12:04:54.711661+01:00",
                   "txt": "v=spf1 -all",
                   "host": 14
                 }
               ],
               "ptr_overrides": [],
+              "srvs": [],
+              "naptrs": [],
+              "sshfps": [],
+              "groups": [],
+              "roles": [],
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
-              "created_at": "2024-12-11T16:45:12.933964+01:00",
-              "updated_at": "2024-12-11T16:45:15.502403+01:00",
+              "communities": [],
+              "created_at": "2025-03-19T12:04:54.709550+01:00",
+              "updated_at": "2025-03-19T12:04:55.670092+01:00",
               "name": "bar.example.org",
               "contact": "me@example.org",
               "ttl": null,
@@ -22936,8 +22017,8 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2024-12-11T16:45:12.965204+01:00",
-              "updated_at": "2024-12-11T16:45:13.218208+01:00",
+              "created_at": "2025-03-19T12:04:54.729053+01:00",
+              "updated_at": "2025-03-19T12:04:54.811998+01:00",
               "ipaddress": "10.0.0.10",
               "host": 14
             }
@@ -22946,18 +22027,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:12.938227+01:00",
-              "updated_at": "2024-12-11T16:45:12.938240+01:00",
+              "created_at": "2025-03-19T12:04:54.711653+01:00",
+              "updated_at": "2025-03-19T12:04:54.711661+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:12.933964+01:00",
-          "updated_at": "2024-12-11T16:45:15.502403+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.709550+01:00",
+          "updated_at": "2025-03-19T12:04:55.670092+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -22972,8 +22059,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:45:12.363738+01:00",
-          "updated_at": "2024-12-11T16:45:12.363771+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.460376+01:00",
+          "updated_at": "2025-03-19T12:04:54.460385+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -23008,8 +22097,8 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2024-12-11T16:45:12.965204+01:00",
-              "updated_at": "2024-12-11T16:45:13.218208+01:00",
+              "created_at": "2025-03-19T12:04:54.729053+01:00",
+              "updated_at": "2025-03-19T12:04:54.811998+01:00",
               "ipaddress": "10.0.0.10",
               "host": 14
             }
@@ -23018,18 +22107,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:12.938227+01:00",
-              "updated_at": "2024-12-11T16:45:12.938240+01:00",
+              "created_at": "2025-03-19T12:04:54.711653+01:00",
+              "updated_at": "2025-03-19T12:04:54.711661+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:12.933964+01:00",
-          "updated_at": "2024-12-11T16:45:15.502403+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.709550+01:00",
+          "updated_at": "2025-03-19T12:04:55.670092+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -23044,8 +22139,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:45:12.363738+01:00",
-          "updated_at": "2024-12-11T16:45:12.363771+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.460376+01:00",
+          "updated_at": "2025-03-19T12:04:54.460385+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -23066,8 +22163,8 @@
         "status": 201,
         "response": {
           "macaddress": "",
-          "created_at": "2024-12-11T16:45:15.977555+01:00",
-          "updated_at": "2024-12-11T16:45:15.977566+01:00",
+          "created_at": "2025-03-19T12:04:55.834780+01:00",
+          "updated_at": "2025-03-19T12:04:55.834786+01:00",
           "ipaddress": "10.0.0.12",
           "host": 14
         }
@@ -23086,15 +22183,15 @@
               "ipaddresses": [
                 {
                   "macaddress": "11:22:33:aa:bb:cc",
-                  "created_at": "2024-12-11T16:45:12.965204+01:00",
-                  "updated_at": "2024-12-11T16:45:13.218208+01:00",
+                  "created_at": "2025-03-19T12:04:54.729053+01:00",
+                  "updated_at": "2025-03-19T12:04:54.811998+01:00",
                   "ipaddress": "10.0.0.10",
                   "host": 14
                 },
                 {
                   "macaddress": "",
-                  "created_at": "2024-12-11T16:45:15.977555+01:00",
-                  "updated_at": "2024-12-11T16:45:15.977566+01:00",
+                  "created_at": "2025-03-19T12:04:55.834780+01:00",
+                  "updated_at": "2025-03-19T12:04:55.834786+01:00",
                   "ipaddress": "10.0.0.12",
                   "host": 14
                 }
@@ -23103,18 +22200,24 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2024-12-11T16:45:12.938227+01:00",
-                  "updated_at": "2024-12-11T16:45:12.938240+01:00",
+                  "created_at": "2025-03-19T12:04:54.711653+01:00",
+                  "updated_at": "2025-03-19T12:04:54.711661+01:00",
                   "txt": "v=spf1 -all",
                   "host": 14
                 }
               ],
               "ptr_overrides": [],
+              "srvs": [],
+              "naptrs": [],
+              "sshfps": [],
+              "groups": [],
+              "roles": [],
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
-              "created_at": "2024-12-11T16:45:12.933964+01:00",
-              "updated_at": "2024-12-11T16:45:15.502403+01:00",
+              "communities": [],
+              "created_at": "2025-03-19T12:04:54.709550+01:00",
+              "updated_at": "2025-03-19T12:04:55.670092+01:00",
               "name": "bar.example.org",
               "contact": "me@example.org",
               "ttl": null,
@@ -23148,15 +22251,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2024-12-11T16:45:12.965204+01:00",
-              "updated_at": "2024-12-11T16:45:13.218208+01:00",
+              "created_at": "2025-03-19T12:04:54.729053+01:00",
+              "updated_at": "2025-03-19T12:04:54.811998+01:00",
               "ipaddress": "10.0.0.10",
               "host": 14
             },
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:15.977555+01:00",
-              "updated_at": "2024-12-11T16:45:15.977566+01:00",
+              "created_at": "2025-03-19T12:04:55.834780+01:00",
+              "updated_at": "2025-03-19T12:04:55.834786+01:00",
               "ipaddress": "10.0.0.12",
               "host": 14
             }
@@ -23165,18 +22268,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:12.938227+01:00",
-              "updated_at": "2024-12-11T16:45:12.938240+01:00",
+              "created_at": "2025-03-19T12:04:54.711653+01:00",
+              "updated_at": "2025-03-19T12:04:54.711661+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:12.933964+01:00",
-          "updated_at": "2024-12-11T16:45:15.502403+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.709550+01:00",
+          "updated_at": "2025-03-19T12:04:55.670092+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -23191,8 +22300,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:45:12.363738+01:00",
-          "updated_at": "2024-12-11T16:45:12.363771+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.460376+01:00",
+          "updated_at": "2025-03-19T12:04:54.460385+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -23214,8 +22325,8 @@
         "status": 201,
         "response": {
           "macaddress": "11:22:33:44:55:66",
-          "created_at": "2024-12-11T16:45:16.291195+01:00",
-          "updated_at": "2024-12-11T16:45:16.291214+01:00",
+          "created_at": "2025-03-19T12:04:55.985109+01:00",
+          "updated_at": "2025-03-19T12:04:55.985117+01:00",
           "ipaddress": "10.0.0.13",
           "host": 14
         }
@@ -23234,22 +22345,22 @@
               "ipaddresses": [
                 {
                   "macaddress": "11:22:33:aa:bb:cc",
-                  "created_at": "2024-12-11T16:45:12.965204+01:00",
-                  "updated_at": "2024-12-11T16:45:13.218208+01:00",
+                  "created_at": "2025-03-19T12:04:54.729053+01:00",
+                  "updated_at": "2025-03-19T12:04:54.811998+01:00",
                   "ipaddress": "10.0.0.10",
                   "host": 14
                 },
                 {
                   "macaddress": "",
-                  "created_at": "2024-12-11T16:45:15.977555+01:00",
-                  "updated_at": "2024-12-11T16:45:15.977566+01:00",
+                  "created_at": "2025-03-19T12:04:55.834780+01:00",
+                  "updated_at": "2025-03-19T12:04:55.834786+01:00",
                   "ipaddress": "10.0.0.12",
                   "host": 14
                 },
                 {
                   "macaddress": "11:22:33:44:55:66",
-                  "created_at": "2024-12-11T16:45:16.291195+01:00",
-                  "updated_at": "2024-12-11T16:45:16.291214+01:00",
+                  "created_at": "2025-03-19T12:04:55.985109+01:00",
+                  "updated_at": "2025-03-19T12:04:55.985117+01:00",
                   "ipaddress": "10.0.0.13",
                   "host": 14
                 }
@@ -23258,18 +22369,24 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2024-12-11T16:45:12.938227+01:00",
-                  "updated_at": "2024-12-11T16:45:12.938240+01:00",
+                  "created_at": "2025-03-19T12:04:54.711653+01:00",
+                  "updated_at": "2025-03-19T12:04:54.711661+01:00",
                   "txt": "v=spf1 -all",
                   "host": 14
                 }
               ],
               "ptr_overrides": [],
+              "srvs": [],
+              "naptrs": [],
+              "sshfps": [],
+              "groups": [],
+              "roles": [],
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
-              "created_at": "2024-12-11T16:45:12.933964+01:00",
-              "updated_at": "2024-12-11T16:45:15.502403+01:00",
+              "communities": [],
+              "created_at": "2025-03-19T12:04:54.709550+01:00",
+              "updated_at": "2025-03-19T12:04:55.670092+01:00",
               "name": "bar.example.org",
               "contact": "me@example.org",
               "ttl": null,
@@ -23303,22 +22420,22 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2024-12-11T16:45:12.965204+01:00",
-              "updated_at": "2024-12-11T16:45:13.218208+01:00",
+              "created_at": "2025-03-19T12:04:54.729053+01:00",
+              "updated_at": "2025-03-19T12:04:54.811998+01:00",
               "ipaddress": "10.0.0.10",
               "host": 14
             },
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:15.977555+01:00",
-              "updated_at": "2024-12-11T16:45:15.977566+01:00",
+              "created_at": "2025-03-19T12:04:55.834780+01:00",
+              "updated_at": "2025-03-19T12:04:55.834786+01:00",
               "ipaddress": "10.0.0.12",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2024-12-11T16:45:16.291195+01:00",
-              "updated_at": "2024-12-11T16:45:16.291214+01:00",
+              "created_at": "2025-03-19T12:04:55.985109+01:00",
+              "updated_at": "2025-03-19T12:04:55.985117+01:00",
               "ipaddress": "10.0.0.13",
               "host": 14
             }
@@ -23327,18 +22444,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:12.938227+01:00",
-              "updated_at": "2024-12-11T16:45:12.938240+01:00",
+              "created_at": "2025-03-19T12:04:54.711653+01:00",
+              "updated_at": "2025-03-19T12:04:54.711661+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:12.933964+01:00",
-          "updated_at": "2024-12-11T16:45:15.502403+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.709550+01:00",
+          "updated_at": "2025-03-19T12:04:55.670092+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -23353,8 +22476,8 @@
         "status": 200,
         "response": {
           "macaddress": "",
-          "created_at": "2024-12-11T16:45:15.977555+01:00",
-          "updated_at": "2024-12-11T16:45:15.977566+01:00",
+          "created_at": "2025-03-19T12:04:55.834780+01:00",
+          "updated_at": "2025-03-19T12:04:55.834786+01:00",
           "ipaddress": "10.0.0.12",
           "host": 14
         }
@@ -23386,8 +22509,8 @@
         "status": 200,
         "response": {
           "macaddress": "",
-          "created_at": "2024-12-11T16:45:15.977555+01:00",
-          "updated_at": "2024-12-11T16:45:16.676520+01:00",
+          "created_at": "2025-03-19T12:04:55.834780+01:00",
+          "updated_at": "2025-03-19T12:04:56.162642+01:00",
           "ipaddress": "10.0.0.14",
           "host": 14
         }
@@ -23416,22 +22539,22 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2024-12-11T16:45:12.965204+01:00",
-              "updated_at": "2024-12-11T16:45:13.218208+01:00",
+              "created_at": "2025-03-19T12:04:54.729053+01:00",
+              "updated_at": "2025-03-19T12:04:54.811998+01:00",
               "ipaddress": "10.0.0.10",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2024-12-11T16:45:16.291195+01:00",
-              "updated_at": "2024-12-11T16:45:16.291214+01:00",
+              "created_at": "2025-03-19T12:04:55.985109+01:00",
+              "updated_at": "2025-03-19T12:04:55.985117+01:00",
               "ipaddress": "10.0.0.13",
               "host": 14
             },
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:15.977555+01:00",
-              "updated_at": "2024-12-11T16:45:16.676520+01:00",
+              "created_at": "2025-03-19T12:04:55.834780+01:00",
+              "updated_at": "2025-03-19T12:04:56.162642+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             }
@@ -23440,18 +22563,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:12.938227+01:00",
-              "updated_at": "2024-12-11T16:45:12.938240+01:00",
+              "created_at": "2025-03-19T12:04:54.711653+01:00",
+              "updated_at": "2025-03-19T12:04:54.711661+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:12.933964+01:00",
-          "updated_at": "2024-12-11T16:45:15.502403+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.709550+01:00",
+          "updated_at": "2025-03-19T12:04:55.670092+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -23466,8 +22595,8 @@
         "status": 200,
         "response": {
           "macaddress": "11:22:33:44:55:66",
-          "created_at": "2024-12-11T16:45:16.291195+01:00",
-          "updated_at": "2024-12-11T16:45:16.291214+01:00",
+          "created_at": "2025-03-19T12:04:55.985109+01:00",
+          "updated_at": "2025-03-19T12:04:55.985117+01:00",
           "ipaddress": "10.0.0.13",
           "host": 14
         }
@@ -23499,8 +22628,8 @@
         "status": 200,
         "response": {
           "macaddress": "11:22:33:44:55:66",
-          "created_at": "2024-12-11T16:45:16.291195+01:00",
-          "updated_at": "2024-12-11T16:45:16.979511+01:00",
+          "created_at": "2025-03-19T12:04:55.985109+01:00",
+          "updated_at": "2025-03-19T12:04:56.289216+01:00",
           "ipaddress": "10.0.0.15",
           "host": 14
         }
@@ -23529,22 +22658,22 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2024-12-11T16:45:12.965204+01:00",
-              "updated_at": "2024-12-11T16:45:13.218208+01:00",
+              "created_at": "2025-03-19T12:04:54.729053+01:00",
+              "updated_at": "2025-03-19T12:04:54.811998+01:00",
               "ipaddress": "10.0.0.10",
               "host": 14
             },
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:15.977555+01:00",
-              "updated_at": "2024-12-11T16:45:16.676520+01:00",
+              "created_at": "2025-03-19T12:04:55.834780+01:00",
+              "updated_at": "2025-03-19T12:04:56.162642+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2024-12-11T16:45:16.291195+01:00",
-              "updated_at": "2024-12-11T16:45:16.979511+01:00",
+              "created_at": "2025-03-19T12:04:55.985109+01:00",
+              "updated_at": "2025-03-19T12:04:56.289216+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
@@ -23553,18 +22682,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:12.938227+01:00",
-              "updated_at": "2024-12-11T16:45:12.938240+01:00",
+              "created_at": "2025-03-19T12:04:54.711653+01:00",
+              "updated_at": "2025-03-19T12:04:54.711661+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:12.933964+01:00",
-          "updated_at": "2024-12-11T16:45:15.502403+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.709550+01:00",
+          "updated_at": "2025-03-19T12:04:55.670092+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -23590,8 +22725,8 @@
       "Contact:      ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Wed Dec 11 16:45:17 2024",
-      "Updated:      Wed Dec 11 16:45:17 2024"
+      "Created:      Wed Mar 19 12:04:56 2025",
+      "Updated:      Wed Mar 19 12:04:56 2025"
     ],
     "api_requests": [
       {
@@ -23621,18 +22756,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2024-12-11T16:44:40.356452+01:00",
-                "updated_at": "2024-12-11T16:44:40.356481+01:00",
+                "created_at": "2025-03-19T12:04:41.191611+01:00",
+                "updated_at": "2025-03-19T12:04:41.191623+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2024-12-11T16:44:39.701254+01:00",
-            "updated_at": "2024-12-11T16:45:16.974494+01:00",
+            "created_at": "2025-03-19T12:04:40.912310+01:00",
+            "updated_at": "2025-03-19T12:04:56.288623+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
+            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -23661,83 +22796,29 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:17.316836+01:00",
-              "updated_at": "2024-12-11T16:45:17.316858+01:00",
+              "created_at": "2025-03-19T12:04:56.406778+01:00",
+              "updated_at": "2025-03-19T12:04:56.406784+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:17.293046+01:00",
-          "updated_at": "2024-12-11T16:45:17.293070+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:56.405048+01:00",
+          "updated_at": "2025-03-19T12:04:56.405055+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
           "comment": "",
           "zone": 1
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/srvs/?host=15",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/naptrs/?host=15",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/sshfps/?host=15",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hostpolicy/roles/?hosts=15",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hostgroups/?hosts=15",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
         }
       }
     ],
@@ -23764,22 +22845,22 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2024-12-11T16:45:12.965204+01:00",
-              "updated_at": "2024-12-11T16:45:13.218208+01:00",
+              "created_at": "2025-03-19T12:04:54.729053+01:00",
+              "updated_at": "2025-03-19T12:04:54.811998+01:00",
               "ipaddress": "10.0.0.10",
               "host": 14
             },
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:15.977555+01:00",
-              "updated_at": "2024-12-11T16:45:16.676520+01:00",
+              "created_at": "2025-03-19T12:04:55.834780+01:00",
+              "updated_at": "2025-03-19T12:04:56.162642+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2024-12-11T16:45:16.291195+01:00",
-              "updated_at": "2024-12-11T16:45:16.979511+01:00",
+              "created_at": "2025-03-19T12:04:55.985109+01:00",
+              "updated_at": "2025-03-19T12:04:56.289216+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
@@ -23788,18 +22869,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:12.938227+01:00",
-              "updated_at": "2024-12-11T16:45:12.938240+01:00",
+              "created_at": "2025-03-19T12:04:54.711653+01:00",
+              "updated_at": "2025-03-19T12:04:54.711661+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:12.933964+01:00",
-          "updated_at": "2024-12-11T16:45:15.502403+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.709550+01:00",
+          "updated_at": "2025-03-19T12:04:55.670092+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -23818,18 +22905,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:17.316836+01:00",
-              "updated_at": "2024-12-11T16:45:17.316858+01:00",
+              "created_at": "2025-03-19T12:04:56.406778+01:00",
+              "updated_at": "2025-03-19T12:04:56.406784+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:17.293046+01:00",
-          "updated_at": "2024-12-11T16:45:17.293070+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:56.405048+01:00",
+          "updated_at": "2025-03-19T12:04:56.405055+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -23852,8 +22945,8 @@
         "status": 200,
         "response": {
           "macaddress": "11:22:33:aa:bb:cc",
-          "created_at": "2024-12-11T16:45:12.965204+01:00",
-          "updated_at": "2024-12-11T16:45:17.976116+01:00",
+          "created_at": "2025-03-19T12:04:54.729053+01:00",
+          "updated_at": "2025-03-19T12:04:56.526058+01:00",
           "ipaddress": "10.0.0.10",
           "host": 15
         }
@@ -23883,8 +22976,8 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2024-12-11T16:45:12.965204+01:00",
-              "updated_at": "2024-12-11T16:45:17.976116+01:00",
+              "created_at": "2025-03-19T12:04:54.729053+01:00",
+              "updated_at": "2025-03-19T12:04:56.526058+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             }
@@ -23893,18 +22986,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:17.316836+01:00",
-              "updated_at": "2024-12-11T16:45:17.316858+01:00",
+              "created_at": "2025-03-19T12:04:56.406778+01:00",
+              "updated_at": "2025-03-19T12:04:56.406784+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:17.293046+01:00",
-          "updated_at": "2024-12-11T16:45:17.293070+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:56.405048+01:00",
+          "updated_at": "2025-03-19T12:04:56.405055+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -23936,15 +23035,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:15.977555+01:00",
-              "updated_at": "2024-12-11T16:45:16.676520+01:00",
+              "created_at": "2025-03-19T12:04:55.834780+01:00",
+              "updated_at": "2025-03-19T12:04:56.162642+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2024-12-11T16:45:16.291195+01:00",
-              "updated_at": "2024-12-11T16:45:16.979511+01:00",
+              "created_at": "2025-03-19T12:04:55.985109+01:00",
+              "updated_at": "2025-03-19T12:04:56.289216+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
@@ -23953,18 +23052,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:12.938227+01:00",
-              "updated_at": "2024-12-11T16:45:12.938240+01:00",
+              "created_at": "2025-03-19T12:04:54.711653+01:00",
+              "updated_at": "2025-03-19T12:04:54.711661+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:12.933964+01:00",
-          "updated_at": "2024-12-11T16:45:15.502403+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.709550+01:00",
+          "updated_at": "2025-03-19T12:04:55.670092+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -23979,8 +23084,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:45:12.555848+01:00",
-          "updated_at": "2024-12-11T16:45:12.555870+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.536879+01:00",
+          "updated_at": "2025-03-19T12:04:54.536908+01:00",
           "network": "2001:db8::/64",
           "description": "dolor sit amet",
           "vlan": null,
@@ -24022,15 +23129,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:15.977555+01:00",
-              "updated_at": "2024-12-11T16:45:16.676520+01:00",
+              "created_at": "2025-03-19T12:04:55.834780+01:00",
+              "updated_at": "2025-03-19T12:04:56.162642+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2024-12-11T16:45:16.291195+01:00",
-              "updated_at": "2024-12-11T16:45:16.979511+01:00",
+              "created_at": "2025-03-19T12:04:55.985109+01:00",
+              "updated_at": "2025-03-19T12:04:56.289216+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
@@ -24039,18 +23146,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:12.938227+01:00",
-              "updated_at": "2024-12-11T16:45:12.938240+01:00",
+              "created_at": "2025-03-19T12:04:54.711653+01:00",
+              "updated_at": "2025-03-19T12:04:54.711661+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:12.933964+01:00",
-          "updated_at": "2024-12-11T16:45:15.502403+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.709550+01:00",
+          "updated_at": "2025-03-19T12:04:55.670092+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -24065,8 +23178,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:45:12.555848+01:00",
-          "updated_at": "2024-12-11T16:45:12.555870+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.536879+01:00",
+          "updated_at": "2025-03-19T12:04:54.536908+01:00",
           "network": "2001:db8::/64",
           "description": "dolor sit amet",
           "vlan": null,
@@ -24087,8 +23202,8 @@
         "status": 201,
         "response": {
           "macaddress": "",
-          "created_at": "2024-12-11T16:45:18.437354+01:00",
-          "updated_at": "2024-12-11T16:45:18.437376+01:00",
+          "created_at": "2025-03-19T12:04:56.791007+01:00",
+          "updated_at": "2025-03-19T12:04:56.791014+01:00",
           "ipaddress": "2001:db8::11",
           "host": 14
         }
@@ -24107,22 +23222,22 @@
               "ipaddresses": [
                 {
                   "macaddress": "",
-                  "created_at": "2024-12-11T16:45:15.977555+01:00",
-                  "updated_at": "2024-12-11T16:45:16.676520+01:00",
+                  "created_at": "2025-03-19T12:04:55.834780+01:00",
+                  "updated_at": "2025-03-19T12:04:56.162642+01:00",
                   "ipaddress": "10.0.0.14",
                   "host": 14
                 },
                 {
                   "macaddress": "11:22:33:44:55:66",
-                  "created_at": "2024-12-11T16:45:16.291195+01:00",
-                  "updated_at": "2024-12-11T16:45:16.979511+01:00",
+                  "created_at": "2025-03-19T12:04:55.985109+01:00",
+                  "updated_at": "2025-03-19T12:04:56.289216+01:00",
                   "ipaddress": "10.0.0.15",
                   "host": 14
                 },
                 {
                   "macaddress": "",
-                  "created_at": "2024-12-11T16:45:18.437354+01:00",
-                  "updated_at": "2024-12-11T16:45:18.437376+01:00",
+                  "created_at": "2025-03-19T12:04:56.791007+01:00",
+                  "updated_at": "2025-03-19T12:04:56.791014+01:00",
                   "ipaddress": "2001:db8::11",
                   "host": 14
                 }
@@ -24131,18 +23246,24 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2024-12-11T16:45:12.938227+01:00",
-                  "updated_at": "2024-12-11T16:45:12.938240+01:00",
+                  "created_at": "2025-03-19T12:04:54.711653+01:00",
+                  "updated_at": "2025-03-19T12:04:54.711661+01:00",
                   "txt": "v=spf1 -all",
                   "host": 14
                 }
               ],
               "ptr_overrides": [],
+              "srvs": [],
+              "naptrs": [],
+              "sshfps": [],
+              "groups": [],
+              "roles": [],
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
-              "created_at": "2024-12-11T16:45:12.933964+01:00",
-              "updated_at": "2024-12-11T16:45:15.502403+01:00",
+              "communities": [],
+              "created_at": "2025-03-19T12:04:54.709550+01:00",
+              "updated_at": "2025-03-19T12:04:55.670092+01:00",
               "name": "bar.example.org",
               "contact": "me@example.org",
               "ttl": null,
@@ -24176,22 +23297,22 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:15.977555+01:00",
-              "updated_at": "2024-12-11T16:45:16.676520+01:00",
+              "created_at": "2025-03-19T12:04:55.834780+01:00",
+              "updated_at": "2025-03-19T12:04:56.162642+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2024-12-11T16:45:16.291195+01:00",
-              "updated_at": "2024-12-11T16:45:16.979511+01:00",
+              "created_at": "2025-03-19T12:04:55.985109+01:00",
+              "updated_at": "2025-03-19T12:04:56.289216+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             },
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:18.437354+01:00",
-              "updated_at": "2024-12-11T16:45:18.437376+01:00",
+              "created_at": "2025-03-19T12:04:56.791007+01:00",
+              "updated_at": "2025-03-19T12:04:56.791014+01:00",
               "ipaddress": "2001:db8::11",
               "host": 14
             }
@@ -24200,18 +23321,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:12.938227+01:00",
-              "updated_at": "2024-12-11T16:45:12.938240+01:00",
+              "created_at": "2025-03-19T12:04:54.711653+01:00",
+              "updated_at": "2025-03-19T12:04:54.711661+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:12.933964+01:00",
-          "updated_at": "2024-12-11T16:45:15.502403+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.709550+01:00",
+          "updated_at": "2025-03-19T12:04:55.670092+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -24226,8 +23353,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:45:12.555848+01:00",
-          "updated_at": "2024-12-11T16:45:12.555870+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.536879+01:00",
+          "updated_at": "2025-03-19T12:04:54.536908+01:00",
           "network": "2001:db8::/64",
           "description": "dolor sit amet",
           "vlan": null,
@@ -24249,8 +23378,8 @@
         "status": 201,
         "response": {
           "macaddress": "11:22:33:44:55:67",
-          "created_at": "2024-12-11T16:45:18.689074+01:00",
-          "updated_at": "2024-12-11T16:45:18.689090+01:00",
+          "created_at": "2025-03-19T12:04:56.923203+01:00",
+          "updated_at": "2025-03-19T12:04:56.923213+01:00",
           "ipaddress": "2001:db8::12",
           "host": 14
         }
@@ -24269,29 +23398,29 @@
               "ipaddresses": [
                 {
                   "macaddress": "",
-                  "created_at": "2024-12-11T16:45:15.977555+01:00",
-                  "updated_at": "2024-12-11T16:45:16.676520+01:00",
+                  "created_at": "2025-03-19T12:04:55.834780+01:00",
+                  "updated_at": "2025-03-19T12:04:56.162642+01:00",
                   "ipaddress": "10.0.0.14",
                   "host": 14
                 },
                 {
                   "macaddress": "11:22:33:44:55:66",
-                  "created_at": "2024-12-11T16:45:16.291195+01:00",
-                  "updated_at": "2024-12-11T16:45:16.979511+01:00",
+                  "created_at": "2025-03-19T12:04:55.985109+01:00",
+                  "updated_at": "2025-03-19T12:04:56.289216+01:00",
                   "ipaddress": "10.0.0.15",
                   "host": 14
                 },
                 {
                   "macaddress": "",
-                  "created_at": "2024-12-11T16:45:18.437354+01:00",
-                  "updated_at": "2024-12-11T16:45:18.437376+01:00",
+                  "created_at": "2025-03-19T12:04:56.791007+01:00",
+                  "updated_at": "2025-03-19T12:04:56.791014+01:00",
                   "ipaddress": "2001:db8::11",
                   "host": 14
                 },
                 {
                   "macaddress": "11:22:33:44:55:67",
-                  "created_at": "2024-12-11T16:45:18.689074+01:00",
-                  "updated_at": "2024-12-11T16:45:18.689090+01:00",
+                  "created_at": "2025-03-19T12:04:56.923203+01:00",
+                  "updated_at": "2025-03-19T12:04:56.923213+01:00",
                   "ipaddress": "2001:db8::12",
                   "host": 14
                 }
@@ -24300,18 +23429,24 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2024-12-11T16:45:12.938227+01:00",
-                  "updated_at": "2024-12-11T16:45:12.938240+01:00",
+                  "created_at": "2025-03-19T12:04:54.711653+01:00",
+                  "updated_at": "2025-03-19T12:04:54.711661+01:00",
                   "txt": "v=spf1 -all",
                   "host": 14
                 }
               ],
               "ptr_overrides": [],
+              "srvs": [],
+              "naptrs": [],
+              "sshfps": [],
+              "groups": [],
+              "roles": [],
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
-              "created_at": "2024-12-11T16:45:12.933964+01:00",
-              "updated_at": "2024-12-11T16:45:15.502403+01:00",
+              "communities": [],
+              "created_at": "2025-03-19T12:04:54.709550+01:00",
+              "updated_at": "2025-03-19T12:04:55.670092+01:00",
               "name": "bar.example.org",
               "contact": "me@example.org",
               "ttl": null,
@@ -24345,29 +23480,29 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:15.977555+01:00",
-              "updated_at": "2024-12-11T16:45:16.676520+01:00",
+              "created_at": "2025-03-19T12:04:55.834780+01:00",
+              "updated_at": "2025-03-19T12:04:56.162642+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2024-12-11T16:45:16.291195+01:00",
-              "updated_at": "2024-12-11T16:45:16.979511+01:00",
+              "created_at": "2025-03-19T12:04:55.985109+01:00",
+              "updated_at": "2025-03-19T12:04:56.289216+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             },
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:18.437354+01:00",
-              "updated_at": "2024-12-11T16:45:18.437376+01:00",
+              "created_at": "2025-03-19T12:04:56.791007+01:00",
+              "updated_at": "2025-03-19T12:04:56.791014+01:00",
               "ipaddress": "2001:db8::11",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2024-12-11T16:45:18.689074+01:00",
-              "updated_at": "2024-12-11T16:45:18.689090+01:00",
+              "created_at": "2025-03-19T12:04:56.923203+01:00",
+              "updated_at": "2025-03-19T12:04:56.923213+01:00",
               "ipaddress": "2001:db8::12",
               "host": 14
             }
@@ -24376,18 +23511,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:12.938227+01:00",
-              "updated_at": "2024-12-11T16:45:12.938240+01:00",
+              "created_at": "2025-03-19T12:04:54.711653+01:00",
+              "updated_at": "2025-03-19T12:04:54.711661+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:12.933964+01:00",
-          "updated_at": "2024-12-11T16:45:15.502403+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.709550+01:00",
+          "updated_at": "2025-03-19T12:04:55.670092+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -24402,8 +23543,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:45:12.363738+01:00",
-          "updated_at": "2024-12-11T16:45:12.363771+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.460376+01:00",
+          "updated_at": "2025-03-19T12:04:54.460385+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -24421,8 +23564,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:45:12.363738+01:00",
-          "updated_at": "2024-12-11T16:45:12.363771+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.460376+01:00",
+          "updated_at": "2025-03-19T12:04:54.460385+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -24440,8 +23585,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:45:12.555848+01:00",
-          "updated_at": "2024-12-11T16:45:12.555870+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.536879+01:00",
+          "updated_at": "2025-03-19T12:04:54.536908+01:00",
           "network": "2001:db8::/64",
           "description": "dolor sit amet",
           "vlan": null,
@@ -24459,8 +23606,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:45:12.555848+01:00",
-          "updated_at": "2024-12-11T16:45:12.555870+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.536879+01:00",
+          "updated_at": "2025-03-19T12:04:54.536908+01:00",
           "network": "2001:db8::/64",
           "description": "dolor sit amet",
           "vlan": null,
@@ -24469,30 +23618,6 @@
           "location": "",
           "frozen": false,
           "reserved": 3
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/naptrs/?host=14",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/srvs/?host=14",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
         }
       }
     ],
@@ -24521,29 +23646,29 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:15.977555+01:00",
-              "updated_at": "2024-12-11T16:45:16.676520+01:00",
+              "created_at": "2025-03-19T12:04:55.834780+01:00",
+              "updated_at": "2025-03-19T12:04:56.162642+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2024-12-11T16:45:16.291195+01:00",
-              "updated_at": "2024-12-11T16:45:16.979511+01:00",
+              "created_at": "2025-03-19T12:04:55.985109+01:00",
+              "updated_at": "2025-03-19T12:04:56.289216+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             },
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:18.437354+01:00",
-              "updated_at": "2024-12-11T16:45:18.437376+01:00",
+              "created_at": "2025-03-19T12:04:56.791007+01:00",
+              "updated_at": "2025-03-19T12:04:56.791014+01:00",
               "ipaddress": "2001:db8::11",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2024-12-11T16:45:18.689074+01:00",
-              "updated_at": "2024-12-11T16:45:18.689090+01:00",
+              "created_at": "2025-03-19T12:04:56.923203+01:00",
+              "updated_at": "2025-03-19T12:04:56.923213+01:00",
               "ipaddress": "2001:db8::12",
               "host": 14
             }
@@ -24552,18 +23677,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:12.938227+01:00",
-              "updated_at": "2024-12-11T16:45:12.938240+01:00",
+              "created_at": "2025-03-19T12:04:54.711653+01:00",
+              "updated_at": "2025-03-19T12:04:54.711661+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:12.933964+01:00",
-          "updated_at": "2024-12-11T16:45:15.502403+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.709550+01:00",
+          "updated_at": "2025-03-19T12:04:55.670092+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -24595,29 +23726,29 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:15.977555+01:00",
-              "updated_at": "2024-12-11T16:45:16.676520+01:00",
+              "created_at": "2025-03-19T12:04:55.834780+01:00",
+              "updated_at": "2025-03-19T12:04:56.162642+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2024-12-11T16:45:16.291195+01:00",
-              "updated_at": "2024-12-11T16:45:16.979511+01:00",
+              "created_at": "2025-03-19T12:04:55.985109+01:00",
+              "updated_at": "2025-03-19T12:04:56.289216+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             },
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:18.437354+01:00",
-              "updated_at": "2024-12-11T16:45:18.437376+01:00",
+              "created_at": "2025-03-19T12:04:56.791007+01:00",
+              "updated_at": "2025-03-19T12:04:56.791014+01:00",
               "ipaddress": "2001:db8::11",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2024-12-11T16:45:18.689074+01:00",
-              "updated_at": "2024-12-11T16:45:18.689090+01:00",
+              "created_at": "2025-03-19T12:04:56.923203+01:00",
+              "updated_at": "2025-03-19T12:04:56.923213+01:00",
               "ipaddress": "2001:db8::12",
               "host": 14
             }
@@ -24626,18 +23757,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:12.938227+01:00",
-              "updated_at": "2024-12-11T16:45:12.938240+01:00",
+              "created_at": "2025-03-19T12:04:54.711653+01:00",
+              "updated_at": "2025-03-19T12:04:54.711661+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:12.933964+01:00",
-          "updated_at": "2024-12-11T16:45:15.502403+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.709550+01:00",
+          "updated_at": "2025-03-19T12:04:55.670092+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -24652,8 +23789,8 @@
         "status": 200,
         "response": {
           "macaddress": "",
-          "created_at": "2024-12-11T16:45:18.437354+01:00",
-          "updated_at": "2024-12-11T16:45:18.437376+01:00",
+          "created_at": "2025-03-19T12:04:56.791007+01:00",
+          "updated_at": "2025-03-19T12:04:56.791014+01:00",
           "ipaddress": "2001:db8::11",
           "host": 14
         }
@@ -24685,8 +23822,8 @@
         "status": 200,
         "response": {
           "macaddress": "",
-          "created_at": "2024-12-11T16:45:18.437354+01:00",
-          "updated_at": "2024-12-11T16:45:19.477304+01:00",
+          "created_at": "2025-03-19T12:04:56.791007+01:00",
+          "updated_at": "2025-03-19T12:04:57.231895+01:00",
           "ipaddress": "2001:db8::13",
           "host": 14
         }
@@ -24715,29 +23852,29 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:15.977555+01:00",
-              "updated_at": "2024-12-11T16:45:16.676520+01:00",
+              "created_at": "2025-03-19T12:04:55.834780+01:00",
+              "updated_at": "2025-03-19T12:04:56.162642+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2024-12-11T16:45:16.291195+01:00",
-              "updated_at": "2024-12-11T16:45:16.979511+01:00",
+              "created_at": "2025-03-19T12:04:55.985109+01:00",
+              "updated_at": "2025-03-19T12:04:56.289216+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2024-12-11T16:45:18.689074+01:00",
-              "updated_at": "2024-12-11T16:45:18.689090+01:00",
+              "created_at": "2025-03-19T12:04:56.923203+01:00",
+              "updated_at": "2025-03-19T12:04:56.923213+01:00",
               "ipaddress": "2001:db8::12",
               "host": 14
             },
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:18.437354+01:00",
-              "updated_at": "2024-12-11T16:45:19.477304+01:00",
+              "created_at": "2025-03-19T12:04:56.791007+01:00",
+              "updated_at": "2025-03-19T12:04:57.231895+01:00",
               "ipaddress": "2001:db8::13",
               "host": 14
             }
@@ -24746,18 +23883,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:12.938227+01:00",
-              "updated_at": "2024-12-11T16:45:12.938240+01:00",
+              "created_at": "2025-03-19T12:04:54.711653+01:00",
+              "updated_at": "2025-03-19T12:04:54.711661+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:12.933964+01:00",
-          "updated_at": "2024-12-11T16:45:15.502403+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.709550+01:00",
+          "updated_at": "2025-03-19T12:04:55.670092+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -24772,8 +23915,8 @@
         "status": 200,
         "response": {
           "macaddress": "11:22:33:44:55:67",
-          "created_at": "2024-12-11T16:45:18.689074+01:00",
-          "updated_at": "2024-12-11T16:45:18.689090+01:00",
+          "created_at": "2025-03-19T12:04:56.923203+01:00",
+          "updated_at": "2025-03-19T12:04:56.923213+01:00",
           "ipaddress": "2001:db8::12",
           "host": 14
         }
@@ -24805,8 +23948,8 @@
         "status": 200,
         "response": {
           "macaddress": "11:22:33:44:55:67",
-          "created_at": "2024-12-11T16:45:18.689074+01:00",
-          "updated_at": "2024-12-11T16:45:19.788296+01:00",
+          "created_at": "2025-03-19T12:04:56.923203+01:00",
+          "updated_at": "2025-03-19T12:04:57.387957+01:00",
           "ipaddress": "2001:db8::14",
           "host": 14
         }
@@ -24835,29 +23978,29 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:15.977555+01:00",
-              "updated_at": "2024-12-11T16:45:16.676520+01:00",
+              "created_at": "2025-03-19T12:04:55.834780+01:00",
+              "updated_at": "2025-03-19T12:04:56.162642+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2024-12-11T16:45:16.291195+01:00",
-              "updated_at": "2024-12-11T16:45:16.979511+01:00",
+              "created_at": "2025-03-19T12:04:55.985109+01:00",
+              "updated_at": "2025-03-19T12:04:56.289216+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             },
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:18.437354+01:00",
-              "updated_at": "2024-12-11T16:45:19.477304+01:00",
+              "created_at": "2025-03-19T12:04:56.791007+01:00",
+              "updated_at": "2025-03-19T12:04:57.231895+01:00",
               "ipaddress": "2001:db8::13",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2024-12-11T16:45:18.689074+01:00",
-              "updated_at": "2024-12-11T16:45:19.788296+01:00",
+              "created_at": "2025-03-19T12:04:56.923203+01:00",
+              "updated_at": "2025-03-19T12:04:57.387957+01:00",
               "ipaddress": "2001:db8::14",
               "host": 14
             }
@@ -24866,18 +24009,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:12.938227+01:00",
-              "updated_at": "2024-12-11T16:45:12.938240+01:00",
+              "created_at": "2025-03-19T12:04:54.711653+01:00",
+              "updated_at": "2025-03-19T12:04:54.711661+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:12.933964+01:00",
-          "updated_at": "2024-12-11T16:45:15.502403+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.709550+01:00",
+          "updated_at": "2025-03-19T12:04:55.670092+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -24915,22 +24064,22 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:15.977555+01:00",
-              "updated_at": "2024-12-11T16:45:16.676520+01:00",
+              "created_at": "2025-03-19T12:04:55.834780+01:00",
+              "updated_at": "2025-03-19T12:04:56.162642+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2024-12-11T16:45:16.291195+01:00",
-              "updated_at": "2024-12-11T16:45:16.979511+01:00",
+              "created_at": "2025-03-19T12:04:55.985109+01:00",
+              "updated_at": "2025-03-19T12:04:56.289216+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2024-12-11T16:45:18.689074+01:00",
-              "updated_at": "2024-12-11T16:45:19.788296+01:00",
+              "created_at": "2025-03-19T12:04:56.923203+01:00",
+              "updated_at": "2025-03-19T12:04:57.387957+01:00",
               "ipaddress": "2001:db8::14",
               "host": 14
             }
@@ -24939,18 +24088,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:12.938227+01:00",
-              "updated_at": "2024-12-11T16:45:12.938240+01:00",
+              "created_at": "2025-03-19T12:04:54.711653+01:00",
+              "updated_at": "2025-03-19T12:04:54.711661+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:12.933964+01:00",
-          "updated_at": "2024-12-11T16:45:15.502403+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.709550+01:00",
+          "updated_at": "2025-03-19T12:04:55.670092+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -24967,8 +24122,8 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2024-12-11T16:45:12.965204+01:00",
-              "updated_at": "2024-12-11T16:45:17.976116+01:00",
+              "created_at": "2025-03-19T12:04:54.729053+01:00",
+              "updated_at": "2025-03-19T12:04:56.526058+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             }
@@ -24977,18 +24132,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:17.316836+01:00",
-              "updated_at": "2024-12-11T16:45:17.316858+01:00",
+              "created_at": "2025-03-19T12:04:56.406778+01:00",
+              "updated_at": "2025-03-19T12:04:56.406784+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:17.293046+01:00",
-          "updated_at": "2024-12-11T16:45:17.293070+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:56.405048+01:00",
+          "updated_at": "2025-03-19T12:04:56.405055+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -25011,8 +24172,8 @@
         "status": 200,
         "response": {
           "macaddress": "11:22:33:44:55:67",
-          "created_at": "2024-12-11T16:45:18.689074+01:00",
-          "updated_at": "2024-12-11T16:45:20.166005+01:00",
+          "created_at": "2025-03-19T12:04:56.923203+01:00",
+          "updated_at": "2025-03-19T12:04:57.546535+01:00",
           "ipaddress": "2001:db8::14",
           "host": 15
         }
@@ -25042,15 +24203,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2024-12-11T16:45:12.965204+01:00",
-              "updated_at": "2024-12-11T16:45:17.976116+01:00",
+              "created_at": "2025-03-19T12:04:54.729053+01:00",
+              "updated_at": "2025-03-19T12:04:56.526058+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2024-12-11T16:45:18.689074+01:00",
-              "updated_at": "2024-12-11T16:45:20.166005+01:00",
+              "created_at": "2025-03-19T12:04:56.923203+01:00",
+              "updated_at": "2025-03-19T12:04:57.546535+01:00",
               "ipaddress": "2001:db8::14",
               "host": 15
             }
@@ -25059,18 +24220,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:17.316836+01:00",
-              "updated_at": "2024-12-11T16:45:17.316858+01:00",
+              "created_at": "2025-03-19T12:04:56.406778+01:00",
+              "updated_at": "2025-03-19T12:04:56.406784+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:17.293046+01:00",
-          "updated_at": "2024-12-11T16:45:17.293070+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:56.405048+01:00",
+          "updated_at": "2025-03-19T12:04:56.405055+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -25102,15 +24269,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:15.977555+01:00",
-              "updated_at": "2024-12-11T16:45:16.676520+01:00",
+              "created_at": "2025-03-19T12:04:55.834780+01:00",
+              "updated_at": "2025-03-19T12:04:56.162642+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2024-12-11T16:45:16.291195+01:00",
-              "updated_at": "2024-12-11T16:45:16.979511+01:00",
+              "created_at": "2025-03-19T12:04:55.985109+01:00",
+              "updated_at": "2025-03-19T12:04:56.289216+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
@@ -25119,18 +24286,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:12.938227+01:00",
-              "updated_at": "2024-12-11T16:45:12.938240+01:00",
+              "created_at": "2025-03-19T12:04:54.711653+01:00",
+              "updated_at": "2025-03-19T12:04:54.711661+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:12.933964+01:00",
-          "updated_at": "2024-12-11T16:45:15.502403+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.709550+01:00",
+          "updated_at": "2025-03-19T12:04:55.670092+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -25165,18 +24338,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2024-12-11T16:44:40.356452+01:00",
-                "updated_at": "2024-12-11T16:44:40.356481+01:00",
+                "created_at": "2025-03-19T12:04:41.191611+01:00",
+                "updated_at": "2025-03-19T12:04:41.191623+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2024-12-11T16:44:39.701254+01:00",
-            "updated_at": "2024-12-11T16:45:20.161160+01:00",
+            "created_at": "2025-03-19T12:04:40.912310+01:00",
+            "updated_at": "2025-03-19T12:04:57.545960+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
+            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -25195,8 +24368,8 @@
         },
         "status": 201,
         "response": {
-          "created_at": "2024-12-11T16:45:20.454046+01:00",
-          "updated_at": "2024-12-11T16:45:20.454066+01:00",
+          "created_at": "2025-03-19T12:04:57.705722+01:00",
+          "updated_at": "2025-03-19T12:04:57.705730+01:00",
           "name": "fubar.example.org",
           "ttl": null,
           "zone": 1,
@@ -25212,23 +24385,23 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:15.977555+01:00",
-              "updated_at": "2024-12-11T16:45:16.676520+01:00",
+              "created_at": "2025-03-19T12:04:55.834780+01:00",
+              "updated_at": "2025-03-19T12:04:56.162642+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2024-12-11T16:45:16.291195+01:00",
-              "updated_at": "2024-12-11T16:45:16.979511+01:00",
+              "created_at": "2025-03-19T12:04:55.985109+01:00",
+              "updated_at": "2025-03-19T12:04:56.289216+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
           ],
           "cnames": [
             {
-              "created_at": "2024-12-11T16:45:20.454046+01:00",
-              "updated_at": "2024-12-11T16:45:20.454066+01:00",
+              "created_at": "2025-03-19T12:04:57.705722+01:00",
+              "updated_at": "2025-03-19T12:04:57.705730+01:00",
               "name": "fubar.example.org",
               "ttl": null,
               "zone": 1,
@@ -25238,18 +24411,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:12.938227+01:00",
-              "updated_at": "2024-12-11T16:45:12.938240+01:00",
+              "created_at": "2025-03-19T12:04:54.711653+01:00",
+              "updated_at": "2025-03-19T12:04:54.711661+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:12.933964+01:00",
-          "updated_at": "2024-12-11T16:45:15.502403+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.709550+01:00",
+          "updated_at": "2025-03-19T12:04:55.670092+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -25268,8 +24447,8 @@
           "previous": null,
           "results": [
             {
-              "created_at": "2024-12-11T16:45:20.454046+01:00",
-              "updated_at": "2024-12-11T16:45:20.454066+01:00",
+              "created_at": "2025-03-19T12:04:57.705722+01:00",
+              "updated_at": "2025-03-19T12:04:57.705730+01:00",
               "name": "fubar.example.org",
               "ttl": null,
               "zone": 1,
@@ -25302,23 +24481,23 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:15.977555+01:00",
-              "updated_at": "2024-12-11T16:45:16.676520+01:00",
+              "created_at": "2025-03-19T12:04:55.834780+01:00",
+              "updated_at": "2025-03-19T12:04:56.162642+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2024-12-11T16:45:16.291195+01:00",
-              "updated_at": "2024-12-11T16:45:16.979511+01:00",
+              "created_at": "2025-03-19T12:04:55.985109+01:00",
+              "updated_at": "2025-03-19T12:04:56.289216+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
           ],
           "cnames": [
             {
-              "created_at": "2024-12-11T16:45:20.454046+01:00",
-              "updated_at": "2024-12-11T16:45:20.454066+01:00",
+              "created_at": "2025-03-19T12:04:57.705722+01:00",
+              "updated_at": "2025-03-19T12:04:57.705730+01:00",
               "name": "fubar.example.org",
               "ttl": null,
               "zone": 1,
@@ -25328,18 +24507,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:12.938227+01:00",
-              "updated_at": "2024-12-11T16:45:12.938240+01:00",
+              "created_at": "2025-03-19T12:04:54.711653+01:00",
+              "updated_at": "2025-03-19T12:04:54.711661+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:12.933964+01:00",
-          "updated_at": "2024-12-11T16:45:15.502403+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.709550+01:00",
+          "updated_at": "2025-03-19T12:04:55.670092+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -25354,8 +24539,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:45:12.363738+01:00",
-          "updated_at": "2024-12-11T16:45:12.363771+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.460376+01:00",
+          "updated_at": "2025-03-19T12:04:54.460385+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -25373,8 +24560,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:45:12.363738+01:00",
-          "updated_at": "2024-12-11T16:45:12.363771+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.460376+01:00",
+          "updated_at": "2025-03-19T12:04:54.460385+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -25383,30 +24572,6 @@
           "location": "",
           "frozen": false,
           "reserved": 3
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/naptrs/?host=14",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/srvs/?host=14",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
         }
       }
     ],
@@ -25433,23 +24598,23 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:15.977555+01:00",
-              "updated_at": "2024-12-11T16:45:16.676520+01:00",
+              "created_at": "2025-03-19T12:04:55.834780+01:00",
+              "updated_at": "2025-03-19T12:04:56.162642+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2024-12-11T16:45:16.291195+01:00",
-              "updated_at": "2024-12-11T16:45:16.979511+01:00",
+              "created_at": "2025-03-19T12:04:55.985109+01:00",
+              "updated_at": "2025-03-19T12:04:56.289216+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
           ],
           "cnames": [
             {
-              "created_at": "2024-12-11T16:45:20.454046+01:00",
-              "updated_at": "2024-12-11T16:45:20.454066+01:00",
+              "created_at": "2025-03-19T12:04:57.705722+01:00",
+              "updated_at": "2025-03-19T12:04:57.705730+01:00",
               "name": "fubar.example.org",
               "ttl": null,
               "zone": 1,
@@ -25459,18 +24624,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:12.938227+01:00",
-              "updated_at": "2024-12-11T16:45:12.938240+01:00",
+              "created_at": "2025-03-19T12:04:54.711653+01:00",
+              "updated_at": "2025-03-19T12:04:54.711661+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:12.933964+01:00",
-          "updated_at": "2024-12-11T16:45:15.502403+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.709550+01:00",
+          "updated_at": "2025-03-19T12:04:55.670092+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -25502,23 +24673,23 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:15.977555+01:00",
-              "updated_at": "2024-12-11T16:45:16.676520+01:00",
+              "created_at": "2025-03-19T12:04:55.834780+01:00",
+              "updated_at": "2025-03-19T12:04:56.162642+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2024-12-11T16:45:16.291195+01:00",
-              "updated_at": "2024-12-11T16:45:16.979511+01:00",
+              "created_at": "2025-03-19T12:04:55.985109+01:00",
+              "updated_at": "2025-03-19T12:04:56.289216+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
           ],
           "cnames": [
             {
-              "created_at": "2024-12-11T16:45:20.454046+01:00",
-              "updated_at": "2024-12-11T16:45:20.454066+01:00",
+              "created_at": "2025-03-19T12:04:57.705722+01:00",
+              "updated_at": "2025-03-19T12:04:57.705730+01:00",
               "name": "fubar.example.org",
               "ttl": null,
               "zone": 1,
@@ -25528,18 +24699,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:12.938227+01:00",
-              "updated_at": "2024-12-11T16:45:12.938240+01:00",
+              "created_at": "2025-03-19T12:04:54.711653+01:00",
+              "updated_at": "2025-03-19T12:04:54.711661+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:12.933964+01:00",
-          "updated_at": "2024-12-11T16:45:15.502403+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.709550+01:00",
+          "updated_at": "2025-03-19T12:04:55.670092+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -25562,8 +24739,8 @@
         "data": {},
         "status": 200,
         "response": {
-          "created_at": "2024-12-11T16:45:20.454046+01:00",
-          "updated_at": "2024-12-11T16:45:20.454066+01:00",
+          "created_at": "2025-03-19T12:04:57.705722+01:00",
+          "updated_at": "2025-03-19T12:04:57.705730+01:00",
           "name": "fubar.example.org",
           "ttl": null,
           "zone": 1,
@@ -25600,15 +24777,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2024-12-11T16:45:12.965204+01:00",
-              "updated_at": "2024-12-11T16:45:17.976116+01:00",
+              "created_at": "2025-03-19T12:04:54.729053+01:00",
+              "updated_at": "2025-03-19T12:04:56.526058+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2024-12-11T16:45:18.689074+01:00",
-              "updated_at": "2024-12-11T16:45:20.166005+01:00",
+              "created_at": "2025-03-19T12:04:56.923203+01:00",
+              "updated_at": "2025-03-19T12:04:57.546535+01:00",
               "ipaddress": "2001:db8::14",
               "host": 15
             }
@@ -25617,18 +24794,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:17.316836+01:00",
-              "updated_at": "2024-12-11T16:45:17.316858+01:00",
+              "created_at": "2025-03-19T12:04:56.406778+01:00",
+              "updated_at": "2025-03-19T12:04:56.406784+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:17.293046+01:00",
-          "updated_at": "2024-12-11T16:45:17.293070+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:56.405048+01:00",
+          "updated_at": "2025-03-19T12:04:56.405055+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -25647,8 +24830,8 @@
         "status": 201,
         "response": {
           "host": 15,
-          "created_at": "2024-12-11T16:45:21.275602+01:00",
-          "updated_at": "2024-12-11T16:45:21.275631+01:00",
+          "created_at": "2025-03-19T12:04:58.050990+01:00",
+          "updated_at": "2025-03-19T12:04:58.050999+01:00",
           "cpu": "x86",
           "os": "Win"
         }
@@ -25667,15 +24850,15 @@
               "ipaddresses": [
                 {
                   "macaddress": "11:22:33:aa:bb:cc",
-                  "created_at": "2024-12-11T16:45:12.965204+01:00",
-                  "updated_at": "2024-12-11T16:45:17.976116+01:00",
+                  "created_at": "2025-03-19T12:04:54.729053+01:00",
+                  "updated_at": "2025-03-19T12:04:56.526058+01:00",
                   "ipaddress": "10.0.0.10",
                   "host": 15
                 },
                 {
                   "macaddress": "11:22:33:44:55:67",
-                  "created_at": "2024-12-11T16:45:18.689074+01:00",
-                  "updated_at": "2024-12-11T16:45:20.166005+01:00",
+                  "created_at": "2025-03-19T12:04:56.923203+01:00",
+                  "updated_at": "2025-03-19T12:04:57.546535+01:00",
                   "ipaddress": "2001:db8::14",
                   "host": 15
                 }
@@ -25684,24 +24867,30 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2024-12-11T16:45:17.316836+01:00",
-                  "updated_at": "2024-12-11T16:45:17.316858+01:00",
+                  "created_at": "2025-03-19T12:04:56.406778+01:00",
+                  "updated_at": "2025-03-19T12:04:56.406784+01:00",
                   "txt": "v=spf1 -all",
                   "host": 15
                 }
               ],
               "ptr_overrides": [],
+              "srvs": [],
+              "naptrs": [],
+              "sshfps": [],
+              "groups": [],
+              "roles": [],
               "hinfo": {
                 "host": 15,
-                "created_at": "2024-12-11T16:45:21.275602+01:00",
-                "updated_at": "2024-12-11T16:45:21.275631+01:00",
+                "created_at": "2025-03-19T12:04:58.050990+01:00",
+                "updated_at": "2025-03-19T12:04:58.050999+01:00",
                 "cpu": "x86",
                 "os": "Win"
               },
               "loc": null,
               "bacnetid": null,
-              "created_at": "2024-12-11T16:45:17.293046+01:00",
-              "updated_at": "2024-12-11T16:45:17.293070+01:00",
+              "communities": [],
+              "created_at": "2025-03-19T12:04:56.405048+01:00",
+              "updated_at": "2025-03-19T12:04:56.405055+01:00",
               "name": "baz.example.org",
               "contact": "",
               "ttl": null,
@@ -25735,15 +24924,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2024-12-11T16:45:12.965204+01:00",
-              "updated_at": "2024-12-11T16:45:17.976116+01:00",
+              "created_at": "2025-03-19T12:04:54.729053+01:00",
+              "updated_at": "2025-03-19T12:04:56.526058+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2024-12-11T16:45:18.689074+01:00",
-              "updated_at": "2024-12-11T16:45:20.166005+01:00",
+              "created_at": "2025-03-19T12:04:56.923203+01:00",
+              "updated_at": "2025-03-19T12:04:57.546535+01:00",
               "ipaddress": "2001:db8::14",
               "host": 15
             }
@@ -25752,24 +24941,30 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:17.316836+01:00",
-              "updated_at": "2024-12-11T16:45:17.316858+01:00",
+              "created_at": "2025-03-19T12:04:56.406778+01:00",
+              "updated_at": "2025-03-19T12:04:56.406784+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": {
             "host": 15,
-            "created_at": "2024-12-11T16:45:21.275602+01:00",
-            "updated_at": "2024-12-11T16:45:21.275631+01:00",
+            "created_at": "2025-03-19T12:04:58.050990+01:00",
+            "updated_at": "2025-03-19T12:04:58.050999+01:00",
             "cpu": "x86",
             "os": "Win"
           },
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:17.293046+01:00",
-          "updated_at": "2024-12-11T16:45:17.293070+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:56.405048+01:00",
+          "updated_at": "2025-03-19T12:04:56.405055+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -25784,8 +24979,8 @@
         "status": 200,
         "response": {
           "host": 15,
-          "created_at": "2024-12-11T16:45:21.275602+01:00",
-          "updated_at": "2024-12-11T16:45:21.275631+01:00",
+          "created_at": "2025-03-19T12:04:58.050990+01:00",
+          "updated_at": "2025-03-19T12:04:58.050999+01:00",
           "cpu": "x86",
           "os": "Win"
         }
@@ -25814,15 +25009,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2024-12-11T16:45:12.965204+01:00",
-              "updated_at": "2024-12-11T16:45:17.976116+01:00",
+              "created_at": "2025-03-19T12:04:54.729053+01:00",
+              "updated_at": "2025-03-19T12:04:56.526058+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2024-12-11T16:45:18.689074+01:00",
-              "updated_at": "2024-12-11T16:45:20.166005+01:00",
+              "created_at": "2025-03-19T12:04:56.923203+01:00",
+              "updated_at": "2025-03-19T12:04:57.546535+01:00",
               "ipaddress": "2001:db8::14",
               "host": 15
             }
@@ -25831,24 +25026,30 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:17.316836+01:00",
-              "updated_at": "2024-12-11T16:45:17.316858+01:00",
+              "created_at": "2025-03-19T12:04:56.406778+01:00",
+              "updated_at": "2025-03-19T12:04:56.406784+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": {
             "host": 15,
-            "created_at": "2024-12-11T16:45:21.275602+01:00",
-            "updated_at": "2024-12-11T16:45:21.275631+01:00",
+            "created_at": "2025-03-19T12:04:58.050990+01:00",
+            "updated_at": "2025-03-19T12:04:58.050999+01:00",
             "cpu": "x86",
             "os": "Win"
           },
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:17.293046+01:00",
-          "updated_at": "2024-12-11T16:45:17.293070+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:56.405048+01:00",
+          "updated_at": "2025-03-19T12:04:56.405055+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -25863,8 +25064,8 @@
         "status": 200,
         "response": {
           "host": 15,
-          "created_at": "2024-12-11T16:45:21.275602+01:00",
-          "updated_at": "2024-12-11T16:45:21.275631+01:00",
+          "created_at": "2025-03-19T12:04:58.050990+01:00",
+          "updated_at": "2025-03-19T12:04:58.050999+01:00",
           "cpu": "x86",
           "os": "Win"
         }
@@ -25899,15 +25100,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2024-12-11T16:45:12.965204+01:00",
-              "updated_at": "2024-12-11T16:45:17.976116+01:00",
+              "created_at": "2025-03-19T12:04:54.729053+01:00",
+              "updated_at": "2025-03-19T12:04:56.526058+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2024-12-11T16:45:18.689074+01:00",
-              "updated_at": "2024-12-11T16:45:20.166005+01:00",
+              "created_at": "2025-03-19T12:04:56.923203+01:00",
+              "updated_at": "2025-03-19T12:04:57.546535+01:00",
               "ipaddress": "2001:db8::14",
               "host": 15
             }
@@ -25916,18 +25117,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:17.316836+01:00",
-              "updated_at": "2024-12-11T16:45:17.316858+01:00",
+              "created_at": "2025-03-19T12:04:56.406778+01:00",
+              "updated_at": "2025-03-19T12:04:56.406784+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:17.293046+01:00",
-          "updated_at": "2024-12-11T16:45:17.293070+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:56.405048+01:00",
+          "updated_at": "2025-03-19T12:04:56.405055+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -25945,8 +25152,8 @@
         "status": 201,
         "response": {
           "host": 15,
-          "created_at": "2024-12-11T16:45:21.726240+01:00",
-          "updated_at": "2024-12-11T16:45:21.726255+01:00",
+          "created_at": "2025-03-19T12:04:58.273533+01:00",
+          "updated_at": "2025-03-19T12:04:58.273540+01:00",
           "loc": "52 22 23.000 N 4 53 32.000 E -2.00m 0.00m 10000m 10m"
         }
       },
@@ -25964,15 +25171,15 @@
               "ipaddresses": [
                 {
                   "macaddress": "11:22:33:aa:bb:cc",
-                  "created_at": "2024-12-11T16:45:12.965204+01:00",
-                  "updated_at": "2024-12-11T16:45:17.976116+01:00",
+                  "created_at": "2025-03-19T12:04:54.729053+01:00",
+                  "updated_at": "2025-03-19T12:04:56.526058+01:00",
                   "ipaddress": "10.0.0.10",
                   "host": 15
                 },
                 {
                   "macaddress": "11:22:33:44:55:67",
-                  "created_at": "2024-12-11T16:45:18.689074+01:00",
-                  "updated_at": "2024-12-11T16:45:20.166005+01:00",
+                  "created_at": "2025-03-19T12:04:56.923203+01:00",
+                  "updated_at": "2025-03-19T12:04:57.546535+01:00",
                   "ipaddress": "2001:db8::14",
                   "host": 15
                 }
@@ -25981,23 +25188,29 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2024-12-11T16:45:17.316836+01:00",
-                  "updated_at": "2024-12-11T16:45:17.316858+01:00",
+                  "created_at": "2025-03-19T12:04:56.406778+01:00",
+                  "updated_at": "2025-03-19T12:04:56.406784+01:00",
                   "txt": "v=spf1 -all",
                   "host": 15
                 }
               ],
               "ptr_overrides": [],
+              "srvs": [],
+              "naptrs": [],
+              "sshfps": [],
+              "groups": [],
+              "roles": [],
               "hinfo": null,
               "loc": {
                 "host": 15,
-                "created_at": "2024-12-11T16:45:21.726240+01:00",
-                "updated_at": "2024-12-11T16:45:21.726255+01:00",
+                "created_at": "2025-03-19T12:04:58.273533+01:00",
+                "updated_at": "2025-03-19T12:04:58.273540+01:00",
                 "loc": "52 22 23.000 N 4 53 32.000 E -2.00m 0.00m 10000m 10m"
               },
               "bacnetid": null,
-              "created_at": "2024-12-11T16:45:17.293046+01:00",
-              "updated_at": "2024-12-11T16:45:17.293070+01:00",
+              "communities": [],
+              "created_at": "2025-03-19T12:04:56.405048+01:00",
+              "updated_at": "2025-03-19T12:04:56.405055+01:00",
               "name": "baz.example.org",
               "contact": "",
               "ttl": null,
@@ -26031,15 +25244,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2024-12-11T16:45:12.965204+01:00",
-              "updated_at": "2024-12-11T16:45:17.976116+01:00",
+              "created_at": "2025-03-19T12:04:54.729053+01:00",
+              "updated_at": "2025-03-19T12:04:56.526058+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2024-12-11T16:45:18.689074+01:00",
-              "updated_at": "2024-12-11T16:45:20.166005+01:00",
+              "created_at": "2025-03-19T12:04:56.923203+01:00",
+              "updated_at": "2025-03-19T12:04:57.546535+01:00",
               "ipaddress": "2001:db8::14",
               "host": 15
             }
@@ -26048,23 +25261,29 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:17.316836+01:00",
-              "updated_at": "2024-12-11T16:45:17.316858+01:00",
+              "created_at": "2025-03-19T12:04:56.406778+01:00",
+              "updated_at": "2025-03-19T12:04:56.406784+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": {
             "host": 15,
-            "created_at": "2024-12-11T16:45:21.726240+01:00",
-            "updated_at": "2024-12-11T16:45:21.726255+01:00",
+            "created_at": "2025-03-19T12:04:58.273533+01:00",
+            "updated_at": "2025-03-19T12:04:58.273540+01:00",
             "loc": "52 22 23.000 N 4 53 32.000 E -2.00m 0.00m 10000m 10m"
           },
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:17.293046+01:00",
-          "updated_at": "2024-12-11T16:45:17.293070+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:56.405048+01:00",
+          "updated_at": "2025-03-19T12:04:56.405055+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -26096,15 +25315,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2024-12-11T16:45:12.965204+01:00",
-              "updated_at": "2024-12-11T16:45:17.976116+01:00",
+              "created_at": "2025-03-19T12:04:54.729053+01:00",
+              "updated_at": "2025-03-19T12:04:56.526058+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2024-12-11T16:45:18.689074+01:00",
-              "updated_at": "2024-12-11T16:45:20.166005+01:00",
+              "created_at": "2025-03-19T12:04:56.923203+01:00",
+              "updated_at": "2025-03-19T12:04:57.546535+01:00",
               "ipaddress": "2001:db8::14",
               "host": 15
             }
@@ -26113,23 +25332,29 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:17.316836+01:00",
-              "updated_at": "2024-12-11T16:45:17.316858+01:00",
+              "created_at": "2025-03-19T12:04:56.406778+01:00",
+              "updated_at": "2025-03-19T12:04:56.406784+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": {
             "host": 15,
-            "created_at": "2024-12-11T16:45:21.726240+01:00",
-            "updated_at": "2024-12-11T16:45:21.726255+01:00",
+            "created_at": "2025-03-19T12:04:58.273533+01:00",
+            "updated_at": "2025-03-19T12:04:58.273540+01:00",
             "loc": "52 22 23.000 N 4 53 32.000 E -2.00m 0.00m 10000m 10m"
           },
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:17.293046+01:00",
-          "updated_at": "2024-12-11T16:45:17.293070+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:56.405048+01:00",
+          "updated_at": "2025-03-19T12:04:56.405055+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -26167,15 +25392,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2024-12-11T16:45:12.965204+01:00",
-              "updated_at": "2024-12-11T16:45:17.976116+01:00",
+              "created_at": "2025-03-19T12:04:54.729053+01:00",
+              "updated_at": "2025-03-19T12:04:56.526058+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2024-12-11T16:45:18.689074+01:00",
-              "updated_at": "2024-12-11T16:45:20.166005+01:00",
+              "created_at": "2025-03-19T12:04:56.923203+01:00",
+              "updated_at": "2025-03-19T12:04:57.546535+01:00",
               "ipaddress": "2001:db8::14",
               "host": 15
             }
@@ -26184,18 +25409,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:17.316836+01:00",
-              "updated_at": "2024-12-11T16:45:17.316858+01:00",
+              "created_at": "2025-03-19T12:04:56.406778+01:00",
+              "updated_at": "2025-03-19T12:04:56.406784+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:17.293046+01:00",
-          "updated_at": "2024-12-11T16:45:17.293070+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:56.405048+01:00",
+          "updated_at": "2025-03-19T12:04:56.405055+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -26213,8 +25444,8 @@
         },
         "status": 201,
         "response": {
-          "created_at": "2024-12-11T16:45:22.104171+01:00",
-          "updated_at": "2024-12-11T16:45:22.104192+01:00",
+          "created_at": "2025-03-19T12:04:58.495484+01:00",
+          "updated_at": "2025-03-19T12:04:58.495490+01:00",
           "priority": 10,
           "mx": "mail.example.org",
           "host": 15
@@ -26245,15 +25476,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2024-12-11T16:45:12.965204+01:00",
-              "updated_at": "2024-12-11T16:45:17.976116+01:00",
+              "created_at": "2025-03-19T12:04:54.729053+01:00",
+              "updated_at": "2025-03-19T12:04:56.526058+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2024-12-11T16:45:18.689074+01:00",
-              "updated_at": "2024-12-11T16:45:20.166005+01:00",
+              "created_at": "2025-03-19T12:04:56.923203+01:00",
+              "updated_at": "2025-03-19T12:04:57.546535+01:00",
               "ipaddress": "2001:db8::14",
               "host": 15
             }
@@ -26261,8 +25492,8 @@
           "cnames": [],
           "mxs": [
             {
-              "created_at": "2024-12-11T16:45:22.104171+01:00",
-              "updated_at": "2024-12-11T16:45:22.104192+01:00",
+              "created_at": "2025-03-19T12:04:58.495484+01:00",
+              "updated_at": "2025-03-19T12:04:58.495490+01:00",
               "priority": 10,
               "mx": "mail.example.org",
               "host": 15
@@ -26270,18 +25501,24 @@
           ],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:17.316836+01:00",
-              "updated_at": "2024-12-11T16:45:17.316858+01:00",
+              "created_at": "2025-03-19T12:04:56.406778+01:00",
+              "updated_at": "2025-03-19T12:04:56.406784+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:17.293046+01:00",
-          "updated_at": "2024-12-11T16:45:17.293070+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:56.405048+01:00",
+          "updated_at": "2025-03-19T12:04:56.405055+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -26313,15 +25550,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2024-12-11T16:45:12.965204+01:00",
-              "updated_at": "2024-12-11T16:45:17.976116+01:00",
+              "created_at": "2025-03-19T12:04:54.729053+01:00",
+              "updated_at": "2025-03-19T12:04:56.526058+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2024-12-11T16:45:18.689074+01:00",
-              "updated_at": "2024-12-11T16:45:20.166005+01:00",
+              "created_at": "2025-03-19T12:04:56.923203+01:00",
+              "updated_at": "2025-03-19T12:04:57.546535+01:00",
               "ipaddress": "2001:db8::14",
               "host": 15
             }
@@ -26329,8 +25566,8 @@
           "cnames": [],
           "mxs": [
             {
-              "created_at": "2024-12-11T16:45:22.104171+01:00",
-              "updated_at": "2024-12-11T16:45:22.104192+01:00",
+              "created_at": "2025-03-19T12:04:58.495484+01:00",
+              "updated_at": "2025-03-19T12:04:58.495490+01:00",
               "priority": 10,
               "mx": "mail.example.org",
               "host": 15
@@ -26338,18 +25575,24 @@
           ],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:17.316836+01:00",
-              "updated_at": "2024-12-11T16:45:17.316858+01:00",
+              "created_at": "2025-03-19T12:04:56.406778+01:00",
+              "updated_at": "2025-03-19T12:04:56.406784+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:17.293046+01:00",
-          "updated_at": "2024-12-11T16:45:17.293070+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:56.405048+01:00",
+          "updated_at": "2025-03-19T12:04:56.405055+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -26364,8 +25607,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:45:12.363738+01:00",
-          "updated_at": "2024-12-11T16:45:12.363771+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.460376+01:00",
+          "updated_at": "2025-03-19T12:04:54.460385+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -26383,8 +25628,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:45:12.555848+01:00",
-          "updated_at": "2024-12-11T16:45:12.555870+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.536879+01:00",
+          "updated_at": "2025-03-19T12:04:54.536908+01:00",
           "network": "2001:db8::/64",
           "description": "dolor sit amet",
           "vlan": null,
@@ -26393,30 +25640,6 @@
           "location": "",
           "frozen": false,
           "reserved": 3
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/naptrs/?host=15",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/srvs/?host=15",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
         }
       }
     ],
@@ -26443,15 +25666,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2024-12-11T16:45:12.965204+01:00",
-              "updated_at": "2024-12-11T16:45:17.976116+01:00",
+              "created_at": "2025-03-19T12:04:54.729053+01:00",
+              "updated_at": "2025-03-19T12:04:56.526058+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2024-12-11T16:45:18.689074+01:00",
-              "updated_at": "2024-12-11T16:45:20.166005+01:00",
+              "created_at": "2025-03-19T12:04:56.923203+01:00",
+              "updated_at": "2025-03-19T12:04:57.546535+01:00",
               "ipaddress": "2001:db8::14",
               "host": 15
             }
@@ -26459,8 +25682,8 @@
           "cnames": [],
           "mxs": [
             {
-              "created_at": "2024-12-11T16:45:22.104171+01:00",
-              "updated_at": "2024-12-11T16:45:22.104192+01:00",
+              "created_at": "2025-03-19T12:04:58.495484+01:00",
+              "updated_at": "2025-03-19T12:04:58.495490+01:00",
               "priority": 10,
               "mx": "mail.example.org",
               "host": 15
@@ -26468,18 +25691,24 @@
           ],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:17.316836+01:00",
-              "updated_at": "2024-12-11T16:45:17.316858+01:00",
+              "created_at": "2025-03-19T12:04:56.406778+01:00",
+              "updated_at": "2025-03-19T12:04:56.406784+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:17.293046+01:00",
-          "updated_at": "2024-12-11T16:45:17.293070+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:56.405048+01:00",
+          "updated_at": "2025-03-19T12:04:56.405055+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -26498,8 +25727,8 @@
           "previous": null,
           "results": [
             {
-              "created_at": "2024-12-11T16:45:22.104171+01:00",
-              "updated_at": "2024-12-11T16:45:22.104192+01:00",
+              "created_at": "2025-03-19T12:04:58.495484+01:00",
+              "updated_at": "2025-03-19T12:04:58.495490+01:00",
               "priority": 10,
               "mx": "mail.example.org",
               "host": 15
@@ -26537,15 +25766,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2024-12-11T16:45:12.965204+01:00",
-              "updated_at": "2024-12-11T16:45:17.976116+01:00",
+              "created_at": "2025-03-19T12:04:54.729053+01:00",
+              "updated_at": "2025-03-19T12:04:56.526058+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2024-12-11T16:45:18.689074+01:00",
-              "updated_at": "2024-12-11T16:45:20.166005+01:00",
+              "created_at": "2025-03-19T12:04:56.923203+01:00",
+              "updated_at": "2025-03-19T12:04:57.546535+01:00",
               "ipaddress": "2001:db8::14",
               "host": 15
             }
@@ -26554,18 +25783,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:17.316836+01:00",
-              "updated_at": "2024-12-11T16:45:17.316858+01:00",
+              "created_at": "2025-03-19T12:04:56.406778+01:00",
+              "updated_at": "2025-03-19T12:04:56.406784+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:17.293046+01:00",
-          "updated_at": "2024-12-11T16:45:17.293070+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:56.405048+01:00",
+          "updated_at": "2025-03-19T12:04:56.405055+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -26599,8 +25834,8 @@
         },
         "status": 201,
         "response": {
-          "created_at": "2024-12-11T16:45:22.749075+01:00",
-          "updated_at": "2024-12-11T16:45:22.749092+01:00",
+          "created_at": "2025-03-19T12:04:58.730998+01:00",
+          "updated_at": "2025-03-19T12:04:58.731005+01:00",
           "preference": 16384,
           "order": 3,
           "flag": "u",
@@ -26635,15 +25870,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2024-12-11T16:45:12.965204+01:00",
-              "updated_at": "2024-12-11T16:45:17.976116+01:00",
+              "created_at": "2025-03-19T12:04:54.729053+01:00",
+              "updated_at": "2025-03-19T12:04:56.526058+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2024-12-11T16:45:18.689074+01:00",
-              "updated_at": "2024-12-11T16:45:20.166005+01:00",
+              "created_at": "2025-03-19T12:04:56.923203+01:00",
+              "updated_at": "2025-03-19T12:04:57.546535+01:00",
               "ipaddress": "2001:db8::14",
               "host": 15
             }
@@ -26652,38 +25887,18 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:17.316836+01:00",
-              "updated_at": "2024-12-11T16:45:17.316858+01:00",
+              "created_at": "2025-03-19T12:04:56.406778+01:00",
+              "updated_at": "2025-03-19T12:04:56.406784+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
           ],
           "ptr_overrides": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "created_at": "2024-12-11T16:45:17.293046+01:00",
-          "updated_at": "2024-12-11T16:45:17.293070+01:00",
-          "name": "baz.example.org",
-          "contact": "",
-          "ttl": null,
-          "comment": "",
-          "zone": 1
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/naptrs/?host=15",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
+          "srvs": [],
+          "naptrs": [
             {
-              "created_at": "2024-12-11T16:45:22.749075+01:00",
-              "updated_at": "2024-12-11T16:45:22.749092+01:00",
+              "created_at": "2025-03-19T12:04:58.730998+01:00",
+              "updated_at": "2025-03-19T12:04:58.731005+01:00",
               "preference": 16384,
               "order": 3,
               "flag": "u",
@@ -26692,7 +25907,21 @@
               "replacement": "wonk",
               "host": 15
             }
-          ]
+          ],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
+          "hinfo": null,
+          "loc": null,
+          "bacnetid": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:56.405048+01:00",
+          "updated_at": "2025-03-19T12:04:56.405055+01:00",
+          "name": "baz.example.org",
+          "contact": "",
+          "ttl": null,
+          "comment": "",
+          "zone": 1
         }
       }
     ],
@@ -26719,15 +25948,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2024-12-11T16:45:12.965204+01:00",
-              "updated_at": "2024-12-11T16:45:17.976116+01:00",
+              "created_at": "2025-03-19T12:04:54.729053+01:00",
+              "updated_at": "2025-03-19T12:04:56.526058+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2024-12-11T16:45:18.689074+01:00",
-              "updated_at": "2024-12-11T16:45:20.166005+01:00",
+              "created_at": "2025-03-19T12:04:56.923203+01:00",
+              "updated_at": "2025-03-19T12:04:57.546535+01:00",
               "ipaddress": "2001:db8::14",
               "host": 15
             }
@@ -26736,38 +25965,18 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:17.316836+01:00",
-              "updated_at": "2024-12-11T16:45:17.316858+01:00",
+              "created_at": "2025-03-19T12:04:56.406778+01:00",
+              "updated_at": "2025-03-19T12:04:56.406784+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
           ],
           "ptr_overrides": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "created_at": "2024-12-11T16:45:17.293046+01:00",
-          "updated_at": "2024-12-11T16:45:17.293070+01:00",
-          "name": "baz.example.org",
-          "contact": "",
-          "ttl": null,
-          "comment": "",
-          "zone": 1
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/naptrs/?host=15",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
+          "srvs": [],
+          "naptrs": [
             {
-              "created_at": "2024-12-11T16:45:22.749075+01:00",
-              "updated_at": "2024-12-11T16:45:22.749092+01:00",
+              "created_at": "2025-03-19T12:04:58.730998+01:00",
+              "updated_at": "2025-03-19T12:04:58.731005+01:00",
               "preference": 16384,
               "order": 3,
               "flag": "u",
@@ -26776,7 +25985,21 @@
               "replacement": "wonk",
               "host": 15
             }
-          ]
+          ],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
+          "hinfo": null,
+          "loc": null,
+          "bacnetid": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:56.405048+01:00",
+          "updated_at": "2025-03-19T12:04:56.405055+01:00",
+          "name": "baz.example.org",
+          "contact": "",
+          "ttl": null,
+          "comment": "",
+          "zone": 1
         }
       },
       {
@@ -26809,15 +26032,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2024-12-11T16:45:12.965204+01:00",
-              "updated_at": "2024-12-11T16:45:17.976116+01:00",
+              "created_at": "2025-03-19T12:04:54.729053+01:00",
+              "updated_at": "2025-03-19T12:04:56.526058+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2024-12-11T16:45:18.689074+01:00",
-              "updated_at": "2024-12-11T16:45:20.166005+01:00",
+              "created_at": "2025-03-19T12:04:56.923203+01:00",
+              "updated_at": "2025-03-19T12:04:57.546535+01:00",
               "ipaddress": "2001:db8::14",
               "host": 15
             }
@@ -26826,18 +26049,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:17.316836+01:00",
-              "updated_at": "2024-12-11T16:45:17.316858+01:00",
+              "created_at": "2025-03-19T12:04:56.406778+01:00",
+              "updated_at": "2025-03-19T12:04:56.406784+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:17.293046+01:00",
-          "updated_at": "2024-12-11T16:45:17.293070+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:56.405048+01:00",
+          "updated_at": "2025-03-19T12:04:56.405055+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -26864,8 +26093,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:45:12.363738+01:00",
-          "updated_at": "2024-12-11T16:45:12.363771+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.460376+01:00",
+          "updated_at": "2025-03-19T12:04:54.460385+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -26898,8 +26129,8 @@
         },
         "status": 201,
         "response": {
-          "created_at": "2024-12-11T16:45:23.272704+01:00",
-          "updated_at": "2024-12-11T16:45:23.272722+01:00",
+          "created_at": "2025-03-19T12:04:58.922958+01:00",
+          "updated_at": "2025-03-19T12:04:58.922966+01:00",
           "ipaddress": "10.0.0.20",
           "host": 15
         }
@@ -26945,15 +26176,15 @@
               "ipaddresses": [
                 {
                   "macaddress": "11:22:33:aa:bb:cc",
-                  "created_at": "2024-12-11T16:45:12.965204+01:00",
-                  "updated_at": "2024-12-11T16:45:17.976116+01:00",
+                  "created_at": "2025-03-19T12:04:54.729053+01:00",
+                  "updated_at": "2025-03-19T12:04:56.526058+01:00",
                   "ipaddress": "10.0.0.10",
                   "host": 15
                 },
                 {
                   "macaddress": "11:22:33:44:55:67",
-                  "created_at": "2024-12-11T16:45:18.689074+01:00",
-                  "updated_at": "2024-12-11T16:45:20.166005+01:00",
+                  "created_at": "2025-03-19T12:04:56.923203+01:00",
+                  "updated_at": "2025-03-19T12:04:57.546535+01:00",
                   "ipaddress": "2001:db8::14",
                   "host": 15
                 }
@@ -26962,25 +26193,31 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2024-12-11T16:45:17.316836+01:00",
-                  "updated_at": "2024-12-11T16:45:17.316858+01:00",
+                  "created_at": "2025-03-19T12:04:56.406778+01:00",
+                  "updated_at": "2025-03-19T12:04:56.406784+01:00",
                   "txt": "v=spf1 -all",
                   "host": 15
                 }
               ],
               "ptr_overrides": [
                 {
-                  "created_at": "2024-12-11T16:45:23.272704+01:00",
-                  "updated_at": "2024-12-11T16:45:23.272722+01:00",
+                  "created_at": "2025-03-19T12:04:58.922958+01:00",
+                  "updated_at": "2025-03-19T12:04:58.922966+01:00",
                   "ipaddress": "10.0.0.20",
                   "host": 15
                 }
               ],
+              "srvs": [],
+              "naptrs": [],
+              "sshfps": [],
+              "groups": [],
+              "roles": [],
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
-              "created_at": "2024-12-11T16:45:17.293046+01:00",
-              "updated_at": "2024-12-11T16:45:17.293070+01:00",
+              "communities": [],
+              "created_at": "2025-03-19T12:04:56.405048+01:00",
+              "updated_at": "2025-03-19T12:04:56.405055+01:00",
               "name": "baz.example.org",
               "contact": "",
               "ttl": null,
@@ -27004,15 +26241,15 @@
               "ipaddresses": [
                 {
                   "macaddress": "11:22:33:aa:bb:cc",
-                  "created_at": "2024-12-11T16:45:12.965204+01:00",
-                  "updated_at": "2024-12-11T16:45:17.976116+01:00",
+                  "created_at": "2025-03-19T12:04:54.729053+01:00",
+                  "updated_at": "2025-03-19T12:04:56.526058+01:00",
                   "ipaddress": "10.0.0.10",
                   "host": 15
                 },
                 {
                   "macaddress": "11:22:33:44:55:67",
-                  "created_at": "2024-12-11T16:45:18.689074+01:00",
-                  "updated_at": "2024-12-11T16:45:20.166005+01:00",
+                  "created_at": "2025-03-19T12:04:56.923203+01:00",
+                  "updated_at": "2025-03-19T12:04:57.546535+01:00",
                   "ipaddress": "2001:db8::14",
                   "host": 15
                 }
@@ -27021,25 +26258,31 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2024-12-11T16:45:17.316836+01:00",
-                  "updated_at": "2024-12-11T16:45:17.316858+01:00",
+                  "created_at": "2025-03-19T12:04:56.406778+01:00",
+                  "updated_at": "2025-03-19T12:04:56.406784+01:00",
                   "txt": "v=spf1 -all",
                   "host": 15
                 }
               ],
               "ptr_overrides": [
                 {
-                  "created_at": "2024-12-11T16:45:23.272704+01:00",
-                  "updated_at": "2024-12-11T16:45:23.272722+01:00",
+                  "created_at": "2025-03-19T12:04:58.922958+01:00",
+                  "updated_at": "2025-03-19T12:04:58.922966+01:00",
                   "ipaddress": "10.0.0.20",
                   "host": 15
                 }
               ],
+              "srvs": [],
+              "naptrs": [],
+              "sshfps": [],
+              "groups": [],
+              "roles": [],
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
-              "created_at": "2024-12-11T16:45:17.293046+01:00",
-              "updated_at": "2024-12-11T16:45:17.293070+01:00",
+              "communities": [],
+              "created_at": "2025-03-19T12:04:56.405048+01:00",
+              "updated_at": "2025-03-19T12:04:56.405055+01:00",
               "name": "baz.example.org",
               "contact": "",
               "ttl": null,
@@ -27067,8 +26310,8 @@
       "Contact:      ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Wed Dec 11 16:45:23 2024",
-      "Updated:      Wed Dec 11 16:45:23 2024"
+      "Created:      Wed Mar 19 12:04:59 2025",
+      "Updated:      Wed Mar 19 12:04:59 2025"
     ],
     "api_requests": [
       {
@@ -27098,18 +26341,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2024-12-11T16:44:40.356452+01:00",
-                "updated_at": "2024-12-11T16:44:40.356481+01:00",
+                "created_at": "2025-03-19T12:04:41.191611+01:00",
+                "updated_at": "2025-03-19T12:04:41.191623+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2024-12-11T16:44:39.701254+01:00",
-            "updated_at": "2024-12-11T16:45:23.262277+01:00",
+            "created_at": "2025-03-19T12:04:40.912310+01:00",
+            "updated_at": "2025-03-19T12:04:58.921960+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
+            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -27138,83 +26381,29 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:23.750260+01:00",
-              "updated_at": "2024-12-11T16:45:23.750274+01:00",
+              "created_at": "2025-03-19T12:04:59.135486+01:00",
+              "updated_at": "2025-03-19T12:04:59.135492+01:00",
               "txt": "v=spf1 -all",
               "host": 16
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:23.732624+01:00",
-          "updated_at": "2024-12-11T16:45:23.732643+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:59.133822+01:00",
+          "updated_at": "2025-03-19T12:04:59.133829+01:00",
           "name": "clover.example.org",
           "contact": "",
           "ttl": null,
           "comment": "",
           "zone": 1
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/srvs/?host=16",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/naptrs/?host=16",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/sshfps/?host=16",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hostpolicy/roles/?hosts=16",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hostgroups/?hosts=16",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
         }
       }
     ],
@@ -27241,15 +26430,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2024-12-11T16:45:12.965204+01:00",
-              "updated_at": "2024-12-11T16:45:17.976116+01:00",
+              "created_at": "2025-03-19T12:04:54.729053+01:00",
+              "updated_at": "2025-03-19T12:04:56.526058+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2024-12-11T16:45:18.689074+01:00",
-              "updated_at": "2024-12-11T16:45:20.166005+01:00",
+              "created_at": "2025-03-19T12:04:56.923203+01:00",
+              "updated_at": "2025-03-19T12:04:57.546535+01:00",
               "ipaddress": "2001:db8::14",
               "host": 15
             }
@@ -27258,25 +26447,31 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:17.316836+01:00",
-              "updated_at": "2024-12-11T16:45:17.316858+01:00",
+              "created_at": "2025-03-19T12:04:56.406778+01:00",
+              "updated_at": "2025-03-19T12:04:56.406784+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
           ],
           "ptr_overrides": [
             {
-              "created_at": "2024-12-11T16:45:23.272704+01:00",
-              "updated_at": "2024-12-11T16:45:23.272722+01:00",
+              "created_at": "2025-03-19T12:04:58.922958+01:00",
+              "updated_at": "2025-03-19T12:04:58.922966+01:00",
               "ipaddress": "10.0.0.20",
               "host": 15
             }
           ],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:17.293046+01:00",
-          "updated_at": "2024-12-11T16:45:17.293070+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:56.405048+01:00",
+          "updated_at": "2025-03-19T12:04:56.405055+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -27295,18 +26490,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:23.750260+01:00",
-              "updated_at": "2024-12-11T16:45:23.750274+01:00",
+              "created_at": "2025-03-19T12:04:59.135486+01:00",
+              "updated_at": "2025-03-19T12:04:59.135492+01:00",
               "txt": "v=spf1 -all",
               "host": 16
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:23.732624+01:00",
-          "updated_at": "2024-12-11T16:45:23.732643+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:59.133822+01:00",
+          "updated_at": "2025-03-19T12:04:59.133829+01:00",
           "name": "clover.example.org",
           "contact": "",
           "ttl": null,
@@ -27328,8 +26529,8 @@
         "data": {},
         "status": 200,
         "response": {
-          "created_at": "2024-12-11T16:45:23.272704+01:00",
-          "updated_at": "2024-12-11T16:45:24.254413+01:00",
+          "created_at": "2025-03-19T12:04:58.922958+01:00",
+          "updated_at": "2025-03-19T12:04:59.254954+01:00",
           "ipaddress": "10.0.0.20",
           "host": 16
         }
@@ -27360,25 +26561,31 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:23.750260+01:00",
-              "updated_at": "2024-12-11T16:45:23.750274+01:00",
+              "created_at": "2025-03-19T12:04:59.135486+01:00",
+              "updated_at": "2025-03-19T12:04:59.135492+01:00",
               "txt": "v=spf1 -all",
               "host": 16
             }
           ],
           "ptr_overrides": [
             {
-              "created_at": "2024-12-11T16:45:23.272704+01:00",
-              "updated_at": "2024-12-11T16:45:24.254413+01:00",
+              "created_at": "2025-03-19T12:04:58.922958+01:00",
+              "updated_at": "2025-03-19T12:04:59.254954+01:00",
               "ipaddress": "10.0.0.20",
               "host": 16
             }
           ],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:23.732624+01:00",
-          "updated_at": "2024-12-11T16:45:23.732643+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:59.133822+01:00",
+          "updated_at": "2025-03-19T12:04:59.133829+01:00",
           "name": "clover.example.org",
           "contact": "",
           "ttl": null,
@@ -27428,15 +26635,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2024-12-11T16:45:12.965204+01:00",
-              "updated_at": "2024-12-11T16:45:17.976116+01:00",
+              "created_at": "2025-03-19T12:04:54.729053+01:00",
+              "updated_at": "2025-03-19T12:04:56.526058+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2024-12-11T16:45:18.689074+01:00",
-              "updated_at": "2024-12-11T16:45:20.166005+01:00",
+              "created_at": "2025-03-19T12:04:56.923203+01:00",
+              "updated_at": "2025-03-19T12:04:57.546535+01:00",
               "ipaddress": "2001:db8::14",
               "host": 15
             }
@@ -27445,18 +26652,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:17.316836+01:00",
-              "updated_at": "2024-12-11T16:45:17.316858+01:00",
+              "created_at": "2025-03-19T12:04:56.406778+01:00",
+              "updated_at": "2025-03-19T12:04:56.406784+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:17.293046+01:00",
-          "updated_at": "2024-12-11T16:45:17.293070+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:56.405048+01:00",
+          "updated_at": "2025-03-19T12:04:56.405055+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -27473,18 +26686,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2024-12-11T16:44:40.356452+01:00",
-                "updated_at": "2024-12-11T16:44:40.356481+01:00",
+                "created_at": "2025-03-19T12:04:41.191611+01:00",
+                "updated_at": "2025-03-19T12:04:41.191623+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2024-12-11T16:44:39.701254+01:00",
-            "updated_at": "2024-12-11T16:45:24.423238+01:00",
+            "created_at": "2025-03-19T12:04:40.912310+01:00",
+            "updated_at": "2025-03-19T12:04:59.377812+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
+            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -27503,18 +26716,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2024-12-11T16:44:40.356452+01:00",
-                "updated_at": "2024-12-11T16:44:40.356481+01:00",
+                "created_at": "2025-03-19T12:04:41.191611+01:00",
+                "updated_at": "2025-03-19T12:04:41.191623+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2024-12-11T16:44:39.701254+01:00",
-            "updated_at": "2024-12-11T16:45:24.423238+01:00",
+            "created_at": "2025-03-19T12:04:40.912310+01:00",
+            "updated_at": "2025-03-19T12:04:59.377812+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
+            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -27577,15 +26790,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2024-12-11T16:45:12.965204+01:00",
-              "updated_at": "2024-12-11T16:45:17.976116+01:00",
+              "created_at": "2025-03-19T12:04:54.729053+01:00",
+              "updated_at": "2025-03-19T12:04:56.526058+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2024-12-11T16:45:18.689074+01:00",
-              "updated_at": "2024-12-11T16:45:20.166005+01:00",
+              "created_at": "2025-03-19T12:04:56.923203+01:00",
+              "updated_at": "2025-03-19T12:04:57.546535+01:00",
               "ipaddress": "2001:db8::14",
               "host": 15
             }
@@ -27594,18 +26807,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:17.316836+01:00",
-              "updated_at": "2024-12-11T16:45:17.316858+01:00",
+              "created_at": "2025-03-19T12:04:56.406778+01:00",
+              "updated_at": "2025-03-19T12:04:56.406784+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:17.293046+01:00",
-          "updated_at": "2024-12-11T16:45:17.293070+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:56.405048+01:00",
+          "updated_at": "2025-03-19T12:04:56.405055+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -27622,18 +26841,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2024-12-11T16:44:40.356452+01:00",
-                "updated_at": "2024-12-11T16:44:40.356481+01:00",
+                "created_at": "2025-03-19T12:04:41.191611+01:00",
+                "updated_at": "2025-03-19T12:04:41.191623+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2024-12-11T16:44:39.701254+01:00",
-            "updated_at": "2024-12-11T16:45:24.423238+01:00",
+            "created_at": "2025-03-19T12:04:40.912310+01:00",
+            "updated_at": "2025-03-19T12:04:59.377812+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
+            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -27652,18 +26871,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2024-12-11T16:44:40.356452+01:00",
-                "updated_at": "2024-12-11T16:44:40.356481+01:00",
+                "created_at": "2025-03-19T12:04:41.191611+01:00",
+                "updated_at": "2025-03-19T12:04:41.191623+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2024-12-11T16:44:39.701254+01:00",
-            "updated_at": "2024-12-11T16:45:24.423238+01:00",
+            "created_at": "2025-03-19T12:04:40.912310+01:00",
+            "updated_at": "2025-03-19T12:04:59.377812+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
+            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -27697,8 +26916,8 @@
         },
         "status": 201,
         "response": {
-          "created_at": "2024-12-11T16:45:25.058544+01:00",
-          "updated_at": "2024-12-11T16:45:25.058565+01:00",
+          "created_at": "2025-03-19T12:04:59.609581+01:00",
+          "updated_at": "2025-03-19T12:04:59.609589+01:00",
           "name": "_sip._tcp.example.org",
           "priority": 10,
           "weight": 5,
@@ -27734,8 +26953,8 @@
           "previous": null,
           "results": [
             {
-              "created_at": "2024-12-11T16:45:25.058544+01:00",
-              "updated_at": "2024-12-11T16:45:25.058565+01:00",
+              "created_at": "2025-03-19T12:04:59.609581+01:00",
+              "updated_at": "2025-03-19T12:04:59.609589+01:00",
               "name": "_sip._tcp.example.org",
               "priority": 10,
               "weight": 5,
@@ -27761,15 +26980,15 @@
               "ipaddresses": [
                 {
                   "macaddress": "11:22:33:aa:bb:cc",
-                  "created_at": "2024-12-11T16:45:12.965204+01:00",
-                  "updated_at": "2024-12-11T16:45:17.976116+01:00",
+                  "created_at": "2025-03-19T12:04:54.729053+01:00",
+                  "updated_at": "2025-03-19T12:04:56.526058+01:00",
                   "ipaddress": "10.0.0.10",
                   "host": 15
                 },
                 {
                   "macaddress": "11:22:33:44:55:67",
-                  "created_at": "2024-12-11T16:45:18.689074+01:00",
-                  "updated_at": "2024-12-11T16:45:20.166005+01:00",
+                  "created_at": "2025-03-19T12:04:56.923203+01:00",
+                  "updated_at": "2025-03-19T12:04:57.546535+01:00",
                   "ipaddress": "2001:db8::14",
                   "host": 15
                 }
@@ -27778,18 +26997,36 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2024-12-11T16:45:17.316836+01:00",
-                  "updated_at": "2024-12-11T16:45:17.316858+01:00",
+                  "created_at": "2025-03-19T12:04:56.406778+01:00",
+                  "updated_at": "2025-03-19T12:04:56.406784+01:00",
                   "txt": "v=spf1 -all",
                   "host": 15
                 }
               ],
               "ptr_overrides": [],
+              "srvs": [
+                {
+                  "created_at": "2025-03-19T12:04:59.609581+01:00",
+                  "updated_at": "2025-03-19T12:04:59.609589+01:00",
+                  "name": "_sip._tcp.example.org",
+                  "priority": 10,
+                  "weight": 5,
+                  "port": 3456,
+                  "ttl": null,
+                  "zone": 1,
+                  "host": 15
+                }
+              ],
+              "naptrs": [],
+              "sshfps": [],
+              "groups": [],
+              "roles": [],
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
-              "created_at": "2024-12-11T16:45:17.293046+01:00",
-              "updated_at": "2024-12-11T16:45:17.293070+01:00",
+              "communities": [],
+              "created_at": "2025-03-19T12:04:56.405048+01:00",
+              "updated_at": "2025-03-19T12:04:56.405055+01:00",
               "name": "baz.example.org",
               "contact": "",
               "ttl": null,
@@ -27823,15 +27060,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2024-12-11T16:45:12.965204+01:00",
-              "updated_at": "2024-12-11T16:45:17.976116+01:00",
+              "created_at": "2025-03-19T12:04:54.729053+01:00",
+              "updated_at": "2025-03-19T12:04:56.526058+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2024-12-11T16:45:18.689074+01:00",
-              "updated_at": "2024-12-11T16:45:20.166005+01:00",
+              "created_at": "2025-03-19T12:04:56.923203+01:00",
+              "updated_at": "2025-03-19T12:04:57.546535+01:00",
               "ipaddress": "2001:db8::14",
               "host": 15
             }
@@ -27840,18 +27077,36 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:17.316836+01:00",
-              "updated_at": "2024-12-11T16:45:17.316858+01:00",
+              "created_at": "2025-03-19T12:04:56.406778+01:00",
+              "updated_at": "2025-03-19T12:04:56.406784+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
           ],
           "ptr_overrides": [],
+          "srvs": [
+            {
+              "created_at": "2025-03-19T12:04:59.609581+01:00",
+              "updated_at": "2025-03-19T12:04:59.609589+01:00",
+              "name": "_sip._tcp.example.org",
+              "priority": 10,
+              "weight": 5,
+              "port": 3456,
+              "ttl": null,
+              "zone": 1,
+              "host": 15
+            }
+          ],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:17.293046+01:00",
-          "updated_at": "2024-12-11T16:45:17.293070+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:56.405048+01:00",
+          "updated_at": "2025-03-19T12:04:56.405055+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -27870,8 +27125,8 @@
           "previous": null,
           "results": [
             {
-              "created_at": "2024-12-11T16:45:25.058544+01:00",
-              "updated_at": "2024-12-11T16:45:25.058565+01:00",
+              "created_at": "2025-03-19T12:04:59.609581+01:00",
+              "updated_at": "2025-03-19T12:04:59.609589+01:00",
               "name": "_sip._tcp.example.org",
               "priority": 10,
               "weight": 5,
@@ -27913,15 +27168,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:15.977555+01:00",
-              "updated_at": "2024-12-11T16:45:16.676520+01:00",
+              "created_at": "2025-03-19T12:04:55.834780+01:00",
+              "updated_at": "2025-03-19T12:04:56.162642+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2024-12-11T16:45:16.291195+01:00",
-              "updated_at": "2024-12-11T16:45:16.979511+01:00",
+              "created_at": "2025-03-19T12:04:55.985109+01:00",
+              "updated_at": "2025-03-19T12:04:56.289216+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
@@ -27930,18 +27185,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:12.938227+01:00",
-              "updated_at": "2024-12-11T16:45:12.938240+01:00",
+              "created_at": "2025-03-19T12:04:54.711653+01:00",
+              "updated_at": "2025-03-19T12:04:54.711661+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:12.933964+01:00",
-          "updated_at": "2024-12-11T16:45:15.502403+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.709550+01:00",
+          "updated_at": "2025-03-19T12:04:55.670092+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -27972,8 +27233,8 @@
         },
         "status": 201,
         "response": {
-          "created_at": "2024-12-11T16:45:25.629669+01:00",
-          "updated_at": "2024-12-11T16:45:25.629690+01:00",
+          "created_at": "2025-03-19T12:04:59.845247+01:00",
+          "updated_at": "2025-03-19T12:04:59.845254+01:00",
           "ttl": null,
           "algorithm": 1,
           "hash_type": 1,
@@ -28006,15 +27267,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:15.977555+01:00",
-              "updated_at": "2024-12-11T16:45:16.676520+01:00",
+              "created_at": "2025-03-19T12:04:55.834780+01:00",
+              "updated_at": "2025-03-19T12:04:56.162642+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2024-12-11T16:45:16.291195+01:00",
-              "updated_at": "2024-12-11T16:45:16.979511+01:00",
+              "created_at": "2025-03-19T12:04:55.985109+01:00",
+              "updated_at": "2025-03-19T12:04:56.289216+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
@@ -28023,45 +27284,39 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:12.938227+01:00",
-              "updated_at": "2024-12-11T16:45:12.938240+01:00",
+              "created_at": "2025-03-19T12:04:54.711653+01:00",
+              "updated_at": "2025-03-19T12:04:54.711661+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
           ],
           "ptr_overrides": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "created_at": "2024-12-11T16:45:12.933964+01:00",
-          "updated_at": "2024-12-11T16:45:15.502403+01:00",
-          "name": "bar.example.org",
-          "contact": "me@example.org",
-          "ttl": null,
-          "comment": "This is the comment",
-          "zone": 1
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/sshfps/?host=14",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [
             {
-              "created_at": "2024-12-11T16:45:25.629669+01:00",
-              "updated_at": "2024-12-11T16:45:25.629690+01:00",
+              "created_at": "2025-03-19T12:04:59.845247+01:00",
+              "updated_at": "2025-03-19T12:04:59.845254+01:00",
               "ttl": null,
               "algorithm": 1,
               "hash_type": 1,
               "fingerprint": "12345678abcde",
               "host": 14
             }
-          ]
+          ],
+          "groups": [],
+          "roles": [],
+          "hinfo": null,
+          "loc": null,
+          "bacnetid": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.709550+01:00",
+          "updated_at": "2025-03-19T12:04:55.670092+01:00",
+          "name": "bar.example.org",
+          "contact": "me@example.org",
+          "ttl": null,
+          "comment": "This is the comment",
+          "zone": 1
         }
       }
     ],
@@ -28088,15 +27343,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:15.977555+01:00",
-              "updated_at": "2024-12-11T16:45:16.676520+01:00",
+              "created_at": "2025-03-19T12:04:55.834780+01:00",
+              "updated_at": "2025-03-19T12:04:56.162642+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2024-12-11T16:45:16.291195+01:00",
-              "updated_at": "2024-12-11T16:45:16.979511+01:00",
+              "created_at": "2025-03-19T12:04:55.985109+01:00",
+              "updated_at": "2025-03-19T12:04:56.289216+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
@@ -28105,18 +27360,34 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:12.938227+01:00",
-              "updated_at": "2024-12-11T16:45:12.938240+01:00",
+              "created_at": "2025-03-19T12:04:54.711653+01:00",
+              "updated_at": "2025-03-19T12:04:54.711661+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [
+            {
+              "created_at": "2025-03-19T12:04:59.845247+01:00",
+              "updated_at": "2025-03-19T12:04:59.845254+01:00",
+              "ttl": null,
+              "algorithm": 1,
+              "hash_type": 1,
+              "fingerprint": "12345678abcde",
+              "host": 14
+            }
+          ],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:12.933964+01:00",
-          "updated_at": "2024-12-11T16:45:15.502403+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.709550+01:00",
+          "updated_at": "2025-03-19T12:04:55.670092+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -28160,15 +27431,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:15.977555+01:00",
-              "updated_at": "2024-12-11T16:45:16.676520+01:00",
+              "created_at": "2025-03-19T12:04:55.834780+01:00",
+              "updated_at": "2025-03-19T12:04:56.162642+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2024-12-11T16:45:16.291195+01:00",
-              "updated_at": "2024-12-11T16:45:16.979511+01:00",
+              "created_at": "2025-03-19T12:04:55.985109+01:00",
+              "updated_at": "2025-03-19T12:04:56.289216+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
@@ -28177,45 +27448,39 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:12.938227+01:00",
-              "updated_at": "2024-12-11T16:45:12.938240+01:00",
+              "created_at": "2025-03-19T12:04:54.711653+01:00",
+              "updated_at": "2025-03-19T12:04:54.711661+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
           ],
           "ptr_overrides": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "created_at": "2024-12-11T16:45:12.933964+01:00",
-          "updated_at": "2024-12-11T16:45:15.502403+01:00",
-          "name": "bar.example.org",
-          "contact": "me@example.org",
-          "ttl": null,
-          "comment": "This is the comment",
-          "zone": 1
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/sshfps/?host=14",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [
             {
-              "created_at": "2024-12-11T16:45:25.629669+01:00",
-              "updated_at": "2024-12-11T16:45:25.629690+01:00",
+              "created_at": "2025-03-19T12:04:59.845247+01:00",
+              "updated_at": "2025-03-19T12:04:59.845254+01:00",
               "ttl": null,
               "algorithm": 1,
               "hash_type": 1,
               "fingerprint": "12345678abcde",
               "host": 14
             }
-          ]
+          ],
+          "groups": [],
+          "roles": [],
+          "hinfo": null,
+          "loc": null,
+          "bacnetid": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.709550+01:00",
+          "updated_at": "2025-03-19T12:04:55.670092+01:00",
+          "name": "bar.example.org",
+          "contact": "me@example.org",
+          "ttl": null,
+          "comment": "This is the comment",
+          "zone": 1
         }
       },
       {
@@ -28248,15 +27513,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:15.977555+01:00",
-              "updated_at": "2024-12-11T16:45:16.676520+01:00",
+              "created_at": "2025-03-19T12:04:55.834780+01:00",
+              "updated_at": "2025-03-19T12:04:56.162642+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2024-12-11T16:45:16.291195+01:00",
-              "updated_at": "2024-12-11T16:45:16.979511+01:00",
+              "created_at": "2025-03-19T12:04:55.985109+01:00",
+              "updated_at": "2025-03-19T12:04:56.289216+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
@@ -28265,18 +27530,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:12.938227+01:00",
-              "updated_at": "2024-12-11T16:45:12.938240+01:00",
+              "created_at": "2025-03-19T12:04:54.711653+01:00",
+              "updated_at": "2025-03-19T12:04:54.711661+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:12.933964+01:00",
-          "updated_at": "2024-12-11T16:45:15.502403+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.709550+01:00",
+          "updated_at": "2025-03-19T12:04:55.670092+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -28306,15 +27577,15 @@
               "ipaddresses": [
                 {
                   "macaddress": "",
-                  "created_at": "2024-12-11T16:45:15.977555+01:00",
-                  "updated_at": "2024-12-11T16:45:16.676520+01:00",
+                  "created_at": "2025-03-19T12:04:55.834780+01:00",
+                  "updated_at": "2025-03-19T12:04:56.162642+01:00",
                   "ipaddress": "10.0.0.14",
                   "host": 14
                 },
                 {
                   "macaddress": "11:22:33:44:55:66",
-                  "created_at": "2024-12-11T16:45:16.291195+01:00",
-                  "updated_at": "2024-12-11T16:45:16.979511+01:00",
+                  "created_at": "2025-03-19T12:04:55.985109+01:00",
+                  "updated_at": "2025-03-19T12:04:56.289216+01:00",
                   "ipaddress": "10.0.0.15",
                   "host": 14
                 }
@@ -28323,18 +27594,24 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2024-12-11T16:45:12.938227+01:00",
-                  "updated_at": "2024-12-11T16:45:12.938240+01:00",
+                  "created_at": "2025-03-19T12:04:54.711653+01:00",
+                  "updated_at": "2025-03-19T12:04:54.711661+01:00",
                   "txt": "v=spf1 -all",
                   "host": 14
                 }
               ],
               "ptr_overrides": [],
+              "srvs": [],
+              "naptrs": [],
+              "sshfps": [],
+              "groups": [],
+              "roles": [],
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
-              "created_at": "2024-12-11T16:45:12.933964+01:00",
-              "updated_at": "2024-12-11T16:45:26.283495+01:00",
+              "communities": [],
+              "created_at": "2025-03-19T12:04:54.709550+01:00",
+              "updated_at": "2025-03-19T12:05:00.112462+01:00",
               "name": "bar.example.org",
               "contact": "me@example.org",
               "ttl": 3600,
@@ -28368,15 +27645,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:15.977555+01:00",
-              "updated_at": "2024-12-11T16:45:16.676520+01:00",
+              "created_at": "2025-03-19T12:04:55.834780+01:00",
+              "updated_at": "2025-03-19T12:04:56.162642+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2024-12-11T16:45:16.291195+01:00",
-              "updated_at": "2024-12-11T16:45:16.979511+01:00",
+              "created_at": "2025-03-19T12:04:55.985109+01:00",
+              "updated_at": "2025-03-19T12:04:56.289216+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
@@ -28385,18 +27662,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:12.938227+01:00",
-              "updated_at": "2024-12-11T16:45:12.938240+01:00",
+              "created_at": "2025-03-19T12:04:54.711653+01:00",
+              "updated_at": "2025-03-19T12:04:54.711661+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:12.933964+01:00",
-          "updated_at": "2024-12-11T16:45:26.283495+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.709550+01:00",
+          "updated_at": "2025-03-19T12:05:00.112462+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": 3600,
@@ -28428,15 +27711,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:15.977555+01:00",
-              "updated_at": "2024-12-11T16:45:16.676520+01:00",
+              "created_at": "2025-03-19T12:04:55.834780+01:00",
+              "updated_at": "2025-03-19T12:04:56.162642+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2024-12-11T16:45:16.291195+01:00",
-              "updated_at": "2024-12-11T16:45:16.979511+01:00",
+              "created_at": "2025-03-19T12:04:55.985109+01:00",
+              "updated_at": "2025-03-19T12:04:56.289216+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
@@ -28445,18 +27728,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:12.938227+01:00",
-              "updated_at": "2024-12-11T16:45:12.938240+01:00",
+              "created_at": "2025-03-19T12:04:54.711653+01:00",
+              "updated_at": "2025-03-19T12:04:54.711661+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:12.933964+01:00",
-          "updated_at": "2024-12-11T16:45:26.283495+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.709550+01:00",
+          "updated_at": "2025-03-19T12:05:00.112462+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": 3600,
@@ -28486,15 +27775,15 @@
               "ipaddresses": [
                 {
                   "macaddress": "",
-                  "created_at": "2024-12-11T16:45:15.977555+01:00",
-                  "updated_at": "2024-12-11T16:45:16.676520+01:00",
+                  "created_at": "2025-03-19T12:04:55.834780+01:00",
+                  "updated_at": "2025-03-19T12:04:56.162642+01:00",
                   "ipaddress": "10.0.0.14",
                   "host": 14
                 },
                 {
                   "macaddress": "11:22:33:44:55:66",
-                  "created_at": "2024-12-11T16:45:16.291195+01:00",
-                  "updated_at": "2024-12-11T16:45:16.979511+01:00",
+                  "created_at": "2025-03-19T12:04:55.985109+01:00",
+                  "updated_at": "2025-03-19T12:04:56.289216+01:00",
                   "ipaddress": "10.0.0.15",
                   "host": 14
                 }
@@ -28503,18 +27792,24 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2024-12-11T16:45:12.938227+01:00",
-                  "updated_at": "2024-12-11T16:45:12.938240+01:00",
+                  "created_at": "2025-03-19T12:04:54.711653+01:00",
+                  "updated_at": "2025-03-19T12:04:54.711661+01:00",
                   "txt": "v=spf1 -all",
                   "host": 14
                 }
               ],
               "ptr_overrides": [],
+              "srvs": [],
+              "naptrs": [],
+              "sshfps": [],
+              "groups": [],
+              "roles": [],
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
-              "created_at": "2024-12-11T16:45:12.933964+01:00",
-              "updated_at": "2024-12-11T16:45:26.616503+01:00",
+              "communities": [],
+              "created_at": "2025-03-19T12:04:54.709550+01:00",
+              "updated_at": "2025-03-19T12:05:00.353453+01:00",
               "name": "bar.example.org",
               "contact": "me@example.org",
               "ttl": null,
@@ -28548,15 +27843,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:15.977555+01:00",
-              "updated_at": "2024-12-11T16:45:16.676520+01:00",
+              "created_at": "2025-03-19T12:04:55.834780+01:00",
+              "updated_at": "2025-03-19T12:04:56.162642+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2024-12-11T16:45:16.291195+01:00",
-              "updated_at": "2024-12-11T16:45:16.979511+01:00",
+              "created_at": "2025-03-19T12:04:55.985109+01:00",
+              "updated_at": "2025-03-19T12:04:56.289216+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
@@ -28565,18 +27860,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:12.938227+01:00",
-              "updated_at": "2024-12-11T16:45:12.938240+01:00",
+              "created_at": "2025-03-19T12:04:54.711653+01:00",
+              "updated_at": "2025-03-19T12:04:54.711661+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:12.933964+01:00",
-          "updated_at": "2024-12-11T16:45:26.616503+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.709550+01:00",
+          "updated_at": "2025-03-19T12:05:00.353453+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -28593,8 +27894,8 @@
         },
         "status": 201,
         "response": {
-          "created_at": "2024-12-11T16:45:26.936264+01:00",
-          "updated_at": "2024-12-11T16:45:26.936276+01:00",
+          "created_at": "2025-03-19T12:05:00.453028+01:00",
+          "updated_at": "2025-03-19T12:05:00.453035+01:00",
           "txt": "Lorem ipsum dolor sit amet",
           "host": 14
         }
@@ -28624,15 +27925,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:15.977555+01:00",
-              "updated_at": "2024-12-11T16:45:16.676520+01:00",
+              "created_at": "2025-03-19T12:04:55.834780+01:00",
+              "updated_at": "2025-03-19T12:04:56.162642+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2024-12-11T16:45:16.291195+01:00",
-              "updated_at": "2024-12-11T16:45:16.979511+01:00",
+              "created_at": "2025-03-19T12:04:55.985109+01:00",
+              "updated_at": "2025-03-19T12:04:56.289216+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
@@ -28641,24 +27942,30 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:12.938227+01:00",
-              "updated_at": "2024-12-11T16:45:12.938240+01:00",
+              "created_at": "2025-03-19T12:04:54.711653+01:00",
+              "updated_at": "2025-03-19T12:04:54.711661+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             },
             {
-              "created_at": "2024-12-11T16:45:26.936264+01:00",
-              "updated_at": "2024-12-11T16:45:26.936276+01:00",
+              "created_at": "2025-03-19T12:05:00.453028+01:00",
+              "updated_at": "2025-03-19T12:05:00.453035+01:00",
               "txt": "Lorem ipsum dolor sit amet",
               "host": 14
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:12.933964+01:00",
-          "updated_at": "2024-12-11T16:45:26.616503+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.709550+01:00",
+          "updated_at": "2025-03-19T12:05:00.353453+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -28690,15 +27997,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:15.977555+01:00",
-              "updated_at": "2024-12-11T16:45:16.676520+01:00",
+              "created_at": "2025-03-19T12:04:55.834780+01:00",
+              "updated_at": "2025-03-19T12:04:56.162642+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2024-12-11T16:45:16.291195+01:00",
-              "updated_at": "2024-12-11T16:45:16.979511+01:00",
+              "created_at": "2025-03-19T12:04:55.985109+01:00",
+              "updated_at": "2025-03-19T12:04:56.289216+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
@@ -28707,24 +28014,30 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:12.938227+01:00",
-              "updated_at": "2024-12-11T16:45:12.938240+01:00",
+              "created_at": "2025-03-19T12:04:54.711653+01:00",
+              "updated_at": "2025-03-19T12:04:54.711661+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             },
             {
-              "created_at": "2024-12-11T16:45:26.936264+01:00",
-              "updated_at": "2024-12-11T16:45:26.936276+01:00",
+              "created_at": "2025-03-19T12:05:00.453028+01:00",
+              "updated_at": "2025-03-19T12:05:00.453035+01:00",
               "txt": "Lorem ipsum dolor sit amet",
               "host": 14
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:12.933964+01:00",
-          "updated_at": "2024-12-11T16:45:26.616503+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.709550+01:00",
+          "updated_at": "2025-03-19T12:05:00.353453+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -28768,15 +28081,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:15.977555+01:00",
-              "updated_at": "2024-12-11T16:45:16.676520+01:00",
+              "created_at": "2025-03-19T12:04:55.834780+01:00",
+              "updated_at": "2025-03-19T12:04:56.162642+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2024-12-11T16:45:16.291195+01:00",
-              "updated_at": "2024-12-11T16:45:16.979511+01:00",
+              "created_at": "2025-03-19T12:04:55.985109+01:00",
+              "updated_at": "2025-03-19T12:04:56.289216+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
@@ -28785,24 +28098,30 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:12.938227+01:00",
-              "updated_at": "2024-12-11T16:45:12.938240+01:00",
+              "created_at": "2025-03-19T12:04:54.711653+01:00",
+              "updated_at": "2025-03-19T12:04:54.711661+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             },
             {
-              "created_at": "2024-12-11T16:45:26.936264+01:00",
-              "updated_at": "2024-12-11T16:45:26.936276+01:00",
+              "created_at": "2025-03-19T12:05:00.453028+01:00",
+              "updated_at": "2025-03-19T12:05:00.453035+01:00",
               "txt": "Lorem ipsum dolor sit amet",
               "host": 14
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:12.933964+01:00",
-          "updated_at": "2024-12-11T16:45:26.616503+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.709550+01:00",
+          "updated_at": "2025-03-19T12:05:00.353453+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -28821,8 +28140,8 @@
           "previous": null,
           "results": [
             {
-              "created_at": "2024-12-11T16:45:26.936264+01:00",
-              "updated_at": "2024-12-11T16:45:26.936276+01:00",
+              "created_at": "2025-03-19T12:05:00.453028+01:00",
+              "updated_at": "2025-03-19T12:05:00.453035+01:00",
               "txt": "Lorem ipsum dolor sit amet",
               "host": 14
             }
@@ -28853,8 +28172,8 @@
       "Contact:      ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Wed Dec 11 16:45:27 2024",
-      "Updated:      Wed Dec 11 16:45:27 2024"
+      "Created:      Wed Mar 19 12:05:00 2025",
+      "Updated:      Wed Mar 19 12:05:00 2025"
     ],
     "api_requests": [
       {
@@ -28884,18 +28203,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2024-12-11T16:44:40.356452+01:00",
-                "updated_at": "2024-12-11T16:44:40.356481+01:00",
+                "created_at": "2025-03-19T12:04:41.191611+01:00",
+                "updated_at": "2025-03-19T12:04:41.191623+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2024-12-11T16:44:39.701254+01:00",
-            "updated_at": "2024-12-11T16:45:27.276284+01:00",
+            "created_at": "2025-03-19T12:04:40.912310+01:00",
+            "updated_at": "2025-03-19T12:05:00.607912+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
+            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -28924,83 +28243,29 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:27.521225+01:00",
-              "updated_at": "2024-12-11T16:45:27.521248+01:00",
+              "created_at": "2025-03-19T12:05:00.715226+01:00",
+              "updated_at": "2025-03-19T12:05:00.715232+01:00",
               "txt": "v=spf1 -all",
               "host": 17
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:27.501702+01:00",
-          "updated_at": "2024-12-11T16:45:27.501726+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:05:00.713318+01:00",
+          "updated_at": "2025-03-19T12:05:00.713326+01:00",
           "name": "*.example.org",
           "contact": "",
           "ttl": null,
           "comment": "",
           "zone": 1
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/srvs/?host=17",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/naptrs/?host=17",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/sshfps/?host=17",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hostpolicy/roles/?hosts=17",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hostgroups/?hosts=17",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
         }
       }
     ],
@@ -29029,47 +28294,29 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:27.521225+01:00",
-              "updated_at": "2024-12-11T16:45:27.521248+01:00",
+              "created_at": "2025-03-19T12:05:00.715226+01:00",
+              "updated_at": "2025-03-19T12:05:00.715232+01:00",
               "txt": "v=spf1 -all",
               "host": 17
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:27.501702+01:00",
-          "updated_at": "2024-12-11T16:45:27.501726+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:05:00.713318+01:00",
+          "updated_at": "2025-03-19T12:05:00.713326+01:00",
           "name": "*.example.org",
           "contact": "",
           "ttl": null,
           "comment": "",
           "zone": 1
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/naptrs/?host=17",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/srvs/?host=17",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
         }
       },
       {
@@ -29102,15 +28349,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:15.977555+01:00",
-              "updated_at": "2024-12-11T16:45:16.676520+01:00",
+              "created_at": "2025-03-19T12:04:55.834780+01:00",
+              "updated_at": "2025-03-19T12:04:56.162642+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2024-12-11T16:45:16.291195+01:00",
-              "updated_at": "2024-12-11T16:45:16.979511+01:00",
+              "created_at": "2025-03-19T12:04:55.985109+01:00",
+              "updated_at": "2025-03-19T12:04:56.289216+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
@@ -29119,18 +28366,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:12.938227+01:00",
-              "updated_at": "2024-12-11T16:45:12.938240+01:00",
+              "created_at": "2025-03-19T12:04:54.711653+01:00",
+              "updated_at": "2025-03-19T12:04:54.711661+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:12.933964+01:00",
-          "updated_at": "2024-12-11T16:45:26.616503+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.709550+01:00",
+          "updated_at": "2025-03-19T12:05:00.353453+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -29145,8 +28398,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:45:12.363738+01:00",
-          "updated_at": "2024-12-11T16:45:12.363771+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.460376+01:00",
+          "updated_at": "2025-03-19T12:04:54.460385+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -29164,8 +28419,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:45:12.363738+01:00",
-          "updated_at": "2024-12-11T16:45:12.363771+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.460376+01:00",
+          "updated_at": "2025-03-19T12:04:54.460385+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -29174,30 +28431,6 @@
           "location": "",
           "frozen": false,
           "reserved": 3
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/naptrs/?host=14",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/srvs/?host=14",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
         }
       },
       {
@@ -29230,15 +28463,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2024-12-11T16:45:12.965204+01:00",
-              "updated_at": "2024-12-11T16:45:17.976116+01:00",
+              "created_at": "2025-03-19T12:04:54.729053+01:00",
+              "updated_at": "2025-03-19T12:04:56.526058+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2024-12-11T16:45:18.689074+01:00",
-              "updated_at": "2024-12-11T16:45:20.166005+01:00",
+              "created_at": "2025-03-19T12:04:56.923203+01:00",
+              "updated_at": "2025-03-19T12:04:57.546535+01:00",
               "ipaddress": "2001:db8::14",
               "host": 15
             }
@@ -29247,18 +28480,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:17.316836+01:00",
-              "updated_at": "2024-12-11T16:45:17.316858+01:00",
+              "created_at": "2025-03-19T12:04:56.406778+01:00",
+              "updated_at": "2025-03-19T12:04:56.406784+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:17.293046+01:00",
-          "updated_at": "2024-12-11T16:45:17.293070+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:56.405048+01:00",
+          "updated_at": "2025-03-19T12:04:56.405055+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -29273,8 +28512,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:45:12.363738+01:00",
-          "updated_at": "2024-12-11T16:45:12.363771+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.460376+01:00",
+          "updated_at": "2025-03-19T12:04:54.460385+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -29292,8 +28533,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:45:12.555848+01:00",
-          "updated_at": "2024-12-11T16:45:12.555870+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.536879+01:00",
+          "updated_at": "2025-03-19T12:04:54.536908+01:00",
           "network": "2001:db8::/64",
           "description": "dolor sit amet",
           "vlan": null,
@@ -29302,30 +28545,6 @@
           "location": "",
           "frozen": false,
           "reserved": 3
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/naptrs/?host=15",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/srvs/?host=15",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
         }
       },
       {
@@ -29360,47 +28579,29 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:23.750260+01:00",
-              "updated_at": "2024-12-11T16:45:23.750274+01:00",
+              "created_at": "2025-03-19T12:04:59.135486+01:00",
+              "updated_at": "2025-03-19T12:04:59.135492+01:00",
               "txt": "v=spf1 -all",
               "host": 16
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:23.732624+01:00",
-          "updated_at": "2024-12-11T16:45:23.732643+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:04:59.133822+01:00",
+          "updated_at": "2025-03-19T12:04:59.133829+01:00",
           "name": "clover.example.org",
           "contact": "",
           "ttl": null,
           "comment": "",
           "zone": 1
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/naptrs/?host=16",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/srvs/?host=16",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
         }
       },
       {
@@ -29430,8 +28631,8 @@
       "              10.0.0.4   aa:bb:cc:cc:bb:aa   ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Thu Feb 27 10:48:01 2025",
-      "Updated:      Thu Feb 27 10:48:01 2025"
+      "Created:      Wed Mar 19 12:05:01 2025",
+      "Updated:      Wed Mar 19 12:05:01 2025"
     ],
     "api_requests": [
       {
@@ -29473,18 +28674,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2025-02-27T10:47:35.896278+01:00",
-                "updated_at": "2025-02-27T10:47:35.896293+01:00",
+                "created_at": "2025-03-19T12:04:41.191611+01:00",
+                "updated_at": "2025-03-19T12:04:41.191623+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-02-27T10:47:35.640608+01:00",
-            "updated_at": "2025-02-27T10:48:01.804890+01:00",
+            "created_at": "2025-03-19T12:04:40.912310+01:00",
+            "updated_at": "2025-03-19T12:05:01.115311+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-02-27T10:47:35.942147+01:00",
+            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -29501,8 +28702,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2025-02-27T10:47:53.101849+01:00",
-          "updated_at": "2025-02-27T10:47:53.101861+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.460376+01:00",
+          "updated_at": "2025-03-19T12:04:54.460385+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -29531,8 +28734,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-02-27T10:48:01.937672+01:00",
-              "updated_at": "2025-02-27T10:48:01.937680+01:00",
+              "created_at": "2025-03-19T12:05:01.250192+01:00",
+              "updated_at": "2025-03-19T12:05:01.250197+01:00",
               "ipaddress": "10.0.0.4",
               "host": 18
             }
@@ -29541,18 +28744,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-02-27T10:48:01.926768+01:00",
-              "updated_at": "2025-02-27T10:48:01.926774+01:00",
+              "created_at": "2025-03-19T12:05:01.236001+01:00",
+              "updated_at": "2025-03-19T12:05:01.236007+01:00",
               "txt": "v=spf1 -all",
               "host": 18
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2025-02-27T10:48:01.925013+01:00",
-          "updated_at": "2025-02-27T10:48:01.925020+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:05:01.234306+01:00",
+          "updated_at": "2025-03-19T12:05:01.234313+01:00",
           "name": "directok.example.org",
           "contact": "",
           "ttl": null,
@@ -29587,8 +28796,8 @@
         "status": 200,
         "response": {
           "macaddress": "aa:bb:cc:cc:bb:aa",
-          "created_at": "2025-02-27T10:48:01.937672+01:00",
-          "updated_at": "2025-02-27T10:48:02.034572+01:00",
+          "created_at": "2025-03-19T12:05:01.250192+01:00",
+          "updated_at": "2025-03-19T12:05:01.327374+01:00",
           "ipaddress": "10.0.0.4",
           "host": 18
         }
@@ -29607,8 +28816,8 @@
               "ipaddresses": [
                 {
                   "macaddress": "aa:bb:cc:cc:bb:aa",
-                  "created_at": "2025-02-27T10:48:01.937672+01:00",
-                  "updated_at": "2025-02-27T10:48:02.034572+01:00",
+                  "created_at": "2025-03-19T12:05:01.250192+01:00",
+                  "updated_at": "2025-03-19T12:05:01.327374+01:00",
                   "ipaddress": "10.0.0.4",
                   "host": 18
                 }
@@ -29617,18 +28826,24 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2025-02-27T10:48:01.926768+01:00",
-                  "updated_at": "2025-02-27T10:48:01.926774+01:00",
+                  "created_at": "2025-03-19T12:05:01.236001+01:00",
+                  "updated_at": "2025-03-19T12:05:01.236007+01:00",
                   "txt": "v=spf1 -all",
                   "host": 18
                 }
               ],
               "ptr_overrides": [],
+              "srvs": [],
+              "naptrs": [],
+              "sshfps": [],
+              "groups": [],
+              "roles": [],
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
-              "created_at": "2025-02-27T10:48:01.925013+01:00",
-              "updated_at": "2025-02-27T10:48:01.925020+01:00",
+              "communities": [],
+              "created_at": "2025-03-19T12:05:01.234306+01:00",
+              "updated_at": "2025-03-19T12:05:01.234313+01:00",
               "name": "directok.example.org",
               "contact": "",
               "ttl": null,
@@ -29645,8 +28860,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2025-02-27T10:47:53.101849+01:00",
-          "updated_at": "2025-02-27T10:47:53.101861+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.460376+01:00",
+          "updated_at": "2025-03-19T12:04:54.460385+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -29655,85 +28872,6 @@
           "location": "",
           "frozen": false,
           "reserved": 3
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/ip/10.0.0.4",
-        "data": {},
-        "status": 200,
-        "response": {
-          "excluded_ranges": [],
-          "created_at": "2025-02-27T10:47:53.101849+01:00",
-          "updated_at": "2025-02-27T10:47:53.101861+01:00",
-          "network": "10.0.0.0/24",
-          "description": "lorem ipsum",
-          "vlan": null,
-          "dns_delegated": false,
-          "category": "",
-          "location": "",
-          "frozen": false,
-          "reserved": 3
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/srvs/?host=18",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/naptrs/?host=18",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/sshfps/?host=18",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hostpolicy/roles/?hosts=18",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hostgroups/?hosts=18",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
         }
       }
     ],
@@ -29795,8 +28933,8 @@
           "ipaddresses": [
             {
               "macaddress": "aa:bb:cc:cc:bb:aa",
-              "created_at": "2024-12-11T16:45:29.386774+01:00",
-              "updated_at": "2024-12-11T16:45:29.586984+01:00",
+              "created_at": "2025-03-19T12:05:01.250192+01:00",
+              "updated_at": "2025-03-19T12:05:01.327374+01:00",
               "ipaddress": "10.0.0.4",
               "host": 18
             }
@@ -29805,47 +28943,29 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:29.367922+01:00",
-              "updated_at": "2024-12-11T16:45:29.367930+01:00",
+              "created_at": "2025-03-19T12:05:01.236001+01:00",
+              "updated_at": "2025-03-19T12:05:01.236007+01:00",
               "txt": "v=spf1 -all",
               "host": 18
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:29.365220+01:00",
-          "updated_at": "2024-12-11T16:45:29.365232+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:05:01.234306+01:00",
+          "updated_at": "2025-03-19T12:05:01.234313+01:00",
           "name": "directok.example.org",
           "contact": "",
           "ttl": null,
           "comment": "",
           "zone": 1
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/naptrs/?host=18",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/srvs/?host=18",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
         }
       },
       {
@@ -29875,8 +28995,8 @@
       "              10.0.0.10   <not set>   ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Thu Feb 27 10:48:02 2025",
-      "Updated:      Thu Feb 27 10:48:02 2025"
+      "Created:      Wed Mar 19 12:05:01 2025",
+      "Updated:      Wed Mar 19 12:05:01 2025"
     ],
     "api_requests": [
       {
@@ -29906,18 +29026,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2025-02-27T10:47:35.896278+01:00",
-                "updated_at": "2025-02-27T10:47:35.896293+01:00",
+                "created_at": "2025-03-19T12:04:41.191611+01:00",
+                "updated_at": "2025-03-19T12:04:41.191623+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-02-27T10:47:35.640608+01:00",
-            "updated_at": "2025-02-27T10:48:02.405682+01:00",
+            "created_at": "2025-03-19T12:04:40.912310+01:00",
+            "updated_at": "2025-03-19T12:05:01.506085+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-02-27T10:47:35.942147+01:00",
+            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -29934,8 +29054,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2025-02-27T10:47:53.101849+01:00",
-          "updated_at": "2025-02-27T10:47:53.101861+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.460376+01:00",
+          "updated_at": "2025-03-19T12:04:54.460385+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -29965,8 +29087,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-02-27T10:48:02.529609+01:00",
-              "updated_at": "2025-02-27T10:48:02.529615+01:00",
+              "created_at": "2025-03-19T12:05:01.616418+01:00",
+              "updated_at": "2025-03-19T12:05:01.616423+01:00",
               "ipaddress": "10.0.0.10",
               "host": 19
             }
@@ -29975,18 +29097,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-02-27T10:48:02.516878+01:00",
-              "updated_at": "2025-02-27T10:48:02.516885+01:00",
+              "created_at": "2025-03-19T12:05:01.602073+01:00",
+              "updated_at": "2025-03-19T12:05:01.602079+01:00",
               "txt": "v=spf1 -all",
               "host": 19
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2025-02-27T10:48:02.514659+01:00",
-          "updated_at": "2025-02-27T10:48:02.514670+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:05:01.599947+01:00",
+          "updated_at": "2025-03-19T12:05:01.599955+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -30001,8 +29129,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2025-02-27T10:47:53.101849+01:00",
-          "updated_at": "2025-02-27T10:47:53.101861+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.460376+01:00",
+          "updated_at": "2025-03-19T12:04:54.460385+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -30011,85 +29141,6 @@
           "location": "",
           "frozen": false,
           "reserved": 3
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/ip/10.0.0.10",
-        "data": {},
-        "status": 200,
-        "response": {
-          "excluded_ranges": [],
-          "created_at": "2025-02-27T10:47:53.101849+01:00",
-          "updated_at": "2025-02-27T10:47:53.101861+01:00",
-          "network": "10.0.0.0/24",
-          "description": "lorem ipsum",
-          "vlan": null,
-          "dns_delegated": false,
-          "category": "",
-          "location": "",
-          "frozen": false,
-          "reserved": 3
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/srvs/?host=19",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/naptrs/?host=19",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/sshfps/?host=19",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hostpolicy/roles/?hosts=19",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hostgroups/?hosts=19",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
         }
       }
     ],
@@ -30116,8 +29167,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:30.487891+01:00",
-              "updated_at": "2024-12-11T16:45:30.487904+01:00",
+              "created_at": "2025-03-19T12:05:01.616418+01:00",
+              "updated_at": "2025-03-19T12:05:01.616423+01:00",
               "ipaddress": "10.0.0.10",
               "host": 19
             }
@@ -30126,18 +29177,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:30.467551+01:00",
-              "updated_at": "2024-12-11T16:45:30.467560+01:00",
+              "created_at": "2025-03-19T12:05:01.602073+01:00",
+              "updated_at": "2025-03-19T12:05:01.602079+01:00",
               "txt": "v=spf1 -all",
               "host": 19
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:30.464508+01:00",
-          "updated_at": "2024-12-11T16:45:30.464524+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:05:01.599947+01:00",
+          "updated_at": "2025-03-19T12:05:01.599955+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -30155,8 +29212,8 @@
         },
         "status": 201,
         "response": {
-          "created_at": "2024-12-11T16:45:30.911540+01:00",
-          "updated_at": "2024-12-11T16:45:30.911562+01:00",
+          "created_at": "2025-03-19T12:05:01.716103+01:00",
+          "updated_at": "2025-03-19T12:05:01.716110+01:00",
           "priority": 10,
           "mx": "mail.example.org",
           "host": 19
@@ -30186,8 +29243,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:30.487891+01:00",
-              "updated_at": "2024-12-11T16:45:30.487904+01:00",
+              "created_at": "2025-03-19T12:05:01.616418+01:00",
+              "updated_at": "2025-03-19T12:05:01.616423+01:00",
               "ipaddress": "10.0.0.10",
               "host": 19
             }
@@ -30195,8 +29252,8 @@
           "cnames": [],
           "mxs": [
             {
-              "created_at": "2024-12-11T16:45:30.911540+01:00",
-              "updated_at": "2024-12-11T16:45:30.911562+01:00",
+              "created_at": "2025-03-19T12:05:01.716103+01:00",
+              "updated_at": "2025-03-19T12:05:01.716110+01:00",
               "priority": 10,
               "mx": "mail.example.org",
               "host": 19
@@ -30204,47 +29261,29 @@
           ],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:30.467551+01:00",
-              "updated_at": "2024-12-11T16:45:30.467560+01:00",
+              "created_at": "2025-03-19T12:05:01.602073+01:00",
+              "updated_at": "2025-03-19T12:05:01.602079+01:00",
               "txt": "v=spf1 -all",
               "host": 19
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:30.464508+01:00",
-          "updated_at": "2024-12-11T16:45:30.464524+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:05:01.599947+01:00",
+          "updated_at": "2025-03-19T12:05:01.599955+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
           "comment": "",
           "zone": 1
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/naptrs/?host=19",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/srvs/?host=19",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
         }
       }
     ],
@@ -30271,8 +29310,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:30.487891+01:00",
-              "updated_at": "2024-12-11T16:45:30.487904+01:00",
+              "created_at": "2025-03-19T12:05:01.616418+01:00",
+              "updated_at": "2025-03-19T12:05:01.616423+01:00",
               "ipaddress": "10.0.0.10",
               "host": 19
             }
@@ -30280,8 +29319,8 @@
           "cnames": [],
           "mxs": [
             {
-              "created_at": "2024-12-11T16:45:30.911540+01:00",
-              "updated_at": "2024-12-11T16:45:30.911562+01:00",
+              "created_at": "2025-03-19T12:05:01.716103+01:00",
+              "updated_at": "2025-03-19T12:05:01.716110+01:00",
               "priority": 10,
               "mx": "mail.example.org",
               "host": 19
@@ -30289,47 +29328,29 @@
           ],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:30.467551+01:00",
-              "updated_at": "2024-12-11T16:45:30.467560+01:00",
+              "created_at": "2025-03-19T12:05:01.602073+01:00",
+              "updated_at": "2025-03-19T12:05:01.602079+01:00",
               "txt": "v=spf1 -all",
               "host": 19
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:30.464508+01:00",
-          "updated_at": "2024-12-11T16:45:30.464524+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:05:01.599947+01:00",
+          "updated_at": "2025-03-19T12:05:01.599955+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
           "comment": "",
           "zone": 1
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/naptrs/?host=19",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/srvs/?host=19",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
         }
       },
       {
@@ -30359,8 +29380,8 @@
       "              10.0.0.10   <not set>   ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Thu Feb 27 10:48:03 2025",
-      "Updated:      Thu Feb 27 10:48:03 2025"
+      "Created:      Wed Mar 19 12:05:01 2025",
+      "Updated:      Wed Mar 19 12:05:01 2025"
     ],
     "api_requests": [
       {
@@ -30390,18 +29411,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2025-02-27T10:47:35.896278+01:00",
-                "updated_at": "2025-02-27T10:47:35.896293+01:00",
+                "created_at": "2025-03-19T12:04:41.191611+01:00",
+                "updated_at": "2025-03-19T12:04:41.191623+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-02-27T10:47:35.640608+01:00",
-            "updated_at": "2025-02-27T10:48:03.100878+01:00",
+            "created_at": "2025-03-19T12:04:40.912310+01:00",
+            "updated_at": "2025-03-19T12:05:01.817618+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-02-27T10:47:35.942147+01:00",
+            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -30418,8 +29439,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2025-02-27T10:47:53.101849+01:00",
-          "updated_at": "2025-02-27T10:47:53.101861+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.460376+01:00",
+          "updated_at": "2025-03-19T12:04:54.460385+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -30449,8 +29472,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-02-27T10:48:03.246669+01:00",
-              "updated_at": "2025-02-27T10:48:03.246675+01:00",
+              "created_at": "2025-03-19T12:05:01.923335+01:00",
+              "updated_at": "2025-03-19T12:05:01.923340+01:00",
               "ipaddress": "10.0.0.10",
               "host": 20
             }
@@ -30459,18 +29482,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-02-27T10:48:03.232638+01:00",
-              "updated_at": "2025-02-27T10:48:03.232647+01:00",
+              "created_at": "2025-03-19T12:05:01.909650+01:00",
+              "updated_at": "2025-03-19T12:05:01.909656+01:00",
               "txt": "v=spf1 -all",
               "host": 20
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2025-02-27T10:48:03.230349+01:00",
-          "updated_at": "2025-02-27T10:48:03.230358+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:05:01.908027+01:00",
+          "updated_at": "2025-03-19T12:05:01.908034+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -30485,8 +29514,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2025-02-27T10:47:53.101849+01:00",
-          "updated_at": "2025-02-27T10:47:53.101861+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.460376+01:00",
+          "updated_at": "2025-03-19T12:04:54.460385+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -30495,85 +29526,6 @@
           "location": "",
           "frozen": false,
           "reserved": 3
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/ip/10.0.0.10",
-        "data": {},
-        "status": 200,
-        "response": {
-          "excluded_ranges": [],
-          "created_at": "2025-02-27T10:47:53.101849+01:00",
-          "updated_at": "2025-02-27T10:47:53.101861+01:00",
-          "network": "10.0.0.0/24",
-          "description": "lorem ipsum",
-          "vlan": null,
-          "dns_delegated": false,
-          "category": "",
-          "location": "",
-          "frozen": false,
-          "reserved": 3
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/srvs/?host=20",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/naptrs/?host=20",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/sshfps/?host=20",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hostpolicy/roles/?hosts=20",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hostgroups/?hosts=20",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
         }
       }
     ],
@@ -30600,8 +29552,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:31.587990+01:00",
-              "updated_at": "2024-12-11T16:45:31.588000+01:00",
+              "created_at": "2025-03-19T12:05:01.923335+01:00",
+              "updated_at": "2025-03-19T12:05:01.923340+01:00",
               "ipaddress": "10.0.0.10",
               "host": 20
             }
@@ -30610,18 +29562,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:31.566412+01:00",
-              "updated_at": "2024-12-11T16:45:31.566424+01:00",
+              "created_at": "2025-03-19T12:05:01.909650+01:00",
+              "updated_at": "2025-03-19T12:05:01.909656+01:00",
               "txt": "v=spf1 -all",
               "host": 20
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:31.562942+01:00",
-          "updated_at": "2024-12-11T16:45:31.562956+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:05:01.908027+01:00",
+          "updated_at": "2025-03-19T12:05:01.908034+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -30648,8 +29606,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:45:12.363738+01:00",
-          "updated_at": "2024-12-11T16:45:12.363771+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.460376+01:00",
+          "updated_at": "2025-03-19T12:04:54.460385+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -30682,8 +29642,8 @@
         },
         "status": 201,
         "response": {
-          "created_at": "2024-12-11T16:45:32.083873+01:00",
-          "updated_at": "2024-12-11T16:45:32.083895+01:00",
+          "created_at": "2025-03-19T12:05:02.068574+01:00",
+          "updated_at": "2025-03-19T12:05:02.068581+01:00",
           "ipaddress": "10.0.0.11",
           "host": 20
         }
@@ -30712,8 +29672,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:31.587990+01:00",
-              "updated_at": "2024-12-11T16:45:31.588000+01:00",
+              "created_at": "2025-03-19T12:05:01.923335+01:00",
+              "updated_at": "2025-03-19T12:05:01.923340+01:00",
               "ipaddress": "10.0.0.10",
               "host": 20
             }
@@ -30722,54 +29682,36 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:31.566412+01:00",
-              "updated_at": "2024-12-11T16:45:31.566424+01:00",
+              "created_at": "2025-03-19T12:05:01.909650+01:00",
+              "updated_at": "2025-03-19T12:05:01.909656+01:00",
               "txt": "v=spf1 -all",
               "host": 20
             }
           ],
           "ptr_overrides": [
             {
-              "created_at": "2024-12-11T16:45:32.083873+01:00",
-              "updated_at": "2024-12-11T16:45:32.083895+01:00",
+              "created_at": "2025-03-19T12:05:02.068574+01:00",
+              "updated_at": "2025-03-19T12:05:02.068581+01:00",
               "ipaddress": "10.0.0.11",
               "host": 20
             }
           ],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:31.562942+01:00",
-          "updated_at": "2024-12-11T16:45:31.562956+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:05:01.908027+01:00",
+          "updated_at": "2025-03-19T12:05:01.908034+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
           "comment": "",
           "zone": 1
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/naptrs/?host=20",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/srvs/?host=20",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
         }
       }
     ],
@@ -30797,8 +29739,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:31.587990+01:00",
-              "updated_at": "2024-12-11T16:45:31.588000+01:00",
+              "created_at": "2025-03-19T12:05:01.923335+01:00",
+              "updated_at": "2025-03-19T12:05:01.923340+01:00",
               "ipaddress": "10.0.0.10",
               "host": 20
             }
@@ -30807,54 +29749,36 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:31.566412+01:00",
-              "updated_at": "2024-12-11T16:45:31.566424+01:00",
+              "created_at": "2025-03-19T12:05:01.909650+01:00",
+              "updated_at": "2025-03-19T12:05:01.909656+01:00",
               "txt": "v=spf1 -all",
               "host": 20
             }
           ],
           "ptr_overrides": [
             {
-              "created_at": "2024-12-11T16:45:32.083873+01:00",
-              "updated_at": "2024-12-11T16:45:32.083895+01:00",
+              "created_at": "2025-03-19T12:05:02.068574+01:00",
+              "updated_at": "2025-03-19T12:05:02.068581+01:00",
               "ipaddress": "10.0.0.11",
               "host": 20
             }
           ],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:31.562942+01:00",
-          "updated_at": "2024-12-11T16:45:31.562956+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:05:01.908027+01:00",
+          "updated_at": "2025-03-19T12:05:01.908034+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
           "comment": "",
           "zone": 1
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/naptrs/?host=20",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/srvs/?host=20",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
         }
       },
       {
@@ -30884,8 +29808,8 @@
       "              10.0.0.10   <not set>   ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Thu Feb 27 10:48:03 2025",
-      "Updated:      Thu Feb 27 10:48:03 2025"
+      "Created:      Wed Mar 19 12:05:02 2025",
+      "Updated:      Wed Mar 19 12:05:02 2025"
     ],
     "api_requests": [
       {
@@ -30915,18 +29839,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2025-02-27T10:47:35.896278+01:00",
-                "updated_at": "2025-02-27T10:47:35.896293+01:00",
+                "created_at": "2025-03-19T12:04:41.191611+01:00",
+                "updated_at": "2025-03-19T12:04:41.191623+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-02-27T10:47:35.640608+01:00",
-            "updated_at": "2025-02-27T10:48:03.822482+01:00",
+            "created_at": "2025-03-19T12:04:40.912310+01:00",
+            "updated_at": "2025-03-19T12:05:02.215243+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-02-27T10:47:35.942147+01:00",
+            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -30943,8 +29867,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2025-02-27T10:47:53.101849+01:00",
-          "updated_at": "2025-02-27T10:47:53.101861+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.460376+01:00",
+          "updated_at": "2025-03-19T12:04:54.460385+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -30974,8 +29900,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-02-27T10:48:03.949977+01:00",
-              "updated_at": "2025-02-27T10:48:03.949984+01:00",
+              "created_at": "2025-03-19T12:05:02.327419+01:00",
+              "updated_at": "2025-03-19T12:05:02.327425+01:00",
               "ipaddress": "10.0.0.10",
               "host": 21
             }
@@ -30984,18 +29910,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-02-27T10:48:03.930127+01:00",
-              "updated_at": "2025-02-27T10:48:03.930134+01:00",
+              "created_at": "2025-03-19T12:05:02.311876+01:00",
+              "updated_at": "2025-03-19T12:05:02.311882+01:00",
               "txt": "v=spf1 -all",
               "host": 21
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2025-02-27T10:48:03.927861+01:00",
-          "updated_at": "2025-02-27T10:48:03.927868+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:05:02.309948+01:00",
+          "updated_at": "2025-03-19T12:05:02.309955+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -31010,8 +29942,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2025-02-27T10:47:53.101849+01:00",
-          "updated_at": "2025-02-27T10:47:53.101861+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.460376+01:00",
+          "updated_at": "2025-03-19T12:04:54.460385+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -31020,85 +29954,6 @@
           "location": "",
           "frozen": false,
           "reserved": 3
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/ip/10.0.0.10",
-        "data": {},
-        "status": 200,
-        "response": {
-          "excluded_ranges": [],
-          "created_at": "2025-02-27T10:47:53.101849+01:00",
-          "updated_at": "2025-02-27T10:47:53.101861+01:00",
-          "network": "10.0.0.0/24",
-          "description": "lorem ipsum",
-          "vlan": null,
-          "dns_delegated": false,
-          "category": "",
-          "location": "",
-          "frozen": false,
-          "reserved": 3
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/srvs/?host=21",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/naptrs/?host=21",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/sshfps/?host=21",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hostpolicy/roles/?hosts=21",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hostgroups/?hosts=21",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
         }
       }
     ],
@@ -31125,8 +29980,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:32.714018+01:00",
-              "updated_at": "2024-12-11T16:45:32.714035+01:00",
+              "created_at": "2025-03-19T12:05:02.327419+01:00",
+              "updated_at": "2025-03-19T12:05:02.327425+01:00",
               "ipaddress": "10.0.0.10",
               "host": 21
             }
@@ -31135,18 +29990,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:32.684424+01:00",
-              "updated_at": "2024-12-11T16:45:32.684452+01:00",
+              "created_at": "2025-03-19T12:05:02.311876+01:00",
+              "updated_at": "2025-03-19T12:05:02.311882+01:00",
               "txt": "v=spf1 -all",
               "host": 21
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:32.678898+01:00",
-          "updated_at": "2024-12-11T16:45:32.678919+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:05:02.309948+01:00",
+          "updated_at": "2025-03-19T12:05:02.309955+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -31180,8 +30041,8 @@
         },
         "status": 201,
         "response": {
-          "created_at": "2024-12-11T16:45:33.190093+01:00",
-          "updated_at": "2024-12-11T16:45:33.190107+01:00",
+          "created_at": "2025-03-19T12:05:02.475604+01:00",
+          "updated_at": "2025-03-19T12:05:02.475612+01:00",
           "preference": 16384,
           "order": 3,
           "flag": "u",
@@ -31215,8 +30076,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:32.714018+01:00",
-              "updated_at": "2024-12-11T16:45:32.714035+01:00",
+              "created_at": "2025-03-19T12:05:02.327419+01:00",
+              "updated_at": "2025-03-19T12:05:02.327425+01:00",
               "ipaddress": "10.0.0.10",
               "host": 21
             }
@@ -31225,38 +30086,18 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:32.684424+01:00",
-              "updated_at": "2024-12-11T16:45:32.684452+01:00",
+              "created_at": "2025-03-19T12:05:02.311876+01:00",
+              "updated_at": "2025-03-19T12:05:02.311882+01:00",
               "txt": "v=spf1 -all",
               "host": 21
             }
           ],
           "ptr_overrides": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "created_at": "2024-12-11T16:45:32.678898+01:00",
-          "updated_at": "2024-12-11T16:45:32.678919+01:00",
-          "name": "foo.example.org",
-          "contact": "foo@example.org",
-          "ttl": null,
-          "comment": "",
-          "zone": 1
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/naptrs/?host=21",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
+          "srvs": [],
+          "naptrs": [
             {
-              "created_at": "2024-12-11T16:45:33.190093+01:00",
-              "updated_at": "2024-12-11T16:45:33.190107+01:00",
+              "created_at": "2025-03-19T12:05:02.475604+01:00",
+              "updated_at": "2025-03-19T12:05:02.475612+01:00",
               "preference": 16384,
               "order": 3,
               "flag": "u",
@@ -31265,19 +30106,21 @@
               "replacement": "wonk",
               "host": 21
             }
-          ]
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/srvs/?host=21",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
+          ],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
+          "hinfo": null,
+          "loc": null,
+          "bacnetid": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:05:02.309948+01:00",
+          "updated_at": "2025-03-19T12:05:02.309955+01:00",
+          "name": "foo.example.org",
+          "contact": "foo@example.org",
+          "ttl": null,
+          "comment": "",
+          "zone": 1
         }
       }
     ],
@@ -31305,8 +30148,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:32.714018+01:00",
-              "updated_at": "2024-12-11T16:45:32.714035+01:00",
+              "created_at": "2025-03-19T12:05:02.327419+01:00",
+              "updated_at": "2025-03-19T12:05:02.327425+01:00",
               "ipaddress": "10.0.0.10",
               "host": 21
             }
@@ -31315,38 +30158,18 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:32.684424+01:00",
-              "updated_at": "2024-12-11T16:45:32.684452+01:00",
+              "created_at": "2025-03-19T12:05:02.311876+01:00",
+              "updated_at": "2025-03-19T12:05:02.311882+01:00",
               "txt": "v=spf1 -all",
               "host": 21
             }
           ],
           "ptr_overrides": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "created_at": "2024-12-11T16:45:32.678898+01:00",
-          "updated_at": "2024-12-11T16:45:32.678919+01:00",
-          "name": "foo.example.org",
-          "contact": "foo@example.org",
-          "ttl": null,
-          "comment": "",
-          "zone": 1
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/naptrs/?host=21",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
+          "srvs": [],
+          "naptrs": [
             {
-              "created_at": "2024-12-11T16:45:33.190093+01:00",
-              "updated_at": "2024-12-11T16:45:33.190107+01:00",
+              "created_at": "2025-03-19T12:05:02.475604+01:00",
+              "updated_at": "2025-03-19T12:05:02.475612+01:00",
               "preference": 16384,
               "order": 3,
               "flag": "u",
@@ -31355,19 +30178,21 @@
               "replacement": "wonk",
               "host": 21
             }
-          ]
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/srvs/?host=21",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
+          ],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
+          "hinfo": null,
+          "loc": null,
+          "bacnetid": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:05:02.309948+01:00",
+          "updated_at": "2025-03-19T12:05:02.309955+01:00",
+          "name": "foo.example.org",
+          "contact": "foo@example.org",
+          "ttl": null,
+          "comment": "",
+          "zone": 1
         }
       },
       {
@@ -31397,8 +30222,8 @@
       "              10.0.0.10   <not set>   ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Thu Feb 27 10:48:04 2025",
-      "Updated:      Thu Feb 27 10:48:04 2025"
+      "Created:      Wed Mar 19 12:05:02 2025",
+      "Updated:      Wed Mar 19 12:05:02 2025"
     ],
     "api_requests": [
       {
@@ -31428,18 +30253,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2025-02-27T10:47:35.896278+01:00",
-                "updated_at": "2025-02-27T10:47:35.896293+01:00",
+                "created_at": "2025-03-19T12:04:41.191611+01:00",
+                "updated_at": "2025-03-19T12:04:41.191623+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-02-27T10:47:35.640608+01:00",
-            "updated_at": "2025-02-27T10:48:04.486804+01:00",
+            "created_at": "2025-03-19T12:04:40.912310+01:00",
+            "updated_at": "2025-03-19T12:05:02.587272+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-02-27T10:47:35.942147+01:00",
+            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -31456,8 +30281,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2025-02-27T10:47:53.101849+01:00",
-          "updated_at": "2025-02-27T10:47:53.101861+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.460376+01:00",
+          "updated_at": "2025-03-19T12:04:54.460385+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -31487,8 +30314,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-02-27T10:48:04.607998+01:00",
-              "updated_at": "2025-02-27T10:48:04.608050+01:00",
+              "created_at": "2025-03-19T12:05:02.704953+01:00",
+              "updated_at": "2025-03-19T12:05:02.704959+01:00",
               "ipaddress": "10.0.0.10",
               "host": 22
             }
@@ -31497,18 +30324,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-02-27T10:48:04.595118+01:00",
-              "updated_at": "2025-02-27T10:48:04.595125+01:00",
+              "created_at": "2025-03-19T12:05:02.689059+01:00",
+              "updated_at": "2025-03-19T12:05:02.689065+01:00",
               "txt": "v=spf1 -all",
               "host": 22
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2025-02-27T10:48:04.593000+01:00",
-          "updated_at": "2025-02-27T10:48:04.593009+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:05:02.687061+01:00",
+          "updated_at": "2025-03-19T12:05:02.687069+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -31523,8 +30356,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2025-02-27T10:47:53.101849+01:00",
-          "updated_at": "2025-02-27T10:47:53.101861+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.460376+01:00",
+          "updated_at": "2025-03-19T12:04:54.460385+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -31533,85 +30368,6 @@
           "location": "",
           "frozen": false,
           "reserved": 3
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/ip/10.0.0.10",
-        "data": {},
-        "status": 200,
-        "response": {
-          "excluded_ranges": [],
-          "created_at": "2025-02-27T10:47:53.101849+01:00",
-          "updated_at": "2025-02-27T10:47:53.101861+01:00",
-          "network": "10.0.0.0/24",
-          "description": "lorem ipsum",
-          "vlan": null,
-          "dns_delegated": false,
-          "category": "",
-          "location": "",
-          "frozen": false,
-          "reserved": 3
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/srvs/?host=22",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/naptrs/?host=22",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/sshfps/?host=22",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hostpolicy/roles/?hosts=22",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hostgroups/?hosts=22",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
         }
       }
     ],
@@ -31638,8 +30394,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:33.776179+01:00",
-              "updated_at": "2024-12-11T16:45:33.776187+01:00",
+              "created_at": "2025-03-19T12:05:02.704953+01:00",
+              "updated_at": "2025-03-19T12:05:02.704959+01:00",
               "ipaddress": "10.0.0.10",
               "host": 22
             }
@@ -31648,18 +30404,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:33.759403+01:00",
-              "updated_at": "2024-12-11T16:45:33.759413+01:00",
+              "created_at": "2025-03-19T12:05:02.689059+01:00",
+              "updated_at": "2025-03-19T12:05:02.689065+01:00",
               "txt": "v=spf1 -all",
               "host": 22
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:33.756101+01:00",
-          "updated_at": "2024-12-11T16:45:33.756113+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:05:02.687061+01:00",
+          "updated_at": "2025-03-19T12:05:02.687069+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -31676,18 +30438,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2024-12-11T16:44:40.356452+01:00",
-                "updated_at": "2024-12-11T16:44:40.356481+01:00",
+                "created_at": "2025-03-19T12:04:41.191611+01:00",
+                "updated_at": "2025-03-19T12:04:41.191623+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2024-12-11T16:44:39.701254+01:00",
-            "updated_at": "2024-12-11T16:45:33.775396+01:00",
+            "created_at": "2025-03-19T12:04:40.912310+01:00",
+            "updated_at": "2025-03-19T12:05:02.703999+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
+            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -31706,18 +30468,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2024-12-11T16:44:40.356452+01:00",
-                "updated_at": "2024-12-11T16:44:40.356481+01:00",
+                "created_at": "2025-03-19T12:04:41.191611+01:00",
+                "updated_at": "2025-03-19T12:04:41.191623+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2024-12-11T16:44:39.701254+01:00",
-            "updated_at": "2024-12-11T16:45:33.775396+01:00",
+            "created_at": "2025-03-19T12:04:40.912310+01:00",
+            "updated_at": "2025-03-19T12:05:02.703999+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
+            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -31751,8 +30513,8 @@
         },
         "status": 201,
         "response": {
-          "created_at": "2024-12-11T16:45:34.272043+01:00",
-          "updated_at": "2024-12-11T16:45:34.272058+01:00",
+          "created_at": "2025-03-19T12:05:02.876109+01:00",
+          "updated_at": "2025-03-19T12:05:02.876117+01:00",
           "name": "_sip._tcp.example.org",
           "priority": 10,
           "weight": 5,
@@ -31786,8 +30548,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:33.776179+01:00",
-              "updated_at": "2024-12-11T16:45:33.776187+01:00",
+              "created_at": "2025-03-19T12:05:02.704953+01:00",
+              "updated_at": "2025-03-19T12:05:02.704959+01:00",
               "ipaddress": "10.0.0.10",
               "host": 22
             }
@@ -31796,50 +30558,17 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:33.759403+01:00",
-              "updated_at": "2024-12-11T16:45:33.759413+01:00",
+              "created_at": "2025-03-19T12:05:02.689059+01:00",
+              "updated_at": "2025-03-19T12:05:02.689065+01:00",
               "txt": "v=spf1 -all",
               "host": 22
             }
           ],
           "ptr_overrides": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "created_at": "2024-12-11T16:45:33.756101+01:00",
-          "updated_at": "2024-12-11T16:45:33.756113+01:00",
-          "name": "foo.example.org",
-          "contact": "foo@example.org",
-          "ttl": null,
-          "comment": "",
-          "zone": 1
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/naptrs/?host=22",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/srvs/?host=22",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
+          "srvs": [
             {
-              "created_at": "2024-12-11T16:45:34.272043+01:00",
-              "updated_at": "2024-12-11T16:45:34.272058+01:00",
+              "created_at": "2025-03-19T12:05:02.876109+01:00",
+              "updated_at": "2025-03-19T12:05:02.876117+01:00",
               "name": "_sip._tcp.example.org",
               "priority": 10,
               "weight": 5,
@@ -31848,7 +30577,22 @@
               "zone": 1,
               "host": 22
             }
-          ]
+          ],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
+          "hinfo": null,
+          "loc": null,
+          "bacnetid": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:05:02.687061+01:00",
+          "updated_at": "2025-03-19T12:05:02.687069+01:00",
+          "name": "foo.example.org",
+          "contact": "foo@example.org",
+          "ttl": null,
+          "comment": "",
+          "zone": 1
         }
       }
     ],
@@ -31876,8 +30620,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:33.776179+01:00",
-              "updated_at": "2024-12-11T16:45:33.776187+01:00",
+              "created_at": "2025-03-19T12:05:02.704953+01:00",
+              "updated_at": "2025-03-19T12:05:02.704959+01:00",
               "ipaddress": "10.0.0.10",
               "host": 22
             }
@@ -31886,50 +30630,17 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:33.759403+01:00",
-              "updated_at": "2024-12-11T16:45:33.759413+01:00",
+              "created_at": "2025-03-19T12:05:02.689059+01:00",
+              "updated_at": "2025-03-19T12:05:02.689065+01:00",
               "txt": "v=spf1 -all",
               "host": 22
             }
           ],
           "ptr_overrides": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "created_at": "2024-12-11T16:45:33.756101+01:00",
-          "updated_at": "2024-12-11T16:45:33.756113+01:00",
-          "name": "foo.example.org",
-          "contact": "foo@example.org",
-          "ttl": null,
-          "comment": "",
-          "zone": 1
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/naptrs/?host=22",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/srvs/?host=22",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
+          "srvs": [
             {
-              "created_at": "2024-12-11T16:45:34.272043+01:00",
-              "updated_at": "2024-12-11T16:45:34.272058+01:00",
+              "created_at": "2025-03-19T12:05:02.876109+01:00",
+              "updated_at": "2025-03-19T12:05:02.876117+01:00",
               "name": "_sip._tcp.example.org",
               "priority": 10,
               "weight": 5,
@@ -31938,7 +30649,22 @@
               "zone": 1,
               "host": 22
             }
-          ]
+          ],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
+          "hinfo": null,
+          "loc": null,
+          "bacnetid": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:05:02.687061+01:00",
+          "updated_at": "2025-03-19T12:05:02.687069+01:00",
+          "name": "foo.example.org",
+          "contact": "foo@example.org",
+          "ttl": null,
+          "comment": "",
+          "zone": 1
         }
       },
       {
@@ -31968,8 +30694,8 @@
       "              10.0.0.10   <not set>   ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Thu Feb 27 10:48:05 2025",
-      "Updated:      Thu Feb 27 10:48:05 2025"
+      "Created:      Wed Mar 19 12:05:03 2025",
+      "Updated:      Wed Mar 19 12:05:03 2025"
     ],
     "api_requests": [
       {
@@ -31999,18 +30725,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2025-02-27T10:47:35.896278+01:00",
-                "updated_at": "2025-02-27T10:47:35.896293+01:00",
+                "created_at": "2025-03-19T12:04:41.191611+01:00",
+                "updated_at": "2025-03-19T12:04:41.191623+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-02-27T10:47:35.640608+01:00",
-            "updated_at": "2025-02-27T10:48:05.306235+01:00",
+            "created_at": "2025-03-19T12:04:40.912310+01:00",
+            "updated_at": "2025-03-19T12:05:02.976839+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-02-27T10:47:35.942147+01:00",
+            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -32027,8 +30753,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2025-02-27T10:47:53.101849+01:00",
-          "updated_at": "2025-02-27T10:47:53.101861+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.460376+01:00",
+          "updated_at": "2025-03-19T12:04:54.460385+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -32058,8 +30786,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-02-27T10:48:05.423771+01:00",
-              "updated_at": "2025-02-27T10:48:05.423776+01:00",
+              "created_at": "2025-03-19T12:05:03.084656+01:00",
+              "updated_at": "2025-03-19T12:05:03.084661+01:00",
               "ipaddress": "10.0.0.10",
               "host": 23
             }
@@ -32068,18 +30796,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-02-27T10:48:05.412724+01:00",
-              "updated_at": "2025-02-27T10:48:05.412730+01:00",
+              "created_at": "2025-03-19T12:05:03.070328+01:00",
+              "updated_at": "2025-03-19T12:05:03.070334+01:00",
               "txt": "v=spf1 -all",
               "host": 23
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2025-02-27T10:48:05.410792+01:00",
-          "updated_at": "2025-02-27T10:48:05.410800+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:05:03.068593+01:00",
+          "updated_at": "2025-03-19T12:05:03.068600+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -32094,8 +30828,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2025-02-27T10:47:53.101849+01:00",
-          "updated_at": "2025-02-27T10:47:53.101861+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.460376+01:00",
+          "updated_at": "2025-03-19T12:04:54.460385+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -32104,85 +30840,6 @@
           "location": "",
           "frozen": false,
           "reserved": 3
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/ip/10.0.0.10",
-        "data": {},
-        "status": 200,
-        "response": {
-          "excluded_ranges": [],
-          "created_at": "2025-02-27T10:47:53.101849+01:00",
-          "updated_at": "2025-02-27T10:47:53.101861+01:00",
-          "network": "10.0.0.0/24",
-          "description": "lorem ipsum",
-          "vlan": null,
-          "dns_delegated": false,
-          "category": "",
-          "location": "",
-          "frozen": false,
-          "reserved": 3
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/srvs/?host=23",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/naptrs/?host=23",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/sshfps/?host=23",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hostpolicy/roles/?hosts=23",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hostgroups/?hosts=23",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
         }
       }
     ],
@@ -32209,8 +30866,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:34.858848+01:00",
-              "updated_at": "2024-12-11T16:45:34.858857+01:00",
+              "created_at": "2025-03-19T12:05:03.084656+01:00",
+              "updated_at": "2025-03-19T12:05:03.084661+01:00",
               "ipaddress": "10.0.0.10",
               "host": 23
             }
@@ -32219,18 +30876,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:34.841296+01:00",
-              "updated_at": "2024-12-11T16:45:34.841304+01:00",
+              "created_at": "2025-03-19T12:05:03.070328+01:00",
+              "updated_at": "2025-03-19T12:05:03.070334+01:00",
               "txt": "v=spf1 -all",
               "host": 23
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:34.837222+01:00",
-          "updated_at": "2024-12-11T16:45:34.837236+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:05:03.068593+01:00",
+          "updated_at": "2025-03-19T12:05:03.068600+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -32265,18 +30928,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2024-12-11T16:44:40.356452+01:00",
-                "updated_at": "2024-12-11T16:44:40.356481+01:00",
+                "created_at": "2025-03-19T12:04:41.191611+01:00",
+                "updated_at": "2025-03-19T12:04:41.191623+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2024-12-11T16:44:39.701254+01:00",
-            "updated_at": "2024-12-11T16:45:34.858049+01:00",
+            "created_at": "2025-03-19T12:04:40.912310+01:00",
+            "updated_at": "2025-03-19T12:05:03.084178+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
+            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -32295,8 +30958,8 @@
         },
         "status": 201,
         "response": {
-          "created_at": "2024-12-11T16:45:35.367441+01:00",
-          "updated_at": "2024-12-11T16:45:35.367455+01:00",
+          "created_at": "2025-03-19T12:05:03.235816+01:00",
+          "updated_at": "2025-03-19T12:05:03.235823+01:00",
           "name": "fubar.example.org",
           "ttl": null,
           "zone": 1,
@@ -32312,16 +30975,16 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:34.858848+01:00",
-              "updated_at": "2024-12-11T16:45:34.858857+01:00",
+              "created_at": "2025-03-19T12:05:03.084656+01:00",
+              "updated_at": "2025-03-19T12:05:03.084661+01:00",
               "ipaddress": "10.0.0.10",
               "host": 23
             }
           ],
           "cnames": [
             {
-              "created_at": "2024-12-11T16:45:35.367441+01:00",
-              "updated_at": "2024-12-11T16:45:35.367455+01:00",
+              "created_at": "2025-03-19T12:05:03.235816+01:00",
+              "updated_at": "2025-03-19T12:05:03.235823+01:00",
               "name": "fubar.example.org",
               "ttl": null,
               "zone": 1,
@@ -32331,18 +30994,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:34.841296+01:00",
-              "updated_at": "2024-12-11T16:45:34.841304+01:00",
+              "created_at": "2025-03-19T12:05:03.070328+01:00",
+              "updated_at": "2025-03-19T12:05:03.070334+01:00",
               "txt": "v=spf1 -all",
               "host": 23
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:34.837222+01:00",
-          "updated_at": "2024-12-11T16:45:34.837236+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:05:03.068593+01:00",
+          "updated_at": "2025-03-19T12:05:03.068600+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -32361,8 +31030,8 @@
           "previous": null,
           "results": [
             {
-              "created_at": "2024-12-11T16:45:35.367441+01:00",
-              "updated_at": "2024-12-11T16:45:35.367455+01:00",
+              "created_at": "2025-03-19T12:05:03.235816+01:00",
+              "updated_at": "2025-03-19T12:05:03.235823+01:00",
               "name": "fubar.example.org",
               "ttl": null,
               "zone": 1,
@@ -32395,16 +31064,16 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:34.858848+01:00",
-              "updated_at": "2024-12-11T16:45:34.858857+01:00",
+              "created_at": "2025-03-19T12:05:03.084656+01:00",
+              "updated_at": "2025-03-19T12:05:03.084661+01:00",
               "ipaddress": "10.0.0.10",
               "host": 23
             }
           ],
           "cnames": [
             {
-              "created_at": "2024-12-11T16:45:35.367441+01:00",
-              "updated_at": "2024-12-11T16:45:35.367455+01:00",
+              "created_at": "2025-03-19T12:05:03.235816+01:00",
+              "updated_at": "2025-03-19T12:05:03.235823+01:00",
               "name": "fubar.example.org",
               "ttl": null,
               "zone": 1,
@@ -32414,47 +31083,29 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:34.841296+01:00",
-              "updated_at": "2024-12-11T16:45:34.841304+01:00",
+              "created_at": "2025-03-19T12:05:03.070328+01:00",
+              "updated_at": "2025-03-19T12:05:03.070334+01:00",
               "txt": "v=spf1 -all",
               "host": 23
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:34.837222+01:00",
-          "updated_at": "2024-12-11T16:45:34.837236+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:05:03.068593+01:00",
+          "updated_at": "2025-03-19T12:05:03.068600+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
           "comment": "",
           "zone": 1
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/naptrs/?host=23",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/srvs/?host=23",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
         }
       }
     ],
@@ -32481,16 +31132,16 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:34.858848+01:00",
-              "updated_at": "2024-12-11T16:45:34.858857+01:00",
+              "created_at": "2025-03-19T12:05:03.084656+01:00",
+              "updated_at": "2025-03-19T12:05:03.084661+01:00",
               "ipaddress": "10.0.0.10",
               "host": 23
             }
           ],
           "cnames": [
             {
-              "created_at": "2024-12-11T16:45:35.367441+01:00",
-              "updated_at": "2024-12-11T16:45:35.367455+01:00",
+              "created_at": "2025-03-19T12:05:03.235816+01:00",
+              "updated_at": "2025-03-19T12:05:03.235823+01:00",
               "name": "fubar.example.org",
               "ttl": null,
               "zone": 1,
@@ -32500,47 +31151,29 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:34.841296+01:00",
-              "updated_at": "2024-12-11T16:45:34.841304+01:00",
+              "created_at": "2025-03-19T12:05:03.070328+01:00",
+              "updated_at": "2025-03-19T12:05:03.070334+01:00",
               "txt": "v=spf1 -all",
               "host": 23
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:34.837222+01:00",
-          "updated_at": "2024-12-11T16:45:34.837236+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:05:03.068593+01:00",
+          "updated_at": "2025-03-19T12:05:03.068600+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
           "comment": "",
           "zone": 1
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/naptrs/?host=23",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/srvs/?host=23",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
         }
       },
       {
@@ -32570,8 +31203,8 @@
       "              10.0.0.10   <not set>   ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Thu Feb 27 10:48:06 2025",
-      "Updated:      Thu Feb 27 10:48:06 2025"
+      "Created:      Wed Mar 19 12:05:03 2025",
+      "Updated:      Wed Mar 19 12:05:03 2025"
     ],
     "api_requests": [
       {
@@ -32601,18 +31234,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2025-02-27T10:47:35.896278+01:00",
-                "updated_at": "2025-02-27T10:47:35.896293+01:00",
+                "created_at": "2025-03-19T12:04:41.191611+01:00",
+                "updated_at": "2025-03-19T12:04:41.191623+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-02-27T10:47:35.640608+01:00",
-            "updated_at": "2025-02-27T10:48:06.002682+01:00",
+            "created_at": "2025-03-19T12:04:40.912310+01:00",
+            "updated_at": "2025-03-19T12:05:03.383021+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-02-27T10:47:35.942147+01:00",
+            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -32629,8 +31262,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2025-02-27T10:47:53.101849+01:00",
-          "updated_at": "2025-02-27T10:47:53.101861+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.460376+01:00",
+          "updated_at": "2025-03-19T12:04:54.460385+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -32660,8 +31295,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-02-27T10:48:06.108600+01:00",
-              "updated_at": "2025-02-27T10:48:06.108606+01:00",
+              "created_at": "2025-03-19T12:05:03.498600+01:00",
+              "updated_at": "2025-03-19T12:05:03.498607+01:00",
               "ipaddress": "10.0.0.10",
               "host": 24
             }
@@ -32670,18 +31305,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-02-27T10:48:06.098703+01:00",
-              "updated_at": "2025-02-27T10:48:06.098709+01:00",
+              "created_at": "2025-03-19T12:05:03.478745+01:00",
+              "updated_at": "2025-03-19T12:05:03.478753+01:00",
               "txt": "v=spf1 -all",
               "host": 24
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2025-02-27T10:48:06.097251+01:00",
-          "updated_at": "2025-02-27T10:48:06.097259+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:05:03.476320+01:00",
+          "updated_at": "2025-03-19T12:05:03.476330+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -32696,8 +31337,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2025-02-27T10:47:53.101849+01:00",
-          "updated_at": "2025-02-27T10:47:53.101861+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.460376+01:00",
+          "updated_at": "2025-03-19T12:04:54.460385+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -32706,85 +31349,6 @@
           "location": "",
           "frozen": false,
           "reserved": 3
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/ip/10.0.0.10",
-        "data": {},
-        "status": 200,
-        "response": {
-          "excluded_ranges": [],
-          "created_at": "2025-02-27T10:47:53.101849+01:00",
-          "updated_at": "2025-02-27T10:47:53.101861+01:00",
-          "network": "10.0.0.0/24",
-          "description": "lorem ipsum",
-          "vlan": null,
-          "dns_delegated": false,
-          "category": "",
-          "location": "",
-          "frozen": false,
-          "reserved": 3
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/srvs/?host=24",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/naptrs/?host=24",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/sshfps/?host=24",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hostpolicy/roles/?hosts=24",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hostgroups/?hosts=24",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
         }
       }
     ],
@@ -32811,8 +31375,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:36.048114+01:00",
-              "updated_at": "2024-12-11T16:45:36.048123+01:00",
+              "created_at": "2025-03-19T12:05:03.498600+01:00",
+              "updated_at": "2025-03-19T12:05:03.498607+01:00",
               "ipaddress": "10.0.0.10",
               "host": 24
             }
@@ -32821,18 +31385,24 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:36.029619+01:00",
-              "updated_at": "2024-12-11T16:45:36.029627+01:00",
+              "created_at": "2025-03-19T12:05:03.478745+01:00",
+              "updated_at": "2025-03-19T12:05:03.478753+01:00",
               "txt": "v=spf1 -all",
               "host": 24
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:36.027149+01:00",
-          "updated_at": "2024-12-11T16:45:36.027158+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:05:03.476320+01:00",
+          "updated_at": "2025-03-19T12:05:03.476330+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -32850,8 +31420,8 @@
         },
         "status": 201,
         "response": {
-          "created_at": "2024-12-11T16:45:36.430253+01:00",
-          "updated_at": "2024-12-11T16:45:36.430266+01:00",
+          "created_at": "2025-03-19T12:05:03.596595+01:00",
+          "updated_at": "2025-03-19T12:05:03.596602+01:00",
           "priority": 10,
           "mx": "mail.example.org",
           "host": 24
@@ -32881,8 +31451,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:36.048114+01:00",
-              "updated_at": "2024-12-11T16:45:36.048123+01:00",
+              "created_at": "2025-03-19T12:05:03.498600+01:00",
+              "updated_at": "2025-03-19T12:05:03.498607+01:00",
               "ipaddress": "10.0.0.10",
               "host": 24
             }
@@ -32890,8 +31460,8 @@
           "cnames": [],
           "mxs": [
             {
-              "created_at": "2024-12-11T16:45:36.430253+01:00",
-              "updated_at": "2024-12-11T16:45:36.430266+01:00",
+              "created_at": "2025-03-19T12:05:03.596595+01:00",
+              "updated_at": "2025-03-19T12:05:03.596602+01:00",
               "priority": 10,
               "mx": "mail.example.org",
               "host": 24
@@ -32899,18 +31469,24 @@
           ],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:36.029619+01:00",
-              "updated_at": "2024-12-11T16:45:36.029627+01:00",
+              "created_at": "2025-03-19T12:05:03.478745+01:00",
+              "updated_at": "2025-03-19T12:05:03.478753+01:00",
               "txt": "v=spf1 -all",
               "host": 24
             }
           ],
           "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:36.027149+01:00",
-          "updated_at": "2024-12-11T16:45:36.027158+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:05:03.476320+01:00",
+          "updated_at": "2025-03-19T12:05:03.476330+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -32937,8 +31513,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:45:12.363738+01:00",
-          "updated_at": "2024-12-11T16:45:12.363771+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:04:54.460376+01:00",
+          "updated_at": "2025-03-19T12:04:54.460385+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -32971,8 +31549,8 @@
         },
         "status": 201,
         "response": {
-          "created_at": "2024-12-11T16:45:36.648723+01:00",
-          "updated_at": "2024-12-11T16:45:36.648735+01:00",
+          "created_at": "2025-03-19T12:05:03.695706+01:00",
+          "updated_at": "2025-03-19T12:05:03.695714+01:00",
           "ipaddress": "10.0.0.11",
           "host": 24
         }
@@ -33001,8 +31579,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:36.048114+01:00",
-              "updated_at": "2024-12-11T16:45:36.048123+01:00",
+              "created_at": "2025-03-19T12:05:03.498600+01:00",
+              "updated_at": "2025-03-19T12:05:03.498607+01:00",
               "ipaddress": "10.0.0.10",
               "host": 24
             }
@@ -33010,8 +31588,8 @@
           "cnames": [],
           "mxs": [
             {
-              "created_at": "2024-12-11T16:45:36.430253+01:00",
-              "updated_at": "2024-12-11T16:45:36.430266+01:00",
+              "created_at": "2025-03-19T12:05:03.596595+01:00",
+              "updated_at": "2025-03-19T12:05:03.596602+01:00",
               "priority": 10,
               "mx": "mail.example.org",
               "host": 24
@@ -33019,25 +31597,31 @@
           ],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:36.029619+01:00",
-              "updated_at": "2024-12-11T16:45:36.029627+01:00",
+              "created_at": "2025-03-19T12:05:03.478745+01:00",
+              "updated_at": "2025-03-19T12:05:03.478753+01:00",
               "txt": "v=spf1 -all",
               "host": 24
             }
           ],
           "ptr_overrides": [
             {
-              "created_at": "2024-12-11T16:45:36.648723+01:00",
-              "updated_at": "2024-12-11T16:45:36.648735+01:00",
+              "created_at": "2025-03-19T12:05:03.695706+01:00",
+              "updated_at": "2025-03-19T12:05:03.695714+01:00",
               "ipaddress": "10.0.0.11",
               "host": 24
             }
           ],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:36.027149+01:00",
-          "updated_at": "2024-12-11T16:45:36.027158+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:05:03.476320+01:00",
+          "updated_at": "2025-03-19T12:05:03.476330+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -33071,8 +31655,8 @@
         },
         "status": 201,
         "response": {
-          "created_at": "2024-12-11T16:45:36.789752+01:00",
-          "updated_at": "2024-12-11T16:45:36.789788+01:00",
+          "created_at": "2025-03-19T12:05:03.765291+01:00",
+          "updated_at": "2025-03-19T12:05:03.765297+01:00",
           "preference": 16384,
           "order": 3,
           "flag": "u",
@@ -33106,8 +31690,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:36.048114+01:00",
-              "updated_at": "2024-12-11T16:45:36.048123+01:00",
+              "created_at": "2025-03-19T12:05:03.498600+01:00",
+              "updated_at": "2025-03-19T12:05:03.498607+01:00",
               "ipaddress": "10.0.0.10",
               "host": 24
             }
@@ -33115,8 +31699,8 @@
           "cnames": [],
           "mxs": [
             {
-              "created_at": "2024-12-11T16:45:36.430253+01:00",
-              "updated_at": "2024-12-11T16:45:36.430266+01:00",
+              "created_at": "2025-03-19T12:05:03.596595+01:00",
+              "updated_at": "2025-03-19T12:05:03.596602+01:00",
               "priority": 10,
               "mx": "mail.example.org",
               "host": 24
@@ -33124,25 +31708,43 @@
           ],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:36.029619+01:00",
-              "updated_at": "2024-12-11T16:45:36.029627+01:00",
+              "created_at": "2025-03-19T12:05:03.478745+01:00",
+              "updated_at": "2025-03-19T12:05:03.478753+01:00",
               "txt": "v=spf1 -all",
               "host": 24
             }
           ],
           "ptr_overrides": [
             {
-              "created_at": "2024-12-11T16:45:36.648723+01:00",
-              "updated_at": "2024-12-11T16:45:36.648735+01:00",
+              "created_at": "2025-03-19T12:05:03.695706+01:00",
+              "updated_at": "2025-03-19T12:05:03.695714+01:00",
               "ipaddress": "10.0.0.11",
               "host": 24
             }
           ],
+          "srvs": [],
+          "naptrs": [
+            {
+              "created_at": "2025-03-19T12:05:03.765291+01:00",
+              "updated_at": "2025-03-19T12:05:03.765297+01:00",
+              "preference": 16384,
+              "order": 3,
+              "flag": "u",
+              "service": "sip",
+              "regex": "[abc]+",
+              "replacement": "wonk",
+              "host": 24
+            }
+          ],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:36.027149+01:00",
-          "updated_at": "2024-12-11T16:45:36.027158+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:05:03.476320+01:00",
+          "updated_at": "2025-03-19T12:05:03.476330+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -33159,18 +31761,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2024-12-11T16:44:40.356452+01:00",
-                "updated_at": "2024-12-11T16:44:40.356481+01:00",
+                "created_at": "2025-03-19T12:04:41.191611+01:00",
+                "updated_at": "2025-03-19T12:04:41.191623+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2024-12-11T16:44:39.701254+01:00",
-            "updated_at": "2024-12-11T16:45:36.784422+01:00",
+            "created_at": "2025-03-19T12:04:40.912310+01:00",
+            "updated_at": "2025-03-19T12:05:03.764498+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
+            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -33189,18 +31791,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2024-12-11T16:44:40.356452+01:00",
-                "updated_at": "2024-12-11T16:44:40.356481+01:00",
+                "created_at": "2025-03-19T12:04:41.191611+01:00",
+                "updated_at": "2025-03-19T12:04:41.191623+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2024-12-11T16:44:39.701254+01:00",
-            "updated_at": "2024-12-11T16:45:36.784422+01:00",
+            "created_at": "2025-03-19T12:04:40.912310+01:00",
+            "updated_at": "2025-03-19T12:05:03.764498+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
+            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -33234,8 +31836,8 @@
         },
         "status": 201,
         "response": {
-          "created_at": "2024-12-11T16:45:37.022008+01:00",
-          "updated_at": "2024-12-11T16:45:37.022022+01:00",
+          "created_at": "2025-03-19T12:05:03.874575+01:00",
+          "updated_at": "2025-03-19T12:05:03.874581+01:00",
           "name": "_sip._tcp.example.org",
           "priority": 10,
           "weight": 5,
@@ -33269,8 +31871,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:36.048114+01:00",
-              "updated_at": "2024-12-11T16:45:36.048123+01:00",
+              "created_at": "2025-03-19T12:05:03.498600+01:00",
+              "updated_at": "2025-03-19T12:05:03.498607+01:00",
               "ipaddress": "10.0.0.10",
               "host": 24
             }
@@ -33278,8 +31880,8 @@
           "cnames": [],
           "mxs": [
             {
-              "created_at": "2024-12-11T16:45:36.430253+01:00",
-              "updated_at": "2024-12-11T16:45:36.430266+01:00",
+              "created_at": "2025-03-19T12:05:03.596595+01:00",
+              "updated_at": "2025-03-19T12:05:03.596602+01:00",
               "priority": 10,
               "mx": "mail.example.org",
               "host": 24
@@ -33287,25 +31889,55 @@
           ],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:36.029619+01:00",
-              "updated_at": "2024-12-11T16:45:36.029627+01:00",
+              "created_at": "2025-03-19T12:05:03.478745+01:00",
+              "updated_at": "2025-03-19T12:05:03.478753+01:00",
               "txt": "v=spf1 -all",
               "host": 24
             }
           ],
           "ptr_overrides": [
             {
-              "created_at": "2024-12-11T16:45:36.648723+01:00",
-              "updated_at": "2024-12-11T16:45:36.648735+01:00",
+              "created_at": "2025-03-19T12:05:03.695706+01:00",
+              "updated_at": "2025-03-19T12:05:03.695714+01:00",
               "ipaddress": "10.0.0.11",
               "host": 24
             }
           ],
+          "srvs": [
+            {
+              "created_at": "2025-03-19T12:05:03.874575+01:00",
+              "updated_at": "2025-03-19T12:05:03.874581+01:00",
+              "name": "_sip._tcp.example.org",
+              "priority": 10,
+              "weight": 5,
+              "port": 3456,
+              "ttl": null,
+              "zone": 1,
+              "host": 24
+            }
+          ],
+          "naptrs": [
+            {
+              "created_at": "2025-03-19T12:05:03.765291+01:00",
+              "updated_at": "2025-03-19T12:05:03.765297+01:00",
+              "preference": 16384,
+              "order": 3,
+              "flag": "u",
+              "service": "sip",
+              "regex": "[abc]+",
+              "replacement": "wonk",
+              "host": 24
+            }
+          ],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:36.027149+01:00",
-          "updated_at": "2024-12-11T16:45:36.027158+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:05:03.476320+01:00",
+          "updated_at": "2025-03-19T12:05:03.476330+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -33340,18 +31972,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2024-12-11T16:44:40.356452+01:00",
-                "updated_at": "2024-12-11T16:44:40.356481+01:00",
+                "created_at": "2025-03-19T12:04:41.191611+01:00",
+                "updated_at": "2025-03-19T12:04:41.191623+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2024-12-11T16:44:39.701254+01:00",
-            "updated_at": "2024-12-11T16:45:37.010300+01:00",
+            "created_at": "2025-03-19T12:04:40.912310+01:00",
+            "updated_at": "2025-03-19T12:05:03.873771+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
+            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -33370,8 +32002,8 @@
         },
         "status": 201,
         "response": {
-          "created_at": "2024-12-11T16:45:37.247207+01:00",
-          "updated_at": "2024-12-11T16:45:37.247221+01:00",
+          "created_at": "2025-03-19T12:05:03.975069+01:00",
+          "updated_at": "2025-03-19T12:05:03.975076+01:00",
           "name": "fubar.example.org",
           "ttl": null,
           "zone": 1,
@@ -33387,16 +32019,16 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:36.048114+01:00",
-              "updated_at": "2024-12-11T16:45:36.048123+01:00",
+              "created_at": "2025-03-19T12:05:03.498600+01:00",
+              "updated_at": "2025-03-19T12:05:03.498607+01:00",
               "ipaddress": "10.0.0.10",
               "host": 24
             }
           ],
           "cnames": [
             {
-              "created_at": "2024-12-11T16:45:37.247207+01:00",
-              "updated_at": "2024-12-11T16:45:37.247221+01:00",
+              "created_at": "2025-03-19T12:05:03.975069+01:00",
+              "updated_at": "2025-03-19T12:05:03.975076+01:00",
               "name": "fubar.example.org",
               "ttl": null,
               "zone": 1,
@@ -33405,8 +32037,8 @@
           ],
           "mxs": [
             {
-              "created_at": "2024-12-11T16:45:36.430253+01:00",
-              "updated_at": "2024-12-11T16:45:36.430266+01:00",
+              "created_at": "2025-03-19T12:05:03.596595+01:00",
+              "updated_at": "2025-03-19T12:05:03.596602+01:00",
               "priority": 10,
               "mx": "mail.example.org",
               "host": 24
@@ -33414,25 +32046,55 @@
           ],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:36.029619+01:00",
-              "updated_at": "2024-12-11T16:45:36.029627+01:00",
+              "created_at": "2025-03-19T12:05:03.478745+01:00",
+              "updated_at": "2025-03-19T12:05:03.478753+01:00",
               "txt": "v=spf1 -all",
               "host": 24
             }
           ],
           "ptr_overrides": [
             {
-              "created_at": "2024-12-11T16:45:36.648723+01:00",
-              "updated_at": "2024-12-11T16:45:36.648735+01:00",
+              "created_at": "2025-03-19T12:05:03.695706+01:00",
+              "updated_at": "2025-03-19T12:05:03.695714+01:00",
               "ipaddress": "10.0.0.11",
               "host": 24
             }
           ],
+          "srvs": [
+            {
+              "created_at": "2025-03-19T12:05:03.874575+01:00",
+              "updated_at": "2025-03-19T12:05:03.874581+01:00",
+              "name": "_sip._tcp.example.org",
+              "priority": 10,
+              "weight": 5,
+              "port": 3456,
+              "ttl": null,
+              "zone": 1,
+              "host": 24
+            }
+          ],
+          "naptrs": [
+            {
+              "created_at": "2025-03-19T12:05:03.765291+01:00",
+              "updated_at": "2025-03-19T12:05:03.765297+01:00",
+              "preference": 16384,
+              "order": 3,
+              "flag": "u",
+              "service": "sip",
+              "regex": "[abc]+",
+              "replacement": "wonk",
+              "host": 24
+            }
+          ],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
-          "created_at": "2024-12-11T16:45:36.027149+01:00",
-          "updated_at": "2024-12-11T16:45:36.027158+01:00",
+          "communities": [],
+          "created_at": "2025-03-19T12:05:03.476320+01:00",
+          "updated_at": "2025-03-19T12:05:03.476330+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -33451,8 +32113,8 @@
           "previous": null,
           "results": [
             {
-              "created_at": "2024-12-11T16:45:37.247207+01:00",
-              "updated_at": "2024-12-11T16:45:37.247221+01:00",
+              "created_at": "2025-03-19T12:05:03.975069+01:00",
+              "updated_at": "2025-03-19T12:05:03.975076+01:00",
               "name": "fubar.example.org",
               "ttl": null,
               "zone": 1,
@@ -33485,16 +32147,16 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:36.048114+01:00",
-              "updated_at": "2024-12-11T16:45:36.048123+01:00",
+              "created_at": "2025-03-19T12:05:03.498600+01:00",
+              "updated_at": "2025-03-19T12:05:03.498607+01:00",
               "ipaddress": "10.0.0.10",
               "host": 24
             }
           ],
           "cnames": [
             {
-              "created_at": "2024-12-11T16:45:37.247207+01:00",
-              "updated_at": "2024-12-11T16:45:37.247221+01:00",
+              "created_at": "2025-03-19T12:05:03.975069+01:00",
+              "updated_at": "2025-03-19T12:05:03.975076+01:00",
               "name": "fubar.example.org",
               "ttl": null,
               "zone": 1,
@@ -33503,8 +32165,8 @@
           ],
           "mxs": [
             {
-              "created_at": "2024-12-11T16:45:36.430253+01:00",
-              "updated_at": "2024-12-11T16:45:36.430266+01:00",
+              "created_at": "2025-03-19T12:05:03.596595+01:00",
+              "updated_at": "2025-03-19T12:05:03.596602+01:00",
               "priority": 10,
               "mx": "mail.example.org",
               "host": 24
@@ -33512,69 +32174,24 @@
           ],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:36.029619+01:00",
-              "updated_at": "2024-12-11T16:45:36.029627+01:00",
+              "created_at": "2025-03-19T12:05:03.478745+01:00",
+              "updated_at": "2025-03-19T12:05:03.478753+01:00",
               "txt": "v=spf1 -all",
               "host": 24
             }
           ],
           "ptr_overrides": [
             {
-              "created_at": "2024-12-11T16:45:36.648723+01:00",
-              "updated_at": "2024-12-11T16:45:36.648735+01:00",
+              "created_at": "2025-03-19T12:05:03.695706+01:00",
+              "updated_at": "2025-03-19T12:05:03.695714+01:00",
               "ipaddress": "10.0.0.11",
               "host": 24
             }
           ],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "created_at": "2024-12-11T16:45:36.027149+01:00",
-          "updated_at": "2024-12-11T16:45:36.027158+01:00",
-          "name": "foo.example.org",
-          "contact": "foo@example.org",
-          "ttl": null,
-          "comment": "",
-          "zone": 1
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/naptrs/?host=24",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
+          "srvs": [
             {
-              "created_at": "2024-12-11T16:45:36.789752+01:00",
-              "updated_at": "2024-12-11T16:45:36.789788+01:00",
-              "preference": 16384,
-              "order": 3,
-              "flag": "u",
-              "service": "sip",
-              "regex": "[abc]+",
-              "replacement": "wonk",
-              "host": 24
-            }
-          ]
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/srvs/?host=24",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
-            {
-              "created_at": "2024-12-11T16:45:37.022008+01:00",
-              "updated_at": "2024-12-11T16:45:37.022022+01:00",
+              "created_at": "2025-03-19T12:05:03.874575+01:00",
+              "updated_at": "2025-03-19T12:05:03.874581+01:00",
               "name": "_sip._tcp.example.org",
               "priority": 10,
               "weight": 5,
@@ -33583,7 +32200,34 @@
               "zone": 1,
               "host": 24
             }
-          ]
+          ],
+          "naptrs": [
+            {
+              "created_at": "2025-03-19T12:05:03.765291+01:00",
+              "updated_at": "2025-03-19T12:05:03.765297+01:00",
+              "preference": 16384,
+              "order": 3,
+              "flag": "u",
+              "service": "sip",
+              "regex": "[abc]+",
+              "replacement": "wonk",
+              "host": 24
+            }
+          ],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
+          "hinfo": null,
+          "loc": null,
+          "bacnetid": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:05:03.476320+01:00",
+          "updated_at": "2025-03-19T12:05:03.476330+01:00",
+          "name": "foo.example.org",
+          "contact": "foo@example.org",
+          "ttl": null,
+          "comment": "",
+          "zone": 1
         }
       }
     ],
@@ -33613,16 +32257,16 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2024-12-11T16:45:36.048114+01:00",
-              "updated_at": "2024-12-11T16:45:36.048123+01:00",
+              "created_at": "2025-03-19T12:05:03.498600+01:00",
+              "updated_at": "2025-03-19T12:05:03.498607+01:00",
               "ipaddress": "10.0.0.10",
               "host": 24
             }
           ],
           "cnames": [
             {
-              "created_at": "2024-12-11T16:45:37.247207+01:00",
-              "updated_at": "2024-12-11T16:45:37.247221+01:00",
+              "created_at": "2025-03-19T12:05:03.975069+01:00",
+              "updated_at": "2025-03-19T12:05:03.975076+01:00",
               "name": "fubar.example.org",
               "ttl": null,
               "zone": 1,
@@ -33631,8 +32275,8 @@
           ],
           "mxs": [
             {
-              "created_at": "2024-12-11T16:45:36.430253+01:00",
-              "updated_at": "2024-12-11T16:45:36.430266+01:00",
+              "created_at": "2025-03-19T12:05:03.596595+01:00",
+              "updated_at": "2025-03-19T12:05:03.596602+01:00",
               "priority": 10,
               "mx": "mail.example.org",
               "host": 24
@@ -33640,69 +32284,24 @@
           ],
           "txts": [
             {
-              "created_at": "2024-12-11T16:45:36.029619+01:00",
-              "updated_at": "2024-12-11T16:45:36.029627+01:00",
+              "created_at": "2025-03-19T12:05:03.478745+01:00",
+              "updated_at": "2025-03-19T12:05:03.478753+01:00",
               "txt": "v=spf1 -all",
               "host": 24
             }
           ],
           "ptr_overrides": [
             {
-              "created_at": "2024-12-11T16:45:36.648723+01:00",
-              "updated_at": "2024-12-11T16:45:36.648735+01:00",
+              "created_at": "2025-03-19T12:05:03.695706+01:00",
+              "updated_at": "2025-03-19T12:05:03.695714+01:00",
               "ipaddress": "10.0.0.11",
               "host": 24
             }
           ],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "created_at": "2024-12-11T16:45:36.027149+01:00",
-          "updated_at": "2024-12-11T16:45:36.027158+01:00",
-          "name": "foo.example.org",
-          "contact": "foo@example.org",
-          "ttl": null,
-          "comment": "",
-          "zone": 1
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/naptrs/?host=24",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
+          "srvs": [
             {
-              "created_at": "2024-12-11T16:45:36.789752+01:00",
-              "updated_at": "2024-12-11T16:45:36.789788+01:00",
-              "preference": 16384,
-              "order": 3,
-              "flag": "u",
-              "service": "sip",
-              "regex": "[abc]+",
-              "replacement": "wonk",
-              "host": 24
-            }
-          ]
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/srvs/?host=24",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
-            {
-              "created_at": "2024-12-11T16:45:37.022008+01:00",
-              "updated_at": "2024-12-11T16:45:37.022022+01:00",
+              "created_at": "2025-03-19T12:05:03.874575+01:00",
+              "updated_at": "2025-03-19T12:05:03.874581+01:00",
               "name": "_sip._tcp.example.org",
               "priority": 10,
               "weight": 5,
@@ -33711,7 +32310,34 @@
               "zone": 1,
               "host": 24
             }
-          ]
+          ],
+          "naptrs": [
+            {
+              "created_at": "2025-03-19T12:05:03.765291+01:00",
+              "updated_at": "2025-03-19T12:05:03.765297+01:00",
+              "preference": 16384,
+              "order": 3,
+              "flag": "u",
+              "service": "sip",
+              "regex": "[abc]+",
+              "replacement": "wonk",
+              "host": 24
+            }
+          ],
+          "sshfps": [],
+          "groups": [],
+          "roles": [],
+          "hinfo": null,
+          "loc": null,
+          "bacnetid": null,
+          "communities": [],
+          "created_at": "2025-03-19T12:05:03.476320+01:00",
+          "updated_at": "2025-03-19T12:05:03.476330+01:00",
+          "name": "foo.example.org",
+          "contact": "foo@example.org",
+          "ttl": null,
+          "comment": "",
+          "zone": 1
         }
       },
       {
@@ -33742,8 +32368,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:45:12.363738+01:00",
-          "updated_at": "2024-12-11T16:45:12.363771+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T10:10:58.258082+01:00",
+          "updated_at": "2025-03-19T10:10:58.258094+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -33789,8 +32417,10 @@
         "status": 200,
         "response": {
           "excluded_ranges": [],
-          "created_at": "2024-12-11T16:45:12.555848+01:00",
-          "updated_at": "2024-12-11T16:45:12.555870+01:00",
+          "policy": null,
+          "communities": [],
+          "created_at": "2025-03-19T10:10:58.349561+01:00",
+          "updated_at": "2025-03-19T10:10:58.349577+01:00",
           "network": "2001:db8::/64",
           "description": "dolor sit amet",
           "vlan": null,

--- a/ci/testsuite-result.json
+++ b/ci/testsuite-result.json
@@ -833,8 +833,8 @@
       "              10.0.2.9   <not set>   ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Wed Mar 19 12:04:41 2025",
-      "Updated:      Wed Mar 19 12:04:41 2025"
+      "Created:      Thu Mar 20 15:36:57 2025",
+      "Updated:      Thu Mar 20 15:36:57 2025"
     ],
     "api_requests": [
       {
@@ -864,18 +864,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2025-03-19T12:04:41.191611+01:00",
-                "updated_at": "2025-03-19T12:04:41.191623+01:00",
+                "created_at": "2025-03-20T15:36:56.518688+01:00",
+                "updated_at": "2025-03-20T15:36:56.518700+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-03-19T12:04:40.912310+01:00",
-            "updated_at": "2025-03-19T12:04:41.355456+01:00",
+            "created_at": "2025-03-20T15:36:56.108293+01:00",
+            "updated_at": "2025-03-20T15:36:56.684389+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
+            "serialno_updated_at": "2025-03-20T15:36:56.561109+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -894,8 +894,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:41.509492+01:00",
-          "updated_at": "2025-03-19T12:04:41.751198+01:00",
+          "created_at": "2025-03-20T15:36:56.750269+01:00",
+          "updated_at": "2025-03-20T15:36:57.035463+01:00",
           "network": "10.0.2.0/28",
           "description": "TinyNet",
           "vlan": null,
@@ -925,8 +925,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:41.978445+01:00",
-              "updated_at": "2025-03-19T12:04:41.978451+01:00",
+              "created_at": "2025-03-20T15:36:57.187507+01:00",
+              "updated_at": "2025-03-20T15:36:57.187513+01:00",
               "ipaddress": "10.0.2.9",
               "host": 1
             }
@@ -935,8 +935,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:41.956953+01:00",
-              "updated_at": "2025-03-19T12:04:41.956960+01:00",
+              "created_at": "2025-03-20T15:36:57.167324+01:00",
+              "updated_at": "2025-03-20T15:36:57.167330+01:00",
               "txt": "v=spf1 -all",
               "host": 1
             }
@@ -945,14 +945,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:41.954723+01:00",
-          "updated_at": "2025-03-19T12:04:41.954730+01:00",
+          "created_at": "2025-03-20T15:36:57.165140+01:00",
+          "updated_at": "2025-03-20T15:36:57.165146+01:00",
           "name": "tinyhost.example.org",
           "contact": "tinyhost@example.org",
           "ttl": null,
@@ -969,8 +969,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:41.509492+01:00",
-          "updated_at": "2025-03-19T12:04:41.751198+01:00",
+          "created_at": "2025-03-20T15:36:56.750269+01:00",
+          "updated_at": "2025-03-20T15:36:57.035463+01:00",
           "network": "10.0.2.0/28",
           "description": "TinyNet",
           "vlan": null,
@@ -1112,8 +1112,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:41.978445+01:00",
-              "updated_at": "2025-03-19T12:04:41.978451+01:00",
+              "created_at": "2025-03-20T15:36:57.187507+01:00",
+              "updated_at": "2025-03-20T15:36:57.187513+01:00",
               "ipaddress": "10.0.2.9",
               "host": 1
             }
@@ -1122,8 +1122,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:41.956953+01:00",
-              "updated_at": "2025-03-19T12:04:41.956960+01:00",
+              "created_at": "2025-03-20T15:36:57.167324+01:00",
+              "updated_at": "2025-03-20T15:36:57.167330+01:00",
               "txt": "v=spf1 -all",
               "host": 1
             }
@@ -1132,14 +1132,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:41.954723+01:00",
-          "updated_at": "2025-03-19T12:04:41.954730+01:00",
+          "created_at": "2025-03-20T15:36:57.165140+01:00",
+          "updated_at": "2025-03-20T15:36:57.165146+01:00",
           "name": "tinyhost.example.org",
           "contact": "tinyhost@example.org",
           "ttl": null,
@@ -9638,8 +9638,8 @@
       "              2001:db8::33   <not set>   ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Wed Mar 19 12:04:42 2025",
-      "Updated:      Wed Mar 19 12:04:42 2025"
+      "Created:      Thu Mar 20 15:36:57 2025",
+      "Updated:      Thu Mar 20 15:36:57 2025"
     ],
     "api_requests": [
       {
@@ -9669,18 +9669,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2025-03-19T12:04:41.191611+01:00",
-                "updated_at": "2025-03-19T12:04:41.191623+01:00",
+                "created_at": "2025-03-20T15:36:56.518688+01:00",
+                "updated_at": "2025-03-20T15:36:56.518700+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-03-19T12:04:40.912310+01:00",
-            "updated_at": "2025-03-19T12:04:42.332125+01:00",
+            "created_at": "2025-03-20T15:36:56.108293+01:00",
+            "updated_at": "2025-03-20T15:36:57.390400+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
+            "serialno_updated_at": "2025-03-20T15:36:56.561109+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -9699,8 +9699,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:42.522693+01:00",
-          "updated_at": "2025-03-19T12:04:42.777112+01:00",
+          "created_at": "2025-03-20T15:36:57.535602+01:00",
+          "updated_at": "2025-03-20T15:36:57.772556+01:00",
           "network": "2001:db8::/64",
           "description": "Lorem ipsum dolor sit amet",
           "vlan": null,
@@ -9730,8 +9730,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:42.941021+01:00",
-              "updated_at": "2025-03-19T12:04:42.941029+01:00",
+              "created_at": "2025-03-20T15:36:57.955525+01:00",
+              "updated_at": "2025-03-20T15:36:57.955532+01:00",
               "ipaddress": "2001:db8::33",
               "host": 2
             }
@@ -9740,8 +9740,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:42.918046+01:00",
-              "updated_at": "2025-03-19T12:04:42.918053+01:00",
+              "created_at": "2025-03-20T15:36:57.936502+01:00",
+              "updated_at": "2025-03-20T15:36:57.936509+01:00",
               "txt": "v=spf1 -all",
               "host": 2
             }
@@ -9750,14 +9750,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:42.915456+01:00",
-          "updated_at": "2025-03-19T12:04:42.915471+01:00",
+          "created_at": "2025-03-20T15:36:57.934243+01:00",
+          "updated_at": "2025-03-20T15:36:57.934250+01:00",
           "name": "tinyhost.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -9774,8 +9774,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:42.522693+01:00",
-          "updated_at": "2025-03-19T12:04:42.777112+01:00",
+          "created_at": "2025-03-20T15:36:57.535602+01:00",
+          "updated_at": "2025-03-20T15:36:57.772556+01:00",
           "network": "2001:db8::/64",
           "description": "Lorem ipsum dolor sit amet",
           "vlan": null,
@@ -9810,8 +9810,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:42.941021+01:00",
-              "updated_at": "2025-03-19T12:04:42.941029+01:00",
+              "created_at": "2025-03-20T15:36:57.955525+01:00",
+              "updated_at": "2025-03-20T15:36:57.955532+01:00",
               "ipaddress": "2001:db8::33",
               "host": 2
             }
@@ -9820,8 +9820,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:42.918046+01:00",
-              "updated_at": "2025-03-19T12:04:42.918053+01:00",
+              "created_at": "2025-03-20T15:36:57.936502+01:00",
+              "updated_at": "2025-03-20T15:36:57.936509+01:00",
               "txt": "v=spf1 -all",
               "host": 2
             }
@@ -9830,14 +9830,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:42.915456+01:00",
-          "updated_at": "2025-03-19T12:04:42.915471+01:00",
+          "created_at": "2025-03-20T15:36:57.934243+01:00",
+          "updated_at": "2025-03-20T15:36:57.934250+01:00",
           "name": "tinyhost.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -9854,8 +9854,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:42.522693+01:00",
-          "updated_at": "2025-03-19T12:04:42.777112+01:00",
+          "created_at": "2025-03-20T15:36:57.535602+01:00",
+          "updated_at": "2025-03-20T15:36:57.772556+01:00",
           "network": "2001:db8::/64",
           "description": "Lorem ipsum dolor sit amet",
           "vlan": null,
@@ -9883,8 +9883,8 @@
       "              2001:db8::33   <not set>   ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Wed Mar 19 12:04:42 2025",
-      "Updated:      Wed Mar 19 12:04:42 2025"
+      "Created:      Thu Mar 20 15:36:57 2025",
+      "Updated:      Thu Mar 20 15:36:57 2025"
     ],
     "api_requests": [
       {
@@ -9896,8 +9896,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:42.941021+01:00",
-              "updated_at": "2025-03-19T12:04:42.941029+01:00",
+              "created_at": "2025-03-20T15:36:57.955525+01:00",
+              "updated_at": "2025-03-20T15:36:57.955532+01:00",
               "ipaddress": "2001:db8::33",
               "host": 2
             }
@@ -9906,8 +9906,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:42.918046+01:00",
-              "updated_at": "2025-03-19T12:04:42.918053+01:00",
+              "created_at": "2025-03-20T15:36:57.936502+01:00",
+              "updated_at": "2025-03-20T15:36:57.936509+01:00",
               "txt": "v=spf1 -all",
               "host": 2
             }
@@ -9916,14 +9916,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:42.915456+01:00",
-          "updated_at": "2025-03-19T12:04:42.915471+01:00",
+          "created_at": "2025-03-20T15:36:57.934243+01:00",
+          "updated_at": "2025-03-20T15:36:57.934250+01:00",
           "name": "tinyhost.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -9940,8 +9940,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:42.522693+01:00",
-          "updated_at": "2025-03-19T12:04:42.777112+01:00",
+          "created_at": "2025-03-20T15:36:57.535602+01:00",
+          "updated_at": "2025-03-20T15:36:57.772556+01:00",
           "network": "2001:db8::/64",
           "description": "Lorem ipsum dolor sit amet",
           "vlan": null,
@@ -9976,8 +9976,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:42.941021+01:00",
-              "updated_at": "2025-03-19T12:04:42.941029+01:00",
+              "created_at": "2025-03-20T15:36:57.955525+01:00",
+              "updated_at": "2025-03-20T15:36:57.955532+01:00",
               "ipaddress": "2001:db8::33",
               "host": 2
             }
@@ -9986,8 +9986,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:42.918046+01:00",
-              "updated_at": "2025-03-19T12:04:42.918053+01:00",
+              "created_at": "2025-03-20T15:36:57.936502+01:00",
+              "updated_at": "2025-03-20T15:36:57.936509+01:00",
               "txt": "v=spf1 -all",
               "host": 2
             }
@@ -9996,14 +9996,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:42.915456+01:00",
-          "updated_at": "2025-03-19T12:04:42.915471+01:00",
+          "created_at": "2025-03-20T15:36:57.934243+01:00",
+          "updated_at": "2025-03-20T15:36:57.934250+01:00",
           "name": "tinyhost.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -10454,8 +10454,8 @@
       "              10.0.1.4   <not set>   ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Wed Mar 19 12:04:43 2025",
-      "Updated:      Wed Mar 19 12:04:43 2025"
+      "Created:      Thu Mar 20 15:36:58 2025",
+      "Updated:      Thu Mar 20 15:36:58 2025"
     ],
     "api_requests": [
       {
@@ -10485,18 +10485,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2025-03-19T12:04:41.191611+01:00",
-                "updated_at": "2025-03-19T12:04:41.191623+01:00",
+                "created_at": "2025-03-20T15:36:56.518688+01:00",
+                "updated_at": "2025-03-20T15:36:56.518700+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-03-19T12:04:40.912310+01:00",
-            "updated_at": "2025-03-19T12:04:43.163803+01:00",
+            "created_at": "2025-03-20T15:36:56.108293+01:00",
+            "updated_at": "2025-03-20T15:36:58.161193+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
+            "serialno_updated_at": "2025-03-20T15:36:56.561109+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -10514,8 +10514,8 @@
         "response": {
           "excluded_ranges": [
             {
-              "created_at": "2025-03-19T12:04:43.477741+01:00",
-              "updated_at": "2025-03-19T12:04:43.477754+01:00",
+              "created_at": "2025-03-20T15:36:58.452833+01:00",
+              "updated_at": "2025-03-20T15:36:58.452841+01:00",
               "start_ip": "10.0.1.20",
               "end_ip": "10.0.1.30",
               "network": 3
@@ -10523,8 +10523,8 @@
           ],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:43.270431+01:00",
-          "updated_at": "2025-03-19T12:04:43.337782+01:00",
+          "created_at": "2025-03-20T15:36:58.260675+01:00",
+          "updated_at": "2025-03-20T15:36:58.315184+01:00",
           "network": "10.0.1.0/24",
           "description": "Frozzzen",
           "vlan": null,
@@ -10554,8 +10554,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:43.725495+01:00",
-              "updated_at": "2025-03-19T12:04:43.725508+01:00",
+              "created_at": "2025-03-20T15:36:58.706620+01:00",
+              "updated_at": "2025-03-20T15:36:58.706626+01:00",
               "ipaddress": "10.0.1.4",
               "host": 4
             }
@@ -10564,8 +10564,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:43.707238+01:00",
-              "updated_at": "2025-03-19T12:04:43.707244+01:00",
+              "created_at": "2025-03-20T15:36:58.692419+01:00",
+              "updated_at": "2025-03-20T15:36:58.692425+01:00",
               "txt": "v=spf1 -all",
               "host": 4
             }
@@ -10574,14 +10574,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:43.705544+01:00",
-          "updated_at": "2025-03-19T12:04:43.705553+01:00",
+          "created_at": "2025-03-20T15:36:58.690682+01:00",
+          "updated_at": "2025-03-20T15:36:58.690689+01:00",
           "name": "somehost.example.org",
           "contact": "support@example.org",
           "ttl": null,
@@ -10597,8 +10597,8 @@
         "response": {
           "excluded_ranges": [
             {
-              "created_at": "2025-03-19T12:04:43.477741+01:00",
-              "updated_at": "2025-03-19T12:04:43.477754+01:00",
+              "created_at": "2025-03-20T15:36:58.452833+01:00",
+              "updated_at": "2025-03-20T15:36:58.452841+01:00",
               "start_ip": "10.0.1.20",
               "end_ip": "10.0.1.30",
               "network": 3
@@ -10606,8 +10606,8 @@
           ],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:43.270431+01:00",
-          "updated_at": "2025-03-19T12:04:43.337782+01:00",
+          "created_at": "2025-03-20T15:36:58.260675+01:00",
+          "updated_at": "2025-03-20T15:36:58.315184+01:00",
           "network": "10.0.1.0/24",
           "description": "Frozzzen",
           "vlan": null,
@@ -11174,8 +11174,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:43.725495+01:00",
-              "updated_at": "2025-03-19T12:04:43.725508+01:00",
+              "created_at": "2025-03-20T15:36:58.706620+01:00",
+              "updated_at": "2025-03-20T15:36:58.706626+01:00",
               "ipaddress": "10.0.1.4",
               "host": 4
             }
@@ -11184,8 +11184,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:43.707238+01:00",
-              "updated_at": "2025-03-19T12:04:43.707244+01:00",
+              "created_at": "2025-03-20T15:36:58.692419+01:00",
+              "updated_at": "2025-03-20T15:36:58.692425+01:00",
               "txt": "v=spf1 -all",
               "host": 4
             }
@@ -11194,14 +11194,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:43.705544+01:00",
-          "updated_at": "2025-03-19T12:04:43.705553+01:00",
+          "created_at": "2025-03-20T15:36:58.690682+01:00",
+          "updated_at": "2025-03-20T15:36:58.690689+01:00",
           "name": "somehost.example.org",
           "contact": "support@example.org",
           "ttl": null,
@@ -11231,8 +11231,8 @@
               "ipaddresses": [
                 {
                   "macaddress": "",
-                  "created_at": "2025-03-19T12:04:43.725495+01:00",
-                  "updated_at": "2025-03-19T12:04:43.725508+01:00",
+                  "created_at": "2025-03-20T15:36:58.706620+01:00",
+                  "updated_at": "2025-03-20T15:36:58.706626+01:00",
                   "ipaddress": "10.0.1.4",
                   "host": 4
                 }
@@ -11241,8 +11241,8 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2025-03-19T12:04:43.707238+01:00",
-                  "updated_at": "2025-03-19T12:04:43.707244+01:00",
+                  "created_at": "2025-03-20T15:36:58.692419+01:00",
+                  "updated_at": "2025-03-20T15:36:58.692425+01:00",
                   "txt": "v=spf1 -all",
                   "host": 4
                 }
@@ -11251,14 +11251,14 @@
               "srvs": [],
               "naptrs": [],
               "sshfps": [],
-              "groups": [],
+              "hostgroups": [],
               "roles": [],
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
               "communities": [],
-              "created_at": "2025-03-19T12:04:43.705544+01:00",
-              "updated_at": "2025-03-19T12:04:44.290099+01:00",
+              "created_at": "2025-03-20T15:36:58.690682+01:00",
+              "updated_at": "2025-03-20T15:36:59.267728+01:00",
               "name": "somehost.example.org",
               "contact": "new-support@example.org",
               "ttl": null,
@@ -11280,10 +11280,10 @@
     "warning": [],
     "error": [],
     "output": [
-      "2025-03-19 12:04:43 [system-signals]: Txt create: txt = 'v=spf1 -all'",
-      "2025-03-19 12:04:43 [test]: Host create: name = 'somehost.example.org', contact = 'support@example.org'",
-      "2025-03-19 12:04:43 [test]: Ipaddress create: ipaddress = '10.0.1.4'",
-      "2025-03-19 12:04:44 [test]: Host update: contact: support@example.org -> new-support@example.org"
+      "2025-03-20 15:36:58 [system-signals]: Txt create: txt = 'v=spf1 -all'",
+      "2025-03-20 15:36:58 [test]: Host create: name = 'somehost.example.org', contact = 'support@example.org'",
+      "2025-03-20 15:36:58 [test]: Ipaddress create: ipaddress = '10.0.1.4'",
+      "2025-03-20 15:36:59 [test]: Host update: contact: support@example.org -> new-support@example.org"
     ],
     "api_requests": [
       {
@@ -11297,7 +11297,7 @@
           "previous": null,
           "results": [
             {
-              "timestamp": "2025-03-19T12:04:43.707643+01:00",
+              "timestamp": "2025-03-20T15:36:58.692928+01:00",
               "user": "system-signals",
               "resource": "host",
               "name": "somehost.example.org",
@@ -11309,7 +11309,7 @@
               }
             },
             {
-              "timestamp": "2025-03-19T12:04:43.717675+01:00",
+              "timestamp": "2025-03-20T15:36:58.701239+01:00",
               "user": "test",
               "resource": "host",
               "name": "somehost.example.org",
@@ -11319,7 +11319,7 @@
               "data": "{\"name\": \"somehost.example.org\", \"contact\": \"support@example.org\"}"
             },
             {
-              "timestamp": "2025-03-19T12:04:43.727304+01:00",
+              "timestamp": "2025-03-20T15:36:58.707191+01:00",
               "user": "test",
               "resource": "host",
               "name": "somehost.example.org",
@@ -11329,14 +11329,14 @@
               "data": "{\"ipaddress\": \"10.0.1.4\"}"
             },
             {
-              "timestamp": "2025-03-19T12:04:44.294647+01:00",
+              "timestamp": "2025-03-20T15:36:59.273131+01:00",
               "user": "test",
               "resource": "host",
               "name": "somehost.example.org",
               "model_id": 4,
               "model": "Host",
               "action": "update",
-              "data": "{\"current_data\": {\"id\": 4, \"ipaddresses\": [{\"id\": 3, \"macaddress\": \"\", \"created_at\": \"2025-03-19T12:04:43.725495+01:00\", \"updated_at\": \"2025-03-19T12:04:43.725508+01:00\", \"ipaddress\": \"10.0.1.4\", \"host\": 4}], \"cnames\": [], \"mxs\": [], \"txts\": [{\"id\": 4, \"created_at\": \"2025-03-19T12:04:43.707238+01:00\", \"updated_at\": \"2025-03-19T12:04:43.707244+01:00\", \"txt\": \"v=spf1 -all\", \"host\": 4}], \"ptr_overrides\": [], \"srvs\": [], \"naptrs\": [], \"sshfps\": [], \"groups\": [], \"roles\": [], \"hinfo\": null, \"loc\": null, \"bacnetid\": null, \"communities\": [], \"created_at\": \"2025-03-19T12:04:43.705544+01:00\", \"updated_at\": \"2025-03-19T12:04:43.705553+01:00\", \"name\": \"somehost.example.org\", \"contact\": \"support@example.org\", \"ttl\": null, \"comment\": \"\", \"zone\": 1}, \"update\": {\"contact\": \"new-support@example.org\"}}"
+              "data": "{\"current_data\": {\"id\": 4, \"ipaddresses\": [{\"id\": 3, \"macaddress\": \"\", \"created_at\": \"2025-03-20T15:36:58.706620+01:00\", \"updated_at\": \"2025-03-20T15:36:58.706626+01:00\", \"ipaddress\": \"10.0.1.4\", \"host\": 4}], \"cnames\": [], \"mxs\": [], \"txts\": [{\"id\": 4, \"created_at\": \"2025-03-20T15:36:58.692419+01:00\", \"updated_at\": \"2025-03-20T15:36:58.692425+01:00\", \"txt\": \"v=spf1 -all\", \"host\": 4}], \"ptr_overrides\": [], \"srvs\": [], \"naptrs\": [], \"sshfps\": [], \"hostgroups\": [], \"roles\": [], \"hinfo\": null, \"loc\": null, \"bacnetid\": null, \"communities\": [], \"created_at\": \"2025-03-20T15:36:58.690682+01:00\", \"updated_at\": \"2025-03-20T15:36:58.690689+01:00\", \"name\": \"somehost.example.org\", \"contact\": \"support@example.org\", \"ttl\": null, \"comment\": \"\", \"zone\": 1}, \"update\": {\"contact\": \"new-support@example.org\"}}"
             }
           ]
         }
@@ -11352,7 +11352,7 @@
           "previous": null,
           "results": [
             {
-              "timestamp": "2025-03-19T12:04:43.707643+01:00",
+              "timestamp": "2025-03-20T15:36:58.692928+01:00",
               "user": "system-signals",
               "resource": "host",
               "name": "somehost.example.org",
@@ -11364,7 +11364,7 @@
               }
             },
             {
-              "timestamp": "2025-03-19T12:04:43.717675+01:00",
+              "timestamp": "2025-03-20T15:36:58.701239+01:00",
               "user": "test",
               "resource": "host",
               "name": "somehost.example.org",
@@ -11374,7 +11374,7 @@
               "data": "{\"name\": \"somehost.example.org\", \"contact\": \"support@example.org\"}"
             },
             {
-              "timestamp": "2025-03-19T12:04:43.727304+01:00",
+              "timestamp": "2025-03-20T15:36:58.707191+01:00",
               "user": "test",
               "resource": "host",
               "name": "somehost.example.org",
@@ -11384,14 +11384,14 @@
               "data": "{\"ipaddress\": \"10.0.1.4\"}"
             },
             {
-              "timestamp": "2025-03-19T12:04:44.294647+01:00",
+              "timestamp": "2025-03-20T15:36:59.273131+01:00",
               "user": "test",
               "resource": "host",
               "name": "somehost.example.org",
               "model_id": 4,
               "model": "Host",
               "action": "update",
-              "data": "{\"current_data\": {\"id\": 4, \"ipaddresses\": [{\"id\": 3, \"macaddress\": \"\", \"created_at\": \"2025-03-19T12:04:43.725495+01:00\", \"updated_at\": \"2025-03-19T12:04:43.725508+01:00\", \"ipaddress\": \"10.0.1.4\", \"host\": 4}], \"cnames\": [], \"mxs\": [], \"txts\": [{\"id\": 4, \"created_at\": \"2025-03-19T12:04:43.707238+01:00\", \"updated_at\": \"2025-03-19T12:04:43.707244+01:00\", \"txt\": \"v=spf1 -all\", \"host\": 4}], \"ptr_overrides\": [], \"srvs\": [], \"naptrs\": [], \"sshfps\": [], \"groups\": [], \"roles\": [], \"hinfo\": null, \"loc\": null, \"bacnetid\": null, \"communities\": [], \"created_at\": \"2025-03-19T12:04:43.705544+01:00\", \"updated_at\": \"2025-03-19T12:04:43.705553+01:00\", \"name\": \"somehost.example.org\", \"contact\": \"support@example.org\", \"ttl\": null, \"comment\": \"\", \"zone\": 1}, \"update\": {\"contact\": \"new-support@example.org\"}}"
+              "data": "{\"current_data\": {\"id\": 4, \"ipaddresses\": [{\"id\": 3, \"macaddress\": \"\", \"created_at\": \"2025-03-20T15:36:58.706620+01:00\", \"updated_at\": \"2025-03-20T15:36:58.706626+01:00\", \"ipaddress\": \"10.0.1.4\", \"host\": 4}], \"cnames\": [], \"mxs\": [], \"txts\": [{\"id\": 4, \"created_at\": \"2025-03-20T15:36:58.692419+01:00\", \"updated_at\": \"2025-03-20T15:36:58.692425+01:00\", \"txt\": \"v=spf1 -all\", \"host\": 4}], \"ptr_overrides\": [], \"srvs\": [], \"naptrs\": [], \"sshfps\": [], \"hostgroups\": [], \"roles\": [], \"hinfo\": null, \"loc\": null, \"bacnetid\": null, \"communities\": [], \"created_at\": \"2025-03-20T15:36:58.690682+01:00\", \"updated_at\": \"2025-03-20T15:36:58.690689+01:00\", \"name\": \"somehost.example.org\", \"contact\": \"support@example.org\", \"ttl\": null, \"comment\": \"\", \"zone\": 1}, \"update\": {\"contact\": \"new-support@example.org\"}}"
             }
           ]
         }
@@ -11432,8 +11432,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:43.725495+01:00",
-              "updated_at": "2025-03-19T12:04:43.725508+01:00",
+              "created_at": "2025-03-20T15:36:58.706620+01:00",
+              "updated_at": "2025-03-20T15:36:58.706626+01:00",
               "ipaddress": "10.0.1.4",
               "host": 4
             }
@@ -11442,8 +11442,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:43.707238+01:00",
-              "updated_at": "2025-03-19T12:04:43.707244+01:00",
+              "created_at": "2025-03-20T15:36:58.692419+01:00",
+              "updated_at": "2025-03-20T15:36:58.692425+01:00",
               "txt": "v=spf1 -all",
               "host": 4
             }
@@ -11452,14 +11452,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:43.705544+01:00",
-          "updated_at": "2025-03-19T12:04:44.290099+01:00",
+          "created_at": "2025-03-20T15:36:58.690682+01:00",
+          "updated_at": "2025-03-20T15:36:59.267728+01:00",
           "name": "somehost.example.org",
           "contact": "new-support@example.org",
           "ttl": null,
@@ -11475,8 +11475,8 @@
         "response": {
           "excluded_ranges": [
             {
-              "created_at": "2025-03-19T12:04:43.477741+01:00",
-              "updated_at": "2025-03-19T12:04:43.477754+01:00",
+              "created_at": "2025-03-20T15:36:58.452833+01:00",
+              "updated_at": "2025-03-20T15:36:58.452841+01:00",
               "start_ip": "10.0.1.20",
               "end_ip": "10.0.1.30",
               "network": 3
@@ -11484,8 +11484,8 @@
           ],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:43.270431+01:00",
-          "updated_at": "2025-03-19T12:04:44.091558+01:00",
+          "created_at": "2025-03-20T15:36:58.260675+01:00",
+          "updated_at": "2025-03-20T15:36:59.051810+01:00",
           "network": "10.0.1.0/24",
           "description": "Frozen but has one host",
           "vlan": 1234,
@@ -11527,8 +11527,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:43.725495+01:00",
-              "updated_at": "2025-03-19T12:04:43.725508+01:00",
+              "created_at": "2025-03-20T15:36:58.706620+01:00",
+              "updated_at": "2025-03-20T15:36:58.706626+01:00",
               "ipaddress": "10.0.1.4",
               "host": 4
             }
@@ -11537,8 +11537,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:43.707238+01:00",
-              "updated_at": "2025-03-19T12:04:43.707244+01:00",
+              "created_at": "2025-03-20T15:36:58.692419+01:00",
+              "updated_at": "2025-03-20T15:36:58.692425+01:00",
               "txt": "v=spf1 -all",
               "host": 4
             }
@@ -11547,14 +11547,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:43.705544+01:00",
-          "updated_at": "2025-03-19T12:04:44.290099+01:00",
+          "created_at": "2025-03-20T15:36:58.690682+01:00",
+          "updated_at": "2025-03-20T15:36:59.267728+01:00",
           "name": "somehost.example.org",
           "contact": "new-support@example.org",
           "ttl": null,
@@ -11570,8 +11570,8 @@
         "response": {
           "excluded_ranges": [
             {
-              "created_at": "2025-03-19T12:04:43.477741+01:00",
-              "updated_at": "2025-03-19T12:04:43.477754+01:00",
+              "created_at": "2025-03-20T15:36:58.452833+01:00",
+              "updated_at": "2025-03-20T15:36:58.452841+01:00",
               "start_ip": "10.0.1.20",
               "end_ip": "10.0.1.30",
               "network": 3
@@ -11579,8 +11579,8 @@
           ],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:43.270431+01:00",
-          "updated_at": "2025-03-19T12:04:44.091558+01:00",
+          "created_at": "2025-03-20T15:36:58.260675+01:00",
+          "updated_at": "2025-03-20T15:36:59.051810+01:00",
           "network": "10.0.1.0/24",
           "description": "Frozen but has one host",
           "vlan": 1234,
@@ -11608,8 +11608,8 @@
         "status": 201,
         "response": {
           "macaddress": "",
-          "created_at": "2025-03-19T12:04:44.602604+01:00",
-          "updated_at": "2025-03-19T12:04:44.602610+01:00",
+          "created_at": "2025-03-20T15:36:59.539135+01:00",
+          "updated_at": "2025-03-20T15:36:59.539141+01:00",
           "ipaddress": "10.0.1.5",
           "host": 4
         }
@@ -11628,15 +11628,15 @@
               "ipaddresses": [
                 {
                   "macaddress": "",
-                  "created_at": "2025-03-19T12:04:43.725495+01:00",
-                  "updated_at": "2025-03-19T12:04:43.725508+01:00",
+                  "created_at": "2025-03-20T15:36:58.706620+01:00",
+                  "updated_at": "2025-03-20T15:36:58.706626+01:00",
                   "ipaddress": "10.0.1.4",
                   "host": 4
                 },
                 {
                   "macaddress": "",
-                  "created_at": "2025-03-19T12:04:44.602604+01:00",
-                  "updated_at": "2025-03-19T12:04:44.602610+01:00",
+                  "created_at": "2025-03-20T15:36:59.539135+01:00",
+                  "updated_at": "2025-03-20T15:36:59.539141+01:00",
                   "ipaddress": "10.0.1.5",
                   "host": 4
                 }
@@ -11645,8 +11645,8 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2025-03-19T12:04:43.707238+01:00",
-                  "updated_at": "2025-03-19T12:04:43.707244+01:00",
+                  "created_at": "2025-03-20T15:36:58.692419+01:00",
+                  "updated_at": "2025-03-20T15:36:58.692425+01:00",
                   "txt": "v=spf1 -all",
                   "host": 4
                 }
@@ -11655,14 +11655,14 @@
               "srvs": [],
               "naptrs": [],
               "sshfps": [],
-              "groups": [],
+              "hostgroups": [],
               "roles": [],
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
               "communities": [],
-              "created_at": "2025-03-19T12:04:43.705544+01:00",
-              "updated_at": "2025-03-19T12:04:44.290099+01:00",
+              "created_at": "2025-03-20T15:36:58.690682+01:00",
+              "updated_at": "2025-03-20T15:36:59.267728+01:00",
               "name": "somehost.example.org",
               "contact": "new-support@example.org",
               "ttl": null,
@@ -11696,15 +11696,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:43.725495+01:00",
-              "updated_at": "2025-03-19T12:04:43.725508+01:00",
+              "created_at": "2025-03-20T15:36:58.706620+01:00",
+              "updated_at": "2025-03-20T15:36:58.706626+01:00",
               "ipaddress": "10.0.1.4",
               "host": 4
             },
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:44.602604+01:00",
-              "updated_at": "2025-03-19T12:04:44.602610+01:00",
+              "created_at": "2025-03-20T15:36:59.539135+01:00",
+              "updated_at": "2025-03-20T15:36:59.539141+01:00",
               "ipaddress": "10.0.1.5",
               "host": 4
             }
@@ -11713,8 +11713,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:43.707238+01:00",
-              "updated_at": "2025-03-19T12:04:43.707244+01:00",
+              "created_at": "2025-03-20T15:36:58.692419+01:00",
+              "updated_at": "2025-03-20T15:36:58.692425+01:00",
               "txt": "v=spf1 -all",
               "host": 4
             }
@@ -11723,14 +11723,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:43.705544+01:00",
-          "updated_at": "2025-03-19T12:04:44.290099+01:00",
+          "created_at": "2025-03-20T15:36:58.690682+01:00",
+          "updated_at": "2025-03-20T15:36:59.267728+01:00",
           "name": "somehost.example.org",
           "contact": "new-support@example.org",
           "ttl": null,
@@ -11746,8 +11746,8 @@
         "response": {
           "excluded_ranges": [
             {
-              "created_at": "2025-03-19T12:04:43.477741+01:00",
-              "updated_at": "2025-03-19T12:04:43.477754+01:00",
+              "created_at": "2025-03-20T15:36:58.452833+01:00",
+              "updated_at": "2025-03-20T15:36:58.452841+01:00",
               "start_ip": "10.0.1.20",
               "end_ip": "10.0.1.30",
               "network": 3
@@ -11755,8 +11755,8 @@
           ],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:43.270431+01:00",
-          "updated_at": "2025-03-19T12:04:44.091558+01:00",
+          "created_at": "2025-03-20T15:36:58.260675+01:00",
+          "updated_at": "2025-03-20T15:36:59.051810+01:00",
           "network": "10.0.1.0/24",
           "description": "Frozen but has one host",
           "vlan": 1234,
@@ -11775,8 +11775,8 @@
         "response": {
           "excluded_ranges": [
             {
-              "created_at": "2025-03-19T12:04:43.477741+01:00",
-              "updated_at": "2025-03-19T12:04:43.477754+01:00",
+              "created_at": "2025-03-20T15:36:58.452833+01:00",
+              "updated_at": "2025-03-20T15:36:58.452841+01:00",
               "start_ip": "10.0.1.20",
               "end_ip": "10.0.1.30",
               "network": 3
@@ -11784,8 +11784,8 @@
           ],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:43.270431+01:00",
-          "updated_at": "2025-03-19T12:04:44.091558+01:00",
+          "created_at": "2025-03-20T15:36:58.260675+01:00",
+          "updated_at": "2025-03-20T15:36:59.051810+01:00",
           "network": "10.0.1.0/24",
           "description": "Frozen but has one host",
           "vlan": 1234,
@@ -11820,15 +11820,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:43.725495+01:00",
-              "updated_at": "2025-03-19T12:04:43.725508+01:00",
+              "created_at": "2025-03-20T15:36:58.706620+01:00",
+              "updated_at": "2025-03-20T15:36:58.706626+01:00",
               "ipaddress": "10.0.1.4",
               "host": 4
             },
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:44.602604+01:00",
-              "updated_at": "2025-03-19T12:04:44.602610+01:00",
+              "created_at": "2025-03-20T15:36:59.539135+01:00",
+              "updated_at": "2025-03-20T15:36:59.539141+01:00",
               "ipaddress": "10.0.1.5",
               "host": 4
             }
@@ -11837,8 +11837,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:43.707238+01:00",
-              "updated_at": "2025-03-19T12:04:43.707244+01:00",
+              "created_at": "2025-03-20T15:36:58.692419+01:00",
+              "updated_at": "2025-03-20T15:36:58.692425+01:00",
               "txt": "v=spf1 -all",
               "host": 4
             }
@@ -11847,14 +11847,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:43.705544+01:00",
-          "updated_at": "2025-03-19T12:04:44.290099+01:00",
+          "created_at": "2025-03-20T15:36:58.690682+01:00",
+          "updated_at": "2025-03-20T15:36:59.267728+01:00",
           "name": "somehost.example.org",
           "contact": "new-support@example.org",
           "ttl": null,
@@ -11870,8 +11870,8 @@
         "response": {
           "excluded_ranges": [
             {
-              "created_at": "2025-03-19T12:04:43.477741+01:00",
-              "updated_at": "2025-03-19T12:04:43.477754+01:00",
+              "created_at": "2025-03-20T15:36:58.452833+01:00",
+              "updated_at": "2025-03-20T15:36:58.452841+01:00",
               "start_ip": "10.0.1.20",
               "end_ip": "10.0.1.30",
               "network": 3
@@ -11879,8 +11879,8 @@
           ],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:43.270431+01:00",
-          "updated_at": "2025-03-19T12:04:44.091558+01:00",
+          "created_at": "2025-03-20T15:36:58.260675+01:00",
+          "updated_at": "2025-03-20T15:36:59.051810+01:00",
           "network": "10.0.1.0/24",
           "description": "Frozen but has one host",
           "vlan": 1234,
@@ -11899,8 +11899,8 @@
         "response": {
           "excluded_ranges": [
             {
-              "created_at": "2025-03-19T12:04:43.477741+01:00",
-              "updated_at": "2025-03-19T12:04:43.477754+01:00",
+              "created_at": "2025-03-20T15:36:58.452833+01:00",
+              "updated_at": "2025-03-20T15:36:58.452841+01:00",
               "start_ip": "10.0.1.20",
               "end_ip": "10.0.1.30",
               "network": 3
@@ -11908,8 +11908,8 @@
           ],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:43.270431+01:00",
-          "updated_at": "2025-03-19T12:04:44.091558+01:00",
+          "created_at": "2025-03-20T15:36:58.260675+01:00",
+          "updated_at": "2025-03-20T15:36:59.051810+01:00",
           "network": "10.0.1.0/24",
           "description": "Frozen but has one host",
           "vlan": 1234,
@@ -12192,8 +12192,8 @@
       "              10.0.1.20   <not set>   ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Wed Mar 19 12:04:45 2025",
-      "Updated:      Wed Mar 19 12:04:45 2025"
+      "Created:      Thu Mar 20 15:37:00 2025",
+      "Updated:      Thu Mar 20 15:37:00 2025"
     ],
     "api_requests": [
       {
@@ -12223,18 +12223,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2025-03-19T12:04:41.191611+01:00",
-                "updated_at": "2025-03-19T12:04:41.191623+01:00",
+                "created_at": "2025-03-20T15:36:56.518688+01:00",
+                "updated_at": "2025-03-20T15:36:56.518700+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-03-19T12:04:40.912310+01:00",
-            "updated_at": "2025-03-19T12:04:44.816296+01:00",
+            "created_at": "2025-03-20T15:36:56.108293+01:00",
+            "updated_at": "2025-03-20T15:36:59.775920+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
+            "serialno_updated_at": "2025-03-20T15:36:56.561109+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -12253,8 +12253,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:43.270431+01:00",
-          "updated_at": "2025-03-19T12:04:44.855926+01:00",
+          "created_at": "2025-03-20T15:36:58.260675+01:00",
+          "updated_at": "2025-03-20T15:36:59.816598+01:00",
           "network": "10.0.1.0/24",
           "description": "Frozen but has one host",
           "vlan": 1234,
@@ -12284,8 +12284,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:45.160723+01:00",
-              "updated_at": "2025-03-19T12:04:45.160729+01:00",
+              "created_at": "2025-03-20T15:37:00.143804+01:00",
+              "updated_at": "2025-03-20T15:37:00.143809+01:00",
               "ipaddress": "10.0.1.20",
               "host": 6
             }
@@ -12294,8 +12294,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:45.143284+01:00",
-              "updated_at": "2025-03-19T12:04:45.143292+01:00",
+              "created_at": "2025-03-20T15:37:00.127542+01:00",
+              "updated_at": "2025-03-20T15:37:00.127548+01:00",
               "txt": "v=spf1 -all",
               "host": 6
             }
@@ -12304,14 +12304,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:45.141574+01:00",
-          "updated_at": "2025-03-19T12:04:45.141583+01:00",
+          "created_at": "2025-03-20T15:37:00.125331+01:00",
+          "updated_at": "2025-03-20T15:37:00.125341+01:00",
           "name": "otherhost.example.org",
           "contact": "support@example.org",
           "ttl": null,
@@ -12328,8 +12328,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:43.270431+01:00",
-          "updated_at": "2025-03-19T12:04:44.855926+01:00",
+          "created_at": "2025-03-20T15:36:58.260675+01:00",
+          "updated_at": "2025-03-20T15:36:59.816598+01:00",
           "network": "10.0.1.0/24",
           "description": "Frozen but has one host",
           "vlan": 1234,
@@ -12364,8 +12364,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:45.160723+01:00",
-              "updated_at": "2025-03-19T12:04:45.160729+01:00",
+              "created_at": "2025-03-20T15:37:00.143804+01:00",
+              "updated_at": "2025-03-20T15:37:00.143809+01:00",
               "ipaddress": "10.0.1.20",
               "host": 6
             }
@@ -12374,8 +12374,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:45.143284+01:00",
-              "updated_at": "2025-03-19T12:04:45.143292+01:00",
+              "created_at": "2025-03-20T15:37:00.127542+01:00",
+              "updated_at": "2025-03-20T15:37:00.127548+01:00",
               "txt": "v=spf1 -all",
               "host": 6
             }
@@ -12384,14 +12384,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:45.141574+01:00",
-          "updated_at": "2025-03-19T12:04:45.141583+01:00",
+          "created_at": "2025-03-20T15:37:00.125331+01:00",
+          "updated_at": "2025-03-20T15:37:00.125341+01:00",
           "name": "otherhost.example.org",
           "contact": "support@example.org",
           "ttl": null,
@@ -12842,8 +12842,8 @@
       "              2001:db8::4   <not set>   ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Wed Mar 19 12:04:45 2025",
-      "Updated:      Wed Mar 19 12:04:45 2025"
+      "Created:      Thu Mar 20 15:37:00 2025",
+      "Updated:      Thu Mar 20 15:37:00 2025"
     ],
     "api_requests": [
       {
@@ -12873,18 +12873,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2025-03-19T12:04:41.191611+01:00",
-                "updated_at": "2025-03-19T12:04:41.191623+01:00",
+                "created_at": "2025-03-20T15:36:56.518688+01:00",
+                "updated_at": "2025-03-20T15:36:56.518700+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-03-19T12:04:40.912310+01:00",
-            "updated_at": "2025-03-19T12:04:45.286162+01:00",
+            "created_at": "2025-03-20T15:36:56.108293+01:00",
+            "updated_at": "2025-03-20T15:37:00.258095+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
+            "serialno_updated_at": "2025-03-20T15:36:56.561109+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -12902,8 +12902,8 @@
         "response": {
           "excluded_ranges": [
             {
-              "created_at": "2025-03-19T12:04:45.667602+01:00",
-              "updated_at": "2025-03-19T12:04:45.667611+01:00",
+              "created_at": "2025-03-20T15:37:00.553832+01:00",
+              "updated_at": "2025-03-20T15:37:00.553840+01:00",
               "start_ip": "2001:db8::20",
               "end_ip": "2001:db8::30",
               "network": 4
@@ -12911,8 +12911,8 @@
           ],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:45.415701+01:00",
-          "updated_at": "2025-03-19T12:04:45.480137+01:00",
+          "created_at": "2025-03-20T15:37:00.356952+01:00",
+          "updated_at": "2025-03-20T15:37:00.413403+01:00",
           "network": "2001:db8::/64",
           "description": "Lorem ipsum dolor sit amet",
           "vlan": null,
@@ -12942,8 +12942,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:45.940471+01:00",
-              "updated_at": "2025-03-19T12:04:45.940476+01:00",
+              "created_at": "2025-03-20T15:37:00.781322+01:00",
+              "updated_at": "2025-03-20T15:37:00.781328+01:00",
               "ipaddress": "2001:db8::4",
               "host": 8
             }
@@ -12952,8 +12952,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:45.923544+01:00",
-              "updated_at": "2025-03-19T12:04:45.923555+01:00",
+              "created_at": "2025-03-20T15:37:00.767133+01:00",
+              "updated_at": "2025-03-20T15:37:00.767138+01:00",
               "txt": "v=spf1 -all",
               "host": 8
             }
@@ -12962,14 +12962,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:45.921732+01:00",
-          "updated_at": "2025-03-19T12:04:45.921739+01:00",
+          "created_at": "2025-03-20T15:37:00.765539+01:00",
+          "updated_at": "2025-03-20T15:37:00.765545+01:00",
           "name": "somehost.example.org",
           "contact": "support@example.org",
           "ttl": null,
@@ -12985,8 +12985,8 @@
         "response": {
           "excluded_ranges": [
             {
-              "created_at": "2025-03-19T12:04:45.667602+01:00",
-              "updated_at": "2025-03-19T12:04:45.667611+01:00",
+              "created_at": "2025-03-20T15:37:00.553832+01:00",
+              "updated_at": "2025-03-20T15:37:00.553840+01:00",
               "start_ip": "2001:db8::20",
               "end_ip": "2001:db8::30",
               "network": 4
@@ -12994,8 +12994,8 @@
           ],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:45.415701+01:00",
-          "updated_at": "2025-03-19T12:04:45.480137+01:00",
+          "created_at": "2025-03-20T15:37:00.356952+01:00",
+          "updated_at": "2025-03-20T15:37:00.413403+01:00",
           "network": "2001:db8::/64",
           "description": "Lorem ipsum dolor sit amet",
           "vlan": null,
@@ -13207,8 +13207,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:45.940471+01:00",
-              "updated_at": "2025-03-19T12:04:45.940476+01:00",
+              "created_at": "2025-03-20T15:37:00.781322+01:00",
+              "updated_at": "2025-03-20T15:37:00.781328+01:00",
               "ipaddress": "2001:db8::4",
               "host": 8
             }
@@ -13217,8 +13217,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:45.923544+01:00",
-              "updated_at": "2025-03-19T12:04:45.923555+01:00",
+              "created_at": "2025-03-20T15:37:00.767133+01:00",
+              "updated_at": "2025-03-20T15:37:00.767138+01:00",
               "txt": "v=spf1 -all",
               "host": 8
             }
@@ -13227,14 +13227,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:45.921732+01:00",
-          "updated_at": "2025-03-19T12:04:45.921739+01:00",
+          "created_at": "2025-03-20T15:37:00.765539+01:00",
+          "updated_at": "2025-03-20T15:37:00.765545+01:00",
           "name": "somehost.example.org",
           "contact": "support@example.org",
           "ttl": null,
@@ -13250,8 +13250,8 @@
         "response": {
           "excluded_ranges": [
             {
-              "created_at": "2025-03-19T12:04:45.667602+01:00",
-              "updated_at": "2025-03-19T12:04:45.667611+01:00",
+              "created_at": "2025-03-20T15:37:00.553832+01:00",
+              "updated_at": "2025-03-20T15:37:00.553840+01:00",
               "start_ip": "2001:db8::20",
               "end_ip": "2001:db8::30",
               "network": 4
@@ -13259,8 +13259,8 @@
           ],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:45.415701+01:00",
-          "updated_at": "2025-03-19T12:04:46.028978+01:00",
+          "created_at": "2025-03-20T15:37:00.356952+01:00",
+          "updated_at": "2025-03-20T15:37:00.864485+01:00",
           "network": "2001:db8::/64",
           "description": "Frozen but has one host",
           "vlan": null,
@@ -13302,8 +13302,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:45.940471+01:00",
-              "updated_at": "2025-03-19T12:04:45.940476+01:00",
+              "created_at": "2025-03-20T15:37:00.781322+01:00",
+              "updated_at": "2025-03-20T15:37:00.781328+01:00",
               "ipaddress": "2001:db8::4",
               "host": 8
             }
@@ -13312,8 +13312,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:45.923544+01:00",
-              "updated_at": "2025-03-19T12:04:45.923555+01:00",
+              "created_at": "2025-03-20T15:37:00.767133+01:00",
+              "updated_at": "2025-03-20T15:37:00.767138+01:00",
               "txt": "v=spf1 -all",
               "host": 8
             }
@@ -13322,14 +13322,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:45.921732+01:00",
-          "updated_at": "2025-03-19T12:04:45.921739+01:00",
+          "created_at": "2025-03-20T15:37:00.765539+01:00",
+          "updated_at": "2025-03-20T15:37:00.765545+01:00",
           "name": "somehost.example.org",
           "contact": "support@example.org",
           "ttl": null,
@@ -13345,8 +13345,8 @@
         "response": {
           "excluded_ranges": [
             {
-              "created_at": "2025-03-19T12:04:45.667602+01:00",
-              "updated_at": "2025-03-19T12:04:45.667611+01:00",
+              "created_at": "2025-03-20T15:37:00.553832+01:00",
+              "updated_at": "2025-03-20T15:37:00.553840+01:00",
               "start_ip": "2001:db8::20",
               "end_ip": "2001:db8::30",
               "network": 4
@@ -13354,8 +13354,8 @@
           ],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:45.415701+01:00",
-          "updated_at": "2025-03-19T12:04:46.028978+01:00",
+          "created_at": "2025-03-20T15:37:00.356952+01:00",
+          "updated_at": "2025-03-20T15:37:00.864485+01:00",
           "network": "2001:db8::/64",
           "description": "Frozen but has one host",
           "vlan": null,
@@ -13383,8 +13383,8 @@
         "status": 201,
         "response": {
           "macaddress": "",
-          "created_at": "2025-03-19T12:04:46.283013+01:00",
-          "updated_at": "2025-03-19T12:04:46.283020+01:00",
+          "created_at": "2025-03-20T15:37:01.118387+01:00",
+          "updated_at": "2025-03-20T15:37:01.118395+01:00",
           "ipaddress": "2001:db8::5",
           "host": 8
         }
@@ -13403,15 +13403,15 @@
               "ipaddresses": [
                 {
                   "macaddress": "",
-                  "created_at": "2025-03-19T12:04:45.940471+01:00",
-                  "updated_at": "2025-03-19T12:04:45.940476+01:00",
+                  "created_at": "2025-03-20T15:37:00.781322+01:00",
+                  "updated_at": "2025-03-20T15:37:00.781328+01:00",
                   "ipaddress": "2001:db8::4",
                   "host": 8
                 },
                 {
                   "macaddress": "",
-                  "created_at": "2025-03-19T12:04:46.283013+01:00",
-                  "updated_at": "2025-03-19T12:04:46.283020+01:00",
+                  "created_at": "2025-03-20T15:37:01.118387+01:00",
+                  "updated_at": "2025-03-20T15:37:01.118395+01:00",
                   "ipaddress": "2001:db8::5",
                   "host": 8
                 }
@@ -13420,8 +13420,8 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2025-03-19T12:04:45.923544+01:00",
-                  "updated_at": "2025-03-19T12:04:45.923555+01:00",
+                  "created_at": "2025-03-20T15:37:00.767133+01:00",
+                  "updated_at": "2025-03-20T15:37:00.767138+01:00",
                   "txt": "v=spf1 -all",
                   "host": 8
                 }
@@ -13430,14 +13430,14 @@
               "srvs": [],
               "naptrs": [],
               "sshfps": [],
-              "groups": [],
+              "hostgroups": [],
               "roles": [],
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
               "communities": [],
-              "created_at": "2025-03-19T12:04:45.921732+01:00",
-              "updated_at": "2025-03-19T12:04:45.921739+01:00",
+              "created_at": "2025-03-20T15:37:00.765539+01:00",
+              "updated_at": "2025-03-20T15:37:00.765545+01:00",
               "name": "somehost.example.org",
               "contact": "support@example.org",
               "ttl": null,
@@ -13471,15 +13471,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:45.940471+01:00",
-              "updated_at": "2025-03-19T12:04:45.940476+01:00",
+              "created_at": "2025-03-20T15:37:00.781322+01:00",
+              "updated_at": "2025-03-20T15:37:00.781328+01:00",
               "ipaddress": "2001:db8::4",
               "host": 8
             },
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:46.283013+01:00",
-              "updated_at": "2025-03-19T12:04:46.283020+01:00",
+              "created_at": "2025-03-20T15:37:01.118387+01:00",
+              "updated_at": "2025-03-20T15:37:01.118395+01:00",
               "ipaddress": "2001:db8::5",
               "host": 8
             }
@@ -13488,8 +13488,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:45.923544+01:00",
-              "updated_at": "2025-03-19T12:04:45.923555+01:00",
+              "created_at": "2025-03-20T15:37:00.767133+01:00",
+              "updated_at": "2025-03-20T15:37:00.767138+01:00",
               "txt": "v=spf1 -all",
               "host": 8
             }
@@ -13498,14 +13498,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:45.921732+01:00",
-          "updated_at": "2025-03-19T12:04:45.921739+01:00",
+          "created_at": "2025-03-20T15:37:00.765539+01:00",
+          "updated_at": "2025-03-20T15:37:00.765545+01:00",
           "name": "somehost.example.org",
           "contact": "support@example.org",
           "ttl": null,
@@ -13521,8 +13521,8 @@
         "response": {
           "excluded_ranges": [
             {
-              "created_at": "2025-03-19T12:04:45.667602+01:00",
-              "updated_at": "2025-03-19T12:04:45.667611+01:00",
+              "created_at": "2025-03-20T15:37:00.553832+01:00",
+              "updated_at": "2025-03-20T15:37:00.553840+01:00",
               "start_ip": "2001:db8::20",
               "end_ip": "2001:db8::30",
               "network": 4
@@ -13530,8 +13530,8 @@
           ],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:45.415701+01:00",
-          "updated_at": "2025-03-19T12:04:46.028978+01:00",
+          "created_at": "2025-03-20T15:37:00.356952+01:00",
+          "updated_at": "2025-03-20T15:37:00.864485+01:00",
           "network": "2001:db8::/64",
           "description": "Frozen but has one host",
           "vlan": null,
@@ -13550,8 +13550,8 @@
         "response": {
           "excluded_ranges": [
             {
-              "created_at": "2025-03-19T12:04:45.667602+01:00",
-              "updated_at": "2025-03-19T12:04:45.667611+01:00",
+              "created_at": "2025-03-20T15:37:00.553832+01:00",
+              "updated_at": "2025-03-20T15:37:00.553840+01:00",
               "start_ip": "2001:db8::20",
               "end_ip": "2001:db8::30",
               "network": 4
@@ -13559,8 +13559,8 @@
           ],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:45.415701+01:00",
-          "updated_at": "2025-03-19T12:04:46.028978+01:00",
+          "created_at": "2025-03-20T15:37:00.356952+01:00",
+          "updated_at": "2025-03-20T15:37:00.864485+01:00",
           "network": "2001:db8::/64",
           "description": "Frozen but has one host",
           "vlan": null,
@@ -13701,8 +13701,8 @@
       "Contact:      ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Wed Mar 19 12:04:46 2025",
-      "Updated:      Wed Mar 19 12:04:46 2025"
+      "Created:      Thu Mar 20 15:37:01 2025",
+      "Updated:      Thu Mar 20 15:37:01 2025"
     ],
     "api_requests": [
       {
@@ -13732,18 +13732,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2025-03-19T12:04:41.191611+01:00",
-                "updated_at": "2025-03-19T12:04:41.191623+01:00",
+                "created_at": "2025-03-20T15:36:56.518688+01:00",
+                "updated_at": "2025-03-20T15:36:56.518700+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-03-19T12:04:40.912310+01:00",
-            "updated_at": "2025-03-19T12:04:46.454935+01:00",
+            "created_at": "2025-03-20T15:36:56.108293+01:00",
+            "updated_at": "2025-03-20T15:37:01.273146+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
+            "serialno_updated_at": "2025-03-20T15:36:56.561109+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -13772,8 +13772,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:46.959322+01:00",
-              "updated_at": "2025-03-19T12:04:46.959341+01:00",
+              "created_at": "2025-03-20T15:37:01.463156+01:00",
+              "updated_at": "2025-03-20T15:37:01.463162+01:00",
               "txt": "v=spf1 -all",
               "host": 9
             }
@@ -13782,14 +13782,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:46.950645+01:00",
-          "updated_at": "2025-03-19T12:04:46.950663+01:00",
+          "created_at": "2025-03-20T15:37:01.461570+01:00",
+          "updated_at": "2025-03-20T15:37:01.461577+01:00",
           "name": "testhost1.example.org",
           "contact": "",
           "ttl": null,
@@ -13815,8 +13815,8 @@
       "Contact:      ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Wed Mar 19 12:04:47 2025",
-      "Updated:      Wed Mar 19 12:04:47 2025"
+      "Created:      Thu Mar 20 15:37:01 2025",
+      "Updated:      Thu Mar 20 15:37:01 2025"
     ],
     "api_requests": [
       {
@@ -13846,18 +13846,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2025-03-19T12:04:41.191611+01:00",
-                "updated_at": "2025-03-19T12:04:41.191623+01:00",
+                "created_at": "2025-03-20T15:36:56.518688+01:00",
+                "updated_at": "2025-03-20T15:36:56.518700+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-03-19T12:04:40.912310+01:00",
-            "updated_at": "2025-03-19T12:04:46.958007+01:00",
+            "created_at": "2025-03-20T15:36:56.108293+01:00",
+            "updated_at": "2025-03-20T15:37:01.462712+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
+            "serialno_updated_at": "2025-03-20T15:36:56.561109+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -13886,8 +13886,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:47.130016+01:00",
-              "updated_at": "2025-03-19T12:04:47.130026+01:00",
+              "created_at": "2025-03-20T15:37:01.567474+01:00",
+              "updated_at": "2025-03-20T15:37:01.567481+01:00",
               "txt": "v=spf1 -all",
               "host": 10
             }
@@ -13896,14 +13896,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:47.127495+01:00",
-          "updated_at": "2025-03-19T12:04:47.127508+01:00",
+          "created_at": "2025-03-20T15:37:01.565908+01:00",
+          "updated_at": "2025-03-20T15:37:01.565914+01:00",
           "name": "testhost2.example.org",
           "contact": "",
           "ttl": null,
@@ -13936,8 +13936,8 @@
           "groups": [],
           "hosts": [],
           "owners": [],
-          "created_at": "2025-03-19T12:04:46.675213+01:00",
-          "updated_at": "2025-03-19T12:04:46.675238+01:00",
+          "created_at": "2025-03-20T15:37:01.369720+01:00",
+          "updated_at": "2025-03-20T15:37:01.369729+01:00",
           "name": "mygroup",
           "description": "This describes the group"
         }
@@ -13953,8 +13953,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:46.959322+01:00",
-              "updated_at": "2025-03-19T12:04:46.959341+01:00",
+              "created_at": "2025-03-20T15:37:01.463156+01:00",
+              "updated_at": "2025-03-20T15:37:01.463162+01:00",
               "txt": "v=spf1 -all",
               "host": 9
             }
@@ -13963,14 +13963,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:46.950645+01:00",
-          "updated_at": "2025-03-19T12:04:46.950663+01:00",
+          "created_at": "2025-03-20T15:37:01.461570+01:00",
+          "updated_at": "2025-03-20T15:37:01.461577+01:00",
           "name": "testhost1.example.org",
           "contact": "",
           "ttl": null,
@@ -14005,8 +14005,8 @@
                 }
               ],
               "owners": [],
-              "created_at": "2025-03-19T12:04:46.675213+01:00",
-              "updated_at": "2025-03-19T12:04:47.283942+01:00",
+              "created_at": "2025-03-20T15:37:01.369720+01:00",
+              "updated_at": "2025-03-20T15:37:01.670365+01:00",
               "name": "mygroup",
               "description": "This describes the group"
             }
@@ -14042,8 +14042,8 @@
             }
           ],
           "owners": [],
-          "created_at": "2025-03-19T12:04:46.675213+01:00",
-          "updated_at": "2025-03-19T12:04:47.283942+01:00",
+          "created_at": "2025-03-20T15:37:01.369720+01:00",
+          "updated_at": "2025-03-20T15:37:01.670365+01:00",
           "name": "mygroup",
           "description": "This describes the group"
         }
@@ -14059,8 +14059,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:47.130016+01:00",
-              "updated_at": "2025-03-19T12:04:47.130026+01:00",
+              "created_at": "2025-03-20T15:37:01.567474+01:00",
+              "updated_at": "2025-03-20T15:37:01.567481+01:00",
               "txt": "v=spf1 -all",
               "host": 10
             }
@@ -14069,14 +14069,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:47.127495+01:00",
-          "updated_at": "2025-03-19T12:04:47.127508+01:00",
+          "created_at": "2025-03-20T15:37:01.565908+01:00",
+          "updated_at": "2025-03-20T15:37:01.565914+01:00",
           "name": "testhost2.example.org",
           "contact": "",
           "ttl": null,
@@ -14114,8 +14114,8 @@
                 }
               ],
               "owners": [],
-              "created_at": "2025-03-19T12:04:46.675213+01:00",
-              "updated_at": "2025-03-19T12:04:47.424796+01:00",
+              "created_at": "2025-03-20T15:37:01.369720+01:00",
+              "updated_at": "2025-03-20T15:37:01.759207+01:00",
               "name": "mygroup",
               "description": "This describes the group"
             }
@@ -14238,8 +14238,8 @@
               "name": "myself"
             }
           ],
-          "created_at": "2025-03-19T12:04:46.675213+01:00",
-          "updated_at": "2025-03-19T12:04:47.424796+01:00",
+          "created_at": "2025-03-20T15:37:01.369720+01:00",
+          "updated_at": "2025-03-20T15:37:01.759207+01:00",
           "name": "mygroup",
           "description": "This describes the group"
         }
@@ -14255,8 +14255,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:47.130016+01:00",
-              "updated_at": "2025-03-19T12:04:47.130026+01:00",
+              "created_at": "2025-03-20T15:37:01.567474+01:00",
+              "updated_at": "2025-03-20T15:37:01.567481+01:00",
               "txt": "v=spf1 -all",
               "host": 10
             }
@@ -14265,7 +14265,7 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [
+          "hostgroups": [
             "mygroup"
           ],
           "roles": [],
@@ -14273,8 +14273,8 @@
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:47.127495+01:00",
-          "updated_at": "2025-03-19T12:04:47.127508+01:00",
+          "created_at": "2025-03-20T15:37:01.565908+01:00",
+          "updated_at": "2025-03-20T15:37:01.565914+01:00",
           "name": "testhost2.example.org",
           "contact": "",
           "ttl": null,
@@ -14311,8 +14311,8 @@
                   "name": "myself"
                 }
               ],
-              "created_at": "2025-03-19T12:04:46.675213+01:00",
-              "updated_at": "2025-03-19T12:04:47.654971+01:00",
+              "created_at": "2025-03-20T15:37:01.369720+01:00",
+              "updated_at": "2025-03-20T15:37:01.908219+01:00",
               "name": "mygroup",
               "description": "This describes the group"
             }
@@ -15419,8 +15419,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:46.959322+01:00",
-              "updated_at": "2025-03-19T12:04:46.959341+01:00",
+              "created_at": "2025-03-20T15:37:01.463156+01:00",
+              "updated_at": "2025-03-20T15:37:01.463162+01:00",
               "txt": "v=spf1 -all",
               "host": 9
             }
@@ -15429,14 +15429,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:46.950645+01:00",
-          "updated_at": "2025-03-19T12:04:46.950663+01:00",
+          "created_at": "2025-03-20T15:37:01.461570+01:00",
+          "updated_at": "2025-03-20T15:37:01.461577+01:00",
           "name": "testhost1.example.org",
           "contact": "",
           "ttl": null,
@@ -15476,8 +15476,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:47.130016+01:00",
-              "updated_at": "2025-03-19T12:04:47.130026+01:00",
+              "created_at": "2025-03-20T15:37:01.567474+01:00",
+              "updated_at": "2025-03-20T15:37:01.567481+01:00",
               "txt": "v=spf1 -all",
               "host": 10
             }
@@ -15486,14 +15486,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:47.127495+01:00",
-          "updated_at": "2025-03-19T12:04:47.127508+01:00",
+          "created_at": "2025-03-20T15:37:01.565908+01:00",
+          "updated_at": "2025-03-20T15:37:01.565914+01:00",
           "name": "testhost2.example.org",
           "contact": "",
           "ttl": null,
@@ -15829,8 +15829,8 @@
       "Name:         testhost.wut.example.org",
       "Contact:      ",
       "TTL:          (Default)",
-      "Created:      Wed Mar 19 12:04:49 2025",
-      "Updated:      Wed Mar 19 12:04:49 2025"
+      "Created:      Thu Mar 20 15:37:03 2025",
+      "Updated:      Thu Mar 20 15:37:03 2025"
     ],
     "api_requests": [
       {
@@ -15860,14 +15860,14 @@
           "delegation": {
             "nameservers": [
               {
-                "created_at": "2025-03-19T12:04:41.191611+01:00",
-                "updated_at": "2025-03-19T12:04:41.191623+01:00",
+                "created_at": "2025-03-20T15:36:56.518688+01:00",
+                "updated_at": "2025-03-20T15:36:56.518700+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-03-19T12:04:49.143150+01:00",
-            "updated_at": "2025-03-19T12:04:49.244747+01:00",
+            "created_at": "2025-03-20T15:37:03.256023+01:00",
+            "updated_at": "2025-03-20T15:37:03.343686+01:00",
             "name": "wut.example.org",
             "comment": "This is a comment",
             "zone": 1
@@ -15896,14 +15896,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:49.514185+01:00",
-          "updated_at": "2025-03-19T12:04:49.514199+01:00",
+          "created_at": "2025-03-20T15:37:03.515664+01:00",
+          "updated_at": "2025-03-20T15:37:03.515673+01:00",
           "name": "testhost.wut.example.org",
           "contact": "",
           "ttl": null,
@@ -15940,14 +15940,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:49.514185+01:00",
-          "updated_at": "2025-03-19T12:04:49.514199+01:00",
+          "created_at": "2025-03-20T15:37:03.515664+01:00",
+          "updated_at": "2025-03-20T15:37:03.515673+01:00",
           "name": "testhost.wut.example.org",
           "contact": "",
           "ttl": null,
@@ -17114,8 +17114,8 @@
       "Contact:      ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Wed Mar 19 12:04:50 2025",
-      "Updated:      Wed Mar 19 12:04:50 2025"
+      "Created:      Thu Mar 20 15:37:05 2025",
+      "Updated:      Thu Mar 20 15:37:05 2025"
     ],
     "api_requests": [
       {
@@ -17145,18 +17145,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2025-03-19T12:04:41.191611+01:00",
-                "updated_at": "2025-03-19T12:04:41.191623+01:00",
+                "created_at": "2025-03-20T15:36:56.518688+01:00",
+                "updated_at": "2025-03-20T15:36:56.518700+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-03-19T12:04:40.912310+01:00",
-            "updated_at": "2025-03-19T12:04:49.780924+01:00",
+            "created_at": "2025-03-20T15:36:56.108293+01:00",
+            "updated_at": "2025-03-20T15:37:03.769536+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
+            "serialno_updated_at": "2025-03-20T15:36:56.561109+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -17185,8 +17185,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:50.904251+01:00",
-              "updated_at": "2025-03-19T12:04:50.904256+01:00",
+              "created_at": "2025-03-20T15:37:05.263899+01:00",
+              "updated_at": "2025-03-20T15:37:05.263906+01:00",
               "txt": "v=spf1 -all",
               "host": 12
             }
@@ -17195,14 +17195,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:50.902521+01:00",
-          "updated_at": "2025-03-19T12:04:50.902527+01:00",
+          "created_at": "2025-03-20T15:37:05.261629+01:00",
+          "updated_at": "2025-03-20T15:37:05.261642+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -17226,8 +17226,8 @@
       "Contact:      ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Wed Mar 19 12:04:50 2025",
-      "Updated:      Wed Mar 19 12:04:50 2025"
+      "Created:      Thu Mar 20 15:37:05 2025",
+      "Updated:      Thu Mar 20 15:37:05 2025"
     ],
     "api_requests": [
       {
@@ -17241,8 +17241,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:50.904251+01:00",
-              "updated_at": "2025-03-19T12:04:50.904256+01:00",
+              "created_at": "2025-03-20T15:37:05.263899+01:00",
+              "updated_at": "2025-03-20T15:37:05.263906+01:00",
               "txt": "v=spf1 -all",
               "host": 12
             }
@@ -17251,14 +17251,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:50.902521+01:00",
-          "updated_at": "2025-03-19T12:04:50.902527+01:00",
+          "created_at": "2025-03-20T15:37:05.261629+01:00",
+          "updated_at": "2025-03-20T15:37:05.261642+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -17317,7 +17317,7 @@
               "name": "tangerine"
             }
           ],
-          "updated_at": "2025-03-19T12:04:50.804103+01:00",
+          "updated_at": "2025-03-20T15:37:05.145404+01:00",
           "description": "5 a day",
           "name": "fruit",
           "labels": []
@@ -17334,8 +17334,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:50.904251+01:00",
-              "updated_at": "2025-03-19T12:04:50.904256+01:00",
+              "created_at": "2025-03-20T15:37:05.263899+01:00",
+              "updated_at": "2025-03-20T15:37:05.263906+01:00",
               "txt": "v=spf1 -all",
               "host": 12
             }
@@ -17344,14 +17344,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:50.902521+01:00",
-          "updated_at": "2025-03-19T12:04:50.902527+01:00",
+          "created_at": "2025-03-20T15:37:05.261629+01:00",
+          "updated_at": "2025-03-20T15:37:05.261642+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -17432,8 +17432,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:50.904251+01:00",
-              "updated_at": "2025-03-19T12:04:50.904256+01:00",
+              "created_at": "2025-03-20T15:37:05.263899+01:00",
+              "updated_at": "2025-03-20T15:37:05.263906+01:00",
               "txt": "v=spf1 -all",
               "host": 12
             }
@@ -17442,7 +17442,7 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [
             "fruit"
           ],
@@ -17450,8 +17450,8 @@
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:50.902521+01:00",
-          "updated_at": "2025-03-19T12:04:50.902527+01:00",
+          "created_at": "2025-03-20T15:37:05.261629+01:00",
+          "updated_at": "2025-03-20T15:37:05.261642+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -17476,8 +17476,8 @@
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
       "Roles:        fruit",
-      "Created:      Wed Mar 19 12:04:50 2025",
-      "Updated:      Wed Mar 19 12:04:50 2025"
+      "Created:      Thu Mar 20 15:37:05 2025",
+      "Updated:      Thu Mar 20 15:37:05 2025"
     ],
     "api_requests": [
       {
@@ -17491,8 +17491,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:50.904251+01:00",
-              "updated_at": "2025-03-19T12:04:50.904256+01:00",
+              "created_at": "2025-03-20T15:37:05.263899+01:00",
+              "updated_at": "2025-03-20T15:37:05.263906+01:00",
               "txt": "v=spf1 -all",
               "host": 12
             }
@@ -17501,7 +17501,7 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [
             "fruit"
           ],
@@ -17509,8 +17509,8 @@
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:50.902521+01:00",
-          "updated_at": "2025-03-19T12:04:50.902527+01:00",
+          "created_at": "2025-03-20T15:37:05.261629+01:00",
+          "updated_at": "2025-03-20T15:37:05.261642+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -17549,7 +17549,7 @@
               "name": "tangerine"
             }
           ],
-          "updated_at": "2025-03-19T12:04:51.045576+01:00",
+          "updated_at": "2025-03-20T15:37:05.454441+01:00",
           "description": "5 a day",
           "name": "fruit",
           "labels": []
@@ -17566,8 +17566,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:50.904251+01:00",
-              "updated_at": "2025-03-19T12:04:50.904256+01:00",
+              "created_at": "2025-03-20T15:37:05.263899+01:00",
+              "updated_at": "2025-03-20T15:37:05.263906+01:00",
               "txt": "v=spf1 -all",
               "host": 12
             }
@@ -17576,7 +17576,7 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [
             "fruit"
           ],
@@ -17584,8 +17584,8 @@
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:50.902521+01:00",
-          "updated_at": "2025-03-19T12:04:50.902527+01:00",
+          "created_at": "2025-03-20T15:37:05.261629+01:00",
+          "updated_at": "2025-03-20T15:37:05.261642+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -18036,8 +18036,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:50.904251+01:00",
-              "updated_at": "2025-03-19T12:04:50.904256+01:00",
+              "created_at": "2025-03-20T15:37:05.263899+01:00",
+              "updated_at": "2025-03-20T15:37:05.263906+01:00",
               "txt": "v=spf1 -all",
               "host": 12
             }
@@ -18046,14 +18046,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:50.902521+01:00",
-          "updated_at": "2025-03-19T12:04:50.902527+01:00",
+          "created_at": "2025-03-20T15:37:05.261629+01:00",
+          "updated_at": "2025-03-20T15:37:05.261642+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -18307,8 +18307,8 @@
       "Contact:      ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Wed Mar 19 12:04:51 2025",
-      "Updated:      Wed Mar 19 12:04:51 2025"
+      "Created:      Thu Mar 20 15:37:06 2025",
+      "Updated:      Thu Mar 20 15:37:06 2025"
     ],
     "api_requests": [
       {
@@ -18338,18 +18338,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2025-03-19T12:04:41.191611+01:00",
-                "updated_at": "2025-03-19T12:04:41.191623+01:00",
+                "created_at": "2025-03-20T15:36:56.518688+01:00",
+                "updated_at": "2025-03-20T15:36:56.518700+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-03-19T12:04:40.912310+01:00",
-            "updated_at": "2025-03-19T12:04:51.510406+01:00",
+            "created_at": "2025-03-20T15:36:56.108293+01:00",
+            "updated_at": "2025-03-20T15:37:06.051140+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
+            "serialno_updated_at": "2025-03-20T15:36:56.561109+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -18378,8 +18378,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:51.792606+01:00",
-              "updated_at": "2025-03-19T12:04:51.792612+01:00",
+              "created_at": "2025-03-20T15:37:06.396618+01:00",
+              "updated_at": "2025-03-20T15:37:06.396624+01:00",
               "txt": "v=spf1 -all",
               "host": 13
             }
@@ -18388,14 +18388,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:51.790986+01:00",
-          "updated_at": "2025-03-19T12:04:51.790994+01:00",
+          "created_at": "2025-03-20T15:37:06.394606+01:00",
+          "updated_at": "2025-03-20T15:37:06.394612+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -18429,8 +18429,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:51.792606+01:00",
-              "updated_at": "2025-03-19T12:04:51.792612+01:00",
+              "created_at": "2025-03-20T15:37:06.396618+01:00",
+              "updated_at": "2025-03-20T15:37:06.396624+01:00",
               "txt": "v=spf1 -all",
               "host": 13
             }
@@ -18439,14 +18439,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:51.790986+01:00",
-          "updated_at": "2025-03-19T12:04:51.790994+01:00",
+          "created_at": "2025-03-20T15:37:06.394606+01:00",
+          "updated_at": "2025-03-20T15:37:06.394612+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -18463,8 +18463,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:51.700856+01:00",
-          "updated_at": "2025-03-19T12:04:51.700881+01:00",
+          "created_at": "2025-03-20T15:37:06.302275+01:00",
+          "updated_at": "2025-03-20T15:37:06.302284+01:00",
           "network": "10.0.0.0/24",
           "description": "foo",
           "vlan": 1234,
@@ -18497,8 +18497,8 @@
         "status": 201,
         "response": {
           "macaddress": "",
-          "created_at": "2025-03-19T12:04:51.972611+01:00",
-          "updated_at": "2025-03-19T12:04:51.972618+01:00",
+          "created_at": "2025-03-20T15:37:06.589266+01:00",
+          "updated_at": "2025-03-20T15:37:06.589280+01:00",
           "ipaddress": "10.0.0.5",
           "host": 13
         }
@@ -18517,8 +18517,8 @@
               "ipaddresses": [
                 {
                   "macaddress": "",
-                  "created_at": "2025-03-19T12:04:51.972611+01:00",
-                  "updated_at": "2025-03-19T12:04:51.972618+01:00",
+                  "created_at": "2025-03-20T15:37:06.589266+01:00",
+                  "updated_at": "2025-03-20T15:37:06.589280+01:00",
                   "ipaddress": "10.0.0.5",
                   "host": 13
                 }
@@ -18527,8 +18527,8 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2025-03-19T12:04:51.792606+01:00",
-                  "updated_at": "2025-03-19T12:04:51.792612+01:00",
+                  "created_at": "2025-03-20T15:37:06.396618+01:00",
+                  "updated_at": "2025-03-20T15:37:06.396624+01:00",
                   "txt": "v=spf1 -all",
                   "host": 13
                 }
@@ -18537,14 +18537,14 @@
               "srvs": [],
               "naptrs": [],
               "sshfps": [],
-              "groups": [],
+              "hostgroups": [],
               "roles": [],
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
               "communities": [],
-              "created_at": "2025-03-19T12:04:51.790986+01:00",
-              "updated_at": "2025-03-19T12:04:51.790994+01:00",
+              "created_at": "2025-03-20T15:37:06.394606+01:00",
+              "updated_at": "2025-03-20T15:37:06.394612+01:00",
               "name": "foo.example.org",
               "contact": "",
               "ttl": null,
@@ -18825,8 +18825,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:51.972611+01:00",
-              "updated_at": "2025-03-19T12:04:52.329514+01:00",
+              "created_at": "2025-03-20T15:37:06.589266+01:00",
+              "updated_at": "2025-03-20T15:37:06.839632+01:00",
               "ipaddress": "10.0.0.5",
               "host": 13
             }
@@ -18835,8 +18835,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:51.792606+01:00",
-              "updated_at": "2025-03-19T12:04:51.792612+01:00",
+              "created_at": "2025-03-20T15:37:06.396618+01:00",
+              "updated_at": "2025-03-20T15:37:06.396624+01:00",
               "txt": "v=spf1 -all",
               "host": 13
             }
@@ -18845,14 +18845,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:51.790986+01:00",
-          "updated_at": "2025-03-19T12:04:51.790994+01:00",
+          "created_at": "2025-03-20T15:37:06.394606+01:00",
+          "updated_at": "2025-03-20T15:37:06.394612+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -18875,8 +18875,8 @@
         "status": 200,
         "response": {
           "macaddress": "aa:bb:cc:dd:ee:ff",
-          "created_at": "2025-03-19T12:04:51.972611+01:00",
-          "updated_at": "2025-03-19T12:04:52.507441+01:00",
+          "created_at": "2025-03-20T15:37:06.589266+01:00",
+          "updated_at": "2025-03-20T15:37:06.991393+01:00",
           "ipaddress": "10.0.0.5",
           "host": 13
         }
@@ -18905,8 +18905,8 @@
           "ipaddresses": [
             {
               "macaddress": "aa:bb:cc:dd:ee:ff",
-              "created_at": "2025-03-19T12:04:51.972611+01:00",
-              "updated_at": "2025-03-19T12:04:52.507441+01:00",
+              "created_at": "2025-03-20T15:37:06.589266+01:00",
+              "updated_at": "2025-03-20T15:37:06.991393+01:00",
               "ipaddress": "10.0.0.5",
               "host": 13
             }
@@ -18915,8 +18915,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:51.792606+01:00",
-              "updated_at": "2025-03-19T12:04:51.792612+01:00",
+              "created_at": "2025-03-20T15:37:06.396618+01:00",
+              "updated_at": "2025-03-20T15:37:06.396624+01:00",
               "txt": "v=spf1 -all",
               "host": 13
             }
@@ -18925,14 +18925,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:51.790986+01:00",
-          "updated_at": "2025-03-19T12:04:51.790994+01:00",
+          "created_at": "2025-03-20T15:37:06.394606+01:00",
+          "updated_at": "2025-03-20T15:37:06.394612+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -18955,8 +18955,8 @@
         "status": 200,
         "response": {
           "macaddress": "",
-          "created_at": "2025-03-19T12:04:51.972611+01:00",
-          "updated_at": "2025-03-19T12:04:52.583974+01:00",
+          "created_at": "2025-03-20T15:37:06.589266+01:00",
+          "updated_at": "2025-03-20T15:37:07.065670+01:00",
           "ipaddress": "10.0.0.5",
           "host": 13
         }
@@ -19018,8 +19018,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:51.972611+01:00",
-              "updated_at": "2025-03-19T12:04:52.583974+01:00",
+              "created_at": "2025-03-20T15:37:06.589266+01:00",
+              "updated_at": "2025-03-20T15:37:07.065670+01:00",
               "ipaddress": "10.0.0.5",
               "host": 13
             }
@@ -19028,8 +19028,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:51.792606+01:00",
-              "updated_at": "2025-03-19T12:04:51.792612+01:00",
+              "created_at": "2025-03-20T15:37:06.396618+01:00",
+              "updated_at": "2025-03-20T15:37:06.396624+01:00",
               "txt": "v=spf1 -all",
               "host": 13
             }
@@ -19038,14 +19038,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:51.790986+01:00",
-          "updated_at": "2025-03-19T12:04:51.790994+01:00",
+          "created_at": "2025-03-20T15:37:06.394606+01:00",
+          "updated_at": "2025-03-20T15:37:06.394612+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -19097,8 +19097,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:51.792606+01:00",
-              "updated_at": "2025-03-19T12:04:51.792612+01:00",
+              "created_at": "2025-03-20T15:37:06.396618+01:00",
+              "updated_at": "2025-03-20T15:37:06.396624+01:00",
               "txt": "v=spf1 -all",
               "host": 13
             }
@@ -19107,14 +19107,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:51.790986+01:00",
-          "updated_at": "2025-03-19T12:04:51.790994+01:00",
+          "created_at": "2025-03-20T15:37:06.394606+01:00",
+          "updated_at": "2025-03-20T15:37:06.394612+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -19148,8 +19148,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:51.792606+01:00",
-              "updated_at": "2025-03-19T12:04:51.792612+01:00",
+              "created_at": "2025-03-20T15:37:06.396618+01:00",
+              "updated_at": "2025-03-20T15:37:06.396624+01:00",
               "txt": "v=spf1 -all",
               "host": 13
             }
@@ -19158,14 +19158,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:51.790986+01:00",
-          "updated_at": "2025-03-19T12:04:51.790994+01:00",
+          "created_at": "2025-03-20T15:37:06.394606+01:00",
+          "updated_at": "2025-03-20T15:37:06.394612+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -19182,8 +19182,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:51.700856+01:00",
-          "updated_at": "2025-03-19T12:04:51.700881+01:00",
+          "created_at": "2025-03-20T15:37:06.302275+01:00",
+          "updated_at": "2025-03-20T15:37:06.302284+01:00",
           "network": "10.0.0.0/24",
           "description": "foo",
           "vlan": 1234,
@@ -19216,8 +19216,8 @@
         "status": 201,
         "response": {
           "macaddress": "",
-          "created_at": "2025-03-19T12:04:52.903980+01:00",
-          "updated_at": "2025-03-19T12:04:52.903987+01:00",
+          "created_at": "2025-03-20T15:37:07.334585+01:00",
+          "updated_at": "2025-03-20T15:37:07.334591+01:00",
           "ipaddress": "10.0.0.5",
           "host": 13
         }
@@ -19236,8 +19236,8 @@
               "ipaddresses": [
                 {
                   "macaddress": "",
-                  "created_at": "2025-03-19T12:04:52.903980+01:00",
-                  "updated_at": "2025-03-19T12:04:52.903987+01:00",
+                  "created_at": "2025-03-20T15:37:07.334585+01:00",
+                  "updated_at": "2025-03-20T15:37:07.334591+01:00",
                   "ipaddress": "10.0.0.5",
                   "host": 13
                 }
@@ -19246,8 +19246,8 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2025-03-19T12:04:51.792606+01:00",
-                  "updated_at": "2025-03-19T12:04:51.792612+01:00",
+                  "created_at": "2025-03-20T15:37:06.396618+01:00",
+                  "updated_at": "2025-03-20T15:37:06.396624+01:00",
                   "txt": "v=spf1 -all",
                   "host": 13
                 }
@@ -19256,14 +19256,14 @@
               "srvs": [],
               "naptrs": [],
               "sshfps": [],
-              "groups": [],
+              "hostgroups": [],
               "roles": [],
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
               "communities": [],
-              "created_at": "2025-03-19T12:04:51.790986+01:00",
-              "updated_at": "2025-03-19T12:04:51.790994+01:00",
+              "created_at": "2025-03-20T15:37:06.394606+01:00",
+              "updated_at": "2025-03-20T15:37:06.394612+01:00",
               "name": "foo.example.org",
               "contact": "",
               "ttl": null,
@@ -19297,8 +19297,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:52.903980+01:00",
-              "updated_at": "2025-03-19T12:04:52.903987+01:00",
+              "created_at": "2025-03-20T15:37:07.334585+01:00",
+              "updated_at": "2025-03-20T15:37:07.334591+01:00",
               "ipaddress": "10.0.0.5",
               "host": 13
             }
@@ -19307,8 +19307,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:51.792606+01:00",
-              "updated_at": "2025-03-19T12:04:51.792612+01:00",
+              "created_at": "2025-03-20T15:37:06.396618+01:00",
+              "updated_at": "2025-03-20T15:37:06.396624+01:00",
               "txt": "v=spf1 -all",
               "host": 13
             }
@@ -19317,14 +19317,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:51.790986+01:00",
-          "updated_at": "2025-03-19T12:04:51.790994+01:00",
+          "created_at": "2025-03-20T15:37:06.394606+01:00",
+          "updated_at": "2025-03-20T15:37:06.394612+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -19341,8 +19341,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:51.700856+01:00",
-          "updated_at": "2025-03-19T12:04:51.700881+01:00",
+          "created_at": "2025-03-20T15:37:06.302275+01:00",
+          "updated_at": "2025-03-20T15:37:06.302284+01:00",
           "network": "10.0.0.0/24",
           "description": "foo",
           "vlan": 1234,
@@ -19363,8 +19363,8 @@
         "status": 201,
         "response": {
           "macaddress": "",
-          "created_at": "2025-03-19T12:04:53.022387+01:00",
-          "updated_at": "2025-03-19T12:04:53.022394+01:00",
+          "created_at": "2025-03-20T15:37:07.456837+01:00",
+          "updated_at": "2025-03-20T15:37:07.456843+01:00",
           "ipaddress": "10.0.0.6",
           "host": 13
         }
@@ -19383,15 +19383,15 @@
               "ipaddresses": [
                 {
                   "macaddress": "",
-                  "created_at": "2025-03-19T12:04:52.903980+01:00",
-                  "updated_at": "2025-03-19T12:04:52.903987+01:00",
+                  "created_at": "2025-03-20T15:37:07.334585+01:00",
+                  "updated_at": "2025-03-20T15:37:07.334591+01:00",
                   "ipaddress": "10.0.0.5",
                   "host": 13
                 },
                 {
                   "macaddress": "",
-                  "created_at": "2025-03-19T12:04:53.022387+01:00",
-                  "updated_at": "2025-03-19T12:04:53.022394+01:00",
+                  "created_at": "2025-03-20T15:37:07.456837+01:00",
+                  "updated_at": "2025-03-20T15:37:07.456843+01:00",
                   "ipaddress": "10.0.0.6",
                   "host": 13
                 }
@@ -19400,8 +19400,8 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2025-03-19T12:04:51.792606+01:00",
-                  "updated_at": "2025-03-19T12:04:51.792612+01:00",
+                  "created_at": "2025-03-20T15:37:06.396618+01:00",
+                  "updated_at": "2025-03-20T15:37:06.396624+01:00",
                   "txt": "v=spf1 -all",
                   "host": 13
                 }
@@ -19410,14 +19410,14 @@
               "srvs": [],
               "naptrs": [],
               "sshfps": [],
-              "groups": [],
+              "hostgroups": [],
               "roles": [],
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
               "communities": [],
-              "created_at": "2025-03-19T12:04:51.790986+01:00",
-              "updated_at": "2025-03-19T12:04:51.790994+01:00",
+              "created_at": "2025-03-20T15:37:06.394606+01:00",
+              "updated_at": "2025-03-20T15:37:06.394612+01:00",
               "name": "foo.example.org",
               "contact": "",
               "ttl": null,
@@ -19463,15 +19463,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:52.903980+01:00",
-              "updated_at": "2025-03-19T12:04:52.903987+01:00",
+              "created_at": "2025-03-20T15:37:07.334585+01:00",
+              "updated_at": "2025-03-20T15:37:07.334591+01:00",
               "ipaddress": "10.0.0.5",
               "host": 13
             },
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:53.022387+01:00",
-              "updated_at": "2025-03-19T12:04:53.022394+01:00",
+              "created_at": "2025-03-20T15:37:07.456837+01:00",
+              "updated_at": "2025-03-20T15:37:07.456843+01:00",
               "ipaddress": "10.0.0.6",
               "host": 13
             }
@@ -19480,8 +19480,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:51.792606+01:00",
-              "updated_at": "2025-03-19T12:04:51.792612+01:00",
+              "created_at": "2025-03-20T15:37:06.396618+01:00",
+              "updated_at": "2025-03-20T15:37:06.396624+01:00",
               "txt": "v=spf1 -all",
               "host": 13
             }
@@ -19490,14 +19490,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:51.790986+01:00",
-          "updated_at": "2025-03-19T12:04:51.790994+01:00",
+          "created_at": "2025-03-20T15:37:06.394606+01:00",
+          "updated_at": "2025-03-20T15:37:06.394612+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -19529,15 +19529,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:52.903980+01:00",
-              "updated_at": "2025-03-19T12:04:52.903987+01:00",
+              "created_at": "2025-03-20T15:37:07.334585+01:00",
+              "updated_at": "2025-03-20T15:37:07.334591+01:00",
               "ipaddress": "10.0.0.5",
               "host": 13
             },
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:53.022387+01:00",
-              "updated_at": "2025-03-19T12:04:53.022394+01:00",
+              "created_at": "2025-03-20T15:37:07.456837+01:00",
+              "updated_at": "2025-03-20T15:37:07.456843+01:00",
               "ipaddress": "10.0.0.6",
               "host": 13
             }
@@ -19546,8 +19546,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:51.792606+01:00",
-              "updated_at": "2025-03-19T12:04:51.792612+01:00",
+              "created_at": "2025-03-20T15:37:06.396618+01:00",
+              "updated_at": "2025-03-20T15:37:06.396624+01:00",
               "txt": "v=spf1 -all",
               "host": 13
             }
@@ -19556,14 +19556,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:51.790986+01:00",
-          "updated_at": "2025-03-19T12:04:51.790994+01:00",
+          "created_at": "2025-03-20T15:37:06.394606+01:00",
+          "updated_at": "2025-03-20T15:37:06.394612+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -19766,8 +19766,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:52.903980+01:00",
-              "updated_at": "2025-03-19T12:04:52.903987+01:00",
+              "created_at": "2025-03-20T15:37:07.334585+01:00",
+              "updated_at": "2025-03-20T15:37:07.334591+01:00",
               "ipaddress": "10.0.0.5",
               "host": 13
             }
@@ -19776,8 +19776,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:51.792606+01:00",
-              "updated_at": "2025-03-19T12:04:51.792612+01:00",
+              "created_at": "2025-03-20T15:37:06.396618+01:00",
+              "updated_at": "2025-03-20T15:37:06.396624+01:00",
               "txt": "v=spf1 -all",
               "host": 13
             }
@@ -19786,14 +19786,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:51.790986+01:00",
-          "updated_at": "2025-03-19T12:04:51.790994+01:00",
+          "created_at": "2025-03-20T15:37:06.394606+01:00",
+          "updated_at": "2025-03-20T15:37:06.394612+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -19810,8 +19810,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:53.282328+01:00",
-          "updated_at": "2025-03-19T12:04:53.282340+01:00",
+          "created_at": "2025-03-20T15:37:07.713213+01:00",
+          "updated_at": "2025-03-20T15:37:07.713224+01:00",
           "network": "2001:db9::/64",
           "description": "notfoo_ipv6",
           "vlan": 1235,
@@ -19832,8 +19832,8 @@
         "status": 201,
         "response": {
           "macaddress": "",
-          "created_at": "2025-03-19T12:04:53.389192+01:00",
-          "updated_at": "2025-03-19T12:04:53.389197+01:00",
+          "created_at": "2025-03-20T15:37:07.813727+01:00",
+          "updated_at": "2025-03-20T15:37:07.813732+01:00",
           "ipaddress": "2001:db9::5",
           "host": 13
         }
@@ -19852,15 +19852,15 @@
               "ipaddresses": [
                 {
                   "macaddress": "",
-                  "created_at": "2025-03-19T12:04:52.903980+01:00",
-                  "updated_at": "2025-03-19T12:04:52.903987+01:00",
+                  "created_at": "2025-03-20T15:37:07.334585+01:00",
+                  "updated_at": "2025-03-20T15:37:07.334591+01:00",
                   "ipaddress": "10.0.0.5",
                   "host": 13
                 },
                 {
                   "macaddress": "",
-                  "created_at": "2025-03-19T12:04:53.389192+01:00",
-                  "updated_at": "2025-03-19T12:04:53.389197+01:00",
+                  "created_at": "2025-03-20T15:37:07.813727+01:00",
+                  "updated_at": "2025-03-20T15:37:07.813732+01:00",
                   "ipaddress": "2001:db9::5",
                   "host": 13
                 }
@@ -19869,8 +19869,8 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2025-03-19T12:04:51.792606+01:00",
-                  "updated_at": "2025-03-19T12:04:51.792612+01:00",
+                  "created_at": "2025-03-20T15:37:06.396618+01:00",
+                  "updated_at": "2025-03-20T15:37:06.396624+01:00",
                   "txt": "v=spf1 -all",
                   "host": 13
                 }
@@ -19879,14 +19879,14 @@
               "srvs": [],
               "naptrs": [],
               "sshfps": [],
-              "groups": [],
+              "hostgroups": [],
               "roles": [],
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
               "communities": [],
-              "created_at": "2025-03-19T12:04:51.790986+01:00",
-              "updated_at": "2025-03-19T12:04:51.790994+01:00",
+              "created_at": "2025-03-20T15:37:06.394606+01:00",
+              "updated_at": "2025-03-20T15:37:06.394612+01:00",
               "name": "foo.example.org",
               "contact": "",
               "ttl": null,
@@ -19932,15 +19932,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:52.903980+01:00",
-              "updated_at": "2025-03-19T12:04:52.903987+01:00",
+              "created_at": "2025-03-20T15:37:07.334585+01:00",
+              "updated_at": "2025-03-20T15:37:07.334591+01:00",
               "ipaddress": "10.0.0.5",
               "host": 13
             },
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:53.389192+01:00",
-              "updated_at": "2025-03-19T12:04:53.389197+01:00",
+              "created_at": "2025-03-20T15:37:07.813727+01:00",
+              "updated_at": "2025-03-20T15:37:07.813732+01:00",
               "ipaddress": "2001:db9::5",
               "host": 13
             }
@@ -19949,8 +19949,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:51.792606+01:00",
-              "updated_at": "2025-03-19T12:04:51.792612+01:00",
+              "created_at": "2025-03-20T15:37:06.396618+01:00",
+              "updated_at": "2025-03-20T15:37:06.396624+01:00",
               "txt": "v=spf1 -all",
               "host": 13
             }
@@ -19959,14 +19959,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:51.790986+01:00",
-          "updated_at": "2025-03-19T12:04:51.790994+01:00",
+          "created_at": "2025-03-20T15:37:06.394606+01:00",
+          "updated_at": "2025-03-20T15:37:06.394612+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -19983,8 +19983,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:51.700856+01:00",
-          "updated_at": "2025-03-19T12:04:51.700881+01:00",
+          "created_at": "2025-03-20T15:37:06.302275+01:00",
+          "updated_at": "2025-03-20T15:37:06.302284+01:00",
           "network": "10.0.0.0/24",
           "description": "foo",
           "vlan": 1234,
@@ -20004,8 +20004,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:53.282328+01:00",
-          "updated_at": "2025-03-19T12:04:53.282340+01:00",
+          "created_at": "2025-03-20T15:37:07.713213+01:00",
+          "updated_at": "2025-03-20T15:37:07.713224+01:00",
           "network": "2001:db9::/64",
           "description": "notfoo_ipv6",
           "vlan": 1235,
@@ -20040,15 +20040,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:52.903980+01:00",
-              "updated_at": "2025-03-19T12:04:52.903987+01:00",
+              "created_at": "2025-03-20T15:37:07.334585+01:00",
+              "updated_at": "2025-03-20T15:37:07.334591+01:00",
               "ipaddress": "10.0.0.5",
               "host": 13
             },
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:53.389192+01:00",
-              "updated_at": "2025-03-19T12:04:53.389197+01:00",
+              "created_at": "2025-03-20T15:37:07.813727+01:00",
+              "updated_at": "2025-03-20T15:37:07.813732+01:00",
               "ipaddress": "2001:db9::5",
               "host": 13
             }
@@ -20057,8 +20057,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:51.792606+01:00",
-              "updated_at": "2025-03-19T12:04:51.792612+01:00",
+              "created_at": "2025-03-20T15:37:06.396618+01:00",
+              "updated_at": "2025-03-20T15:37:06.396624+01:00",
               "txt": "v=spf1 -all",
               "host": 13
             }
@@ -20067,14 +20067,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:51.790986+01:00",
-          "updated_at": "2025-03-19T12:04:51.790994+01:00",
+          "created_at": "2025-03-20T15:37:06.394606+01:00",
+          "updated_at": "2025-03-20T15:37:06.394612+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -20112,8 +20112,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:52.903980+01:00",
-              "updated_at": "2025-03-19T12:04:52.903987+01:00",
+              "created_at": "2025-03-20T15:37:07.334585+01:00",
+              "updated_at": "2025-03-20T15:37:07.334591+01:00",
               "ipaddress": "10.0.0.5",
               "host": 13
             }
@@ -20122,8 +20122,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:51.792606+01:00",
-              "updated_at": "2025-03-19T12:04:51.792612+01:00",
+              "created_at": "2025-03-20T15:37:06.396618+01:00",
+              "updated_at": "2025-03-20T15:37:06.396624+01:00",
               "txt": "v=spf1 -all",
               "host": 13
             }
@@ -20132,14 +20132,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:51.790986+01:00",
-          "updated_at": "2025-03-19T12:04:51.790994+01:00",
+          "created_at": "2025-03-20T15:37:06.394606+01:00",
+          "updated_at": "2025-03-20T15:37:06.394612+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -20156,8 +20156,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:53.207389+01:00",
-          "updated_at": "2025-03-19T12:04:53.207398+01:00",
+          "created_at": "2025-03-20T15:37:07.650384+01:00",
+          "updated_at": "2025-03-20T15:37:07.650393+01:00",
           "network": "2001:db8::/64",
           "description": "foo_ipv6",
           "vlan": 1234,
@@ -20178,8 +20178,8 @@
         "status": 201,
         "response": {
           "macaddress": "",
-          "created_at": "2025-03-19T12:04:53.799713+01:00",
-          "updated_at": "2025-03-19T12:04:53.799719+01:00",
+          "created_at": "2025-03-20T15:37:08.234594+01:00",
+          "updated_at": "2025-03-20T15:37:08.234600+01:00",
           "ipaddress": "2001:db8::5",
           "host": 13
         }
@@ -20198,15 +20198,15 @@
               "ipaddresses": [
                 {
                   "macaddress": "",
-                  "created_at": "2025-03-19T12:04:52.903980+01:00",
-                  "updated_at": "2025-03-19T12:04:52.903987+01:00",
+                  "created_at": "2025-03-20T15:37:07.334585+01:00",
+                  "updated_at": "2025-03-20T15:37:07.334591+01:00",
                   "ipaddress": "10.0.0.5",
                   "host": 13
                 },
                 {
                   "macaddress": "",
-                  "created_at": "2025-03-19T12:04:53.799713+01:00",
-                  "updated_at": "2025-03-19T12:04:53.799719+01:00",
+                  "created_at": "2025-03-20T15:37:08.234594+01:00",
+                  "updated_at": "2025-03-20T15:37:08.234600+01:00",
                   "ipaddress": "2001:db8::5",
                   "host": 13
                 }
@@ -20215,8 +20215,8 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2025-03-19T12:04:51.792606+01:00",
-                  "updated_at": "2025-03-19T12:04:51.792612+01:00",
+                  "created_at": "2025-03-20T15:37:06.396618+01:00",
+                  "updated_at": "2025-03-20T15:37:06.396624+01:00",
                   "txt": "v=spf1 -all",
                   "host": 13
                 }
@@ -20225,14 +20225,14 @@
               "srvs": [],
               "naptrs": [],
               "sshfps": [],
-              "groups": [],
+              "hostgroups": [],
               "roles": [],
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
               "communities": [],
-              "created_at": "2025-03-19T12:04:51.790986+01:00",
-              "updated_at": "2025-03-19T12:04:51.790994+01:00",
+              "created_at": "2025-03-20T15:37:06.394606+01:00",
+              "updated_at": "2025-03-20T15:37:06.394612+01:00",
               "name": "foo.example.org",
               "contact": "",
               "ttl": null,
@@ -20278,15 +20278,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:52.903980+01:00",
-              "updated_at": "2025-03-19T12:04:52.903987+01:00",
+              "created_at": "2025-03-20T15:37:07.334585+01:00",
+              "updated_at": "2025-03-20T15:37:07.334591+01:00",
               "ipaddress": "10.0.0.5",
               "host": 13
             },
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:53.799713+01:00",
-              "updated_at": "2025-03-19T12:04:53.799719+01:00",
+              "created_at": "2025-03-20T15:37:08.234594+01:00",
+              "updated_at": "2025-03-20T15:37:08.234600+01:00",
               "ipaddress": "2001:db8::5",
               "host": 13
             }
@@ -20295,8 +20295,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:51.792606+01:00",
-              "updated_at": "2025-03-19T12:04:51.792612+01:00",
+              "created_at": "2025-03-20T15:37:06.396618+01:00",
+              "updated_at": "2025-03-20T15:37:06.396624+01:00",
               "txt": "v=spf1 -all",
               "host": 13
             }
@@ -20305,14 +20305,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:51.790986+01:00",
-          "updated_at": "2025-03-19T12:04:51.790994+01:00",
+          "created_at": "2025-03-20T15:37:06.394606+01:00",
+          "updated_at": "2025-03-20T15:37:06.394612+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -20329,8 +20329,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:51.700856+01:00",
-          "updated_at": "2025-03-19T12:04:51.700881+01:00",
+          "created_at": "2025-03-20T15:37:06.302275+01:00",
+          "updated_at": "2025-03-20T15:37:06.302284+01:00",
           "network": "10.0.0.0/24",
           "description": "foo",
           "vlan": 1234,
@@ -20350,8 +20350,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:53.207389+01:00",
-          "updated_at": "2025-03-19T12:04:53.207398+01:00",
+          "created_at": "2025-03-20T15:37:07.650384+01:00",
+          "updated_at": "2025-03-20T15:37:07.650393+01:00",
           "network": "2001:db8::/64",
           "description": "foo_ipv6",
           "vlan": 1234,
@@ -20377,8 +20377,8 @@
         "status": 200,
         "response": {
           "macaddress": "aa:bb:cc:dd:ee:ff",
-          "created_at": "2025-03-19T12:04:52.903980+01:00",
-          "updated_at": "2025-03-19T12:04:54.012531+01:00",
+          "created_at": "2025-03-20T15:37:07.334585+01:00",
+          "updated_at": "2025-03-20T15:37:08.405563+01:00",
           "ipaddress": "10.0.0.5",
           "host": 13
         }
@@ -20405,8 +20405,8 @@
       "              2001:db8::5   <not set>   ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Wed Mar 19 12:04:51 2025",
-      "Updated:      Wed Mar 19 12:04:51 2025"
+      "Created:      Thu Mar 20 15:37:06 2025",
+      "Updated:      Thu Mar 20 15:37:06 2025"
     ],
     "api_requests": [
       {
@@ -20418,15 +20418,15 @@
           "ipaddresses": [
             {
               "macaddress": "aa:bb:cc:dd:ee:ff",
-              "created_at": "2025-03-19T12:04:52.903980+01:00",
-              "updated_at": "2025-03-19T12:04:54.012531+01:00",
+              "created_at": "2025-03-20T15:37:07.334585+01:00",
+              "updated_at": "2025-03-20T15:37:08.405563+01:00",
               "ipaddress": "10.0.0.5",
               "host": 13
             },
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:53.799713+01:00",
-              "updated_at": "2025-03-19T12:04:53.799719+01:00",
+              "created_at": "2025-03-20T15:37:08.234594+01:00",
+              "updated_at": "2025-03-20T15:37:08.234600+01:00",
               "ipaddress": "2001:db8::5",
               "host": 13
             }
@@ -20435,8 +20435,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:51.792606+01:00",
-              "updated_at": "2025-03-19T12:04:51.792612+01:00",
+              "created_at": "2025-03-20T15:37:06.396618+01:00",
+              "updated_at": "2025-03-20T15:37:06.396624+01:00",
               "txt": "v=spf1 -all",
               "host": 13
             }
@@ -20445,14 +20445,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:51.790986+01:00",
-          "updated_at": "2025-03-19T12:04:51.790994+01:00",
+          "created_at": "2025-03-20T15:37:06.394606+01:00",
+          "updated_at": "2025-03-20T15:37:06.394612+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -20469,8 +20469,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:51.700856+01:00",
-          "updated_at": "2025-03-19T12:04:51.700881+01:00",
+          "created_at": "2025-03-20T15:37:06.302275+01:00",
+          "updated_at": "2025-03-20T15:37:06.302284+01:00",
           "network": "10.0.0.0/24",
           "description": "foo",
           "vlan": 1234,
@@ -20490,8 +20490,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:53.207389+01:00",
-          "updated_at": "2025-03-19T12:04:53.207398+01:00",
+          "created_at": "2025-03-20T15:37:07.650384+01:00",
+          "updated_at": "2025-03-20T15:37:07.650393+01:00",
           "network": "2001:db8::/64",
           "description": "foo_ipv6",
           "vlan": 1234,
@@ -20526,15 +20526,15 @@
           "ipaddresses": [
             {
               "macaddress": "aa:bb:cc:dd:ee:ff",
-              "created_at": "2025-03-19T12:04:52.903980+01:00",
-              "updated_at": "2025-03-19T12:04:54.012531+01:00",
+              "created_at": "2025-03-20T15:37:07.334585+01:00",
+              "updated_at": "2025-03-20T15:37:08.405563+01:00",
               "ipaddress": "10.0.0.5",
               "host": 13
             },
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:53.799713+01:00",
-              "updated_at": "2025-03-19T12:04:53.799719+01:00",
+              "created_at": "2025-03-20T15:37:08.234594+01:00",
+              "updated_at": "2025-03-20T15:37:08.234600+01:00",
               "ipaddress": "2001:db8::5",
               "host": 13
             }
@@ -20543,8 +20543,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:51.792606+01:00",
-              "updated_at": "2025-03-19T12:04:51.792612+01:00",
+              "created_at": "2025-03-20T15:37:06.396618+01:00",
+              "updated_at": "2025-03-20T15:37:06.396624+01:00",
               "txt": "v=spf1 -all",
               "host": 13
             }
@@ -20553,14 +20553,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:51.790986+01:00",
-          "updated_at": "2025-03-19T12:04:51.790994+01:00",
+          "created_at": "2025-03-20T15:37:06.394606+01:00",
+          "updated_at": "2025-03-20T15:37:06.394612+01:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -20577,8 +20577,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:51.700856+01:00",
-          "updated_at": "2025-03-19T12:04:51.700881+01:00",
+          "created_at": "2025-03-20T15:37:06.302275+01:00",
+          "updated_at": "2025-03-20T15:37:06.302284+01:00",
           "network": "10.0.0.0/24",
           "description": "foo",
           "vlan": 1234,
@@ -20598,8 +20598,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:53.207389+01:00",
-          "updated_at": "2025-03-19T12:04:53.207398+01:00",
+          "created_at": "2025-03-20T15:37:07.650384+01:00",
+          "updated_at": "2025-03-20T15:37:07.650393+01:00",
           "network": "2001:db8::/64",
           "description": "foo_ipv6",
           "vlan": 1234,
@@ -20917,8 +20917,8 @@
       "              10.0.0.10   11:22:33:aa:bb:cc   ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Wed Mar 19 12:04:54 2025",
-      "Updated:      Wed Mar 19 12:04:54 2025"
+      "Created:      Thu Mar 20 15:37:09 2025",
+      "Updated:      Thu Mar 20 15:37:09 2025"
     ],
     "api_requests": [
       {
@@ -20960,18 +20960,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2025-03-19T12:04:41.191611+01:00",
-                "updated_at": "2025-03-19T12:04:41.191623+01:00",
+                "created_at": "2025-03-20T15:36:56.518688+01:00",
+                "updated_at": "2025-03-20T15:36:56.518700+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-03-19T12:04:40.912310+01:00",
-            "updated_at": "2025-03-19T12:04:54.213585+01:00",
+            "created_at": "2025-03-20T15:36:56.108293+01:00",
+            "updated_at": "2025-03-20T15:37:08.616160+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
+            "serialno_updated_at": "2025-03-20T15:36:56.561109+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -20990,8 +20990,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.460376+01:00",
-          "updated_at": "2025-03-19T12:04:54.460385+01:00",
+          "created_at": "2025-03-20T15:37:08.831678+01:00",
+          "updated_at": "2025-03-20T15:37:08.831687+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -21022,8 +21022,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:54.729053+01:00",
-              "updated_at": "2025-03-19T12:04:54.729059+01:00",
+              "created_at": "2025-03-20T15:37:09.046400+01:00",
+              "updated_at": "2025-03-20T15:37:09.046406+01:00",
               "ipaddress": "10.0.0.10",
               "host": 14
             }
@@ -21032,8 +21032,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:54.711653+01:00",
-              "updated_at": "2025-03-19T12:04:54.711661+01:00",
+              "created_at": "2025-03-20T15:37:09.032853+01:00",
+              "updated_at": "2025-03-20T15:37:09.032859+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -21042,14 +21042,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.709550+01:00",
-          "updated_at": "2025-03-19T12:04:54.709558+01:00",
+          "created_at": "2025-03-20T15:37:09.031195+01:00",
+          "updated_at": "2025-03-20T15:37:09.031202+01:00",
           "name": "foo.example.org",
           "contact": "hi@ho.com",
           "ttl": null,
@@ -21084,8 +21084,8 @@
         "status": 200,
         "response": {
           "macaddress": "11:22:33:aa:bb:cc",
-          "created_at": "2025-03-19T12:04:54.729053+01:00",
-          "updated_at": "2025-03-19T12:04:54.811998+01:00",
+          "created_at": "2025-03-20T15:37:09.046400+01:00",
+          "updated_at": "2025-03-20T15:37:09.131859+01:00",
           "ipaddress": "10.0.0.10",
           "host": 14
         }
@@ -21104,8 +21104,8 @@
               "ipaddresses": [
                 {
                   "macaddress": "11:22:33:aa:bb:cc",
-                  "created_at": "2025-03-19T12:04:54.729053+01:00",
-                  "updated_at": "2025-03-19T12:04:54.811998+01:00",
+                  "created_at": "2025-03-20T15:37:09.046400+01:00",
+                  "updated_at": "2025-03-20T15:37:09.131859+01:00",
                   "ipaddress": "10.0.0.10",
                   "host": 14
                 }
@@ -21114,8 +21114,8 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2025-03-19T12:04:54.711653+01:00",
-                  "updated_at": "2025-03-19T12:04:54.711661+01:00",
+                  "created_at": "2025-03-20T15:37:09.032853+01:00",
+                  "updated_at": "2025-03-20T15:37:09.032859+01:00",
                   "txt": "v=spf1 -all",
                   "host": 14
                 }
@@ -21124,14 +21124,14 @@
               "srvs": [],
               "naptrs": [],
               "sshfps": [],
-              "groups": [],
+              "hostgroups": [],
               "roles": [],
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
               "communities": [],
-              "created_at": "2025-03-19T12:04:54.709550+01:00",
-              "updated_at": "2025-03-19T12:04:54.709558+01:00",
+              "created_at": "2025-03-20T15:37:09.031195+01:00",
+              "updated_at": "2025-03-20T15:37:09.031202+01:00",
               "name": "foo.example.org",
               "contact": "hi@ho.com",
               "ttl": null,
@@ -21150,8 +21150,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.460376+01:00",
-          "updated_at": "2025-03-19T12:04:54.460385+01:00",
+          "created_at": "2025-03-20T15:37:08.831678+01:00",
+          "updated_at": "2025-03-20T15:37:08.831687+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -21182,8 +21182,8 @@
       "              10.0.0.10   11:22:33:aa:bb:cc   ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Wed Mar 19 12:04:54 2025",
-      "Updated:      Wed Mar 19 12:04:54 2025"
+      "Created:      Thu Mar 20 15:37:09 2025",
+      "Updated:      Thu Mar 20 15:37:09 2025"
     ],
     "api_requests": [
       {
@@ -21195,8 +21195,8 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2025-03-19T12:04:54.729053+01:00",
-              "updated_at": "2025-03-19T12:04:54.811998+01:00",
+              "created_at": "2025-03-20T15:37:09.046400+01:00",
+              "updated_at": "2025-03-20T15:37:09.131859+01:00",
               "ipaddress": "10.0.0.10",
               "host": 14
             }
@@ -21205,8 +21205,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:54.711653+01:00",
-              "updated_at": "2025-03-19T12:04:54.711661+01:00",
+              "created_at": "2025-03-20T15:37:09.032853+01:00",
+              "updated_at": "2025-03-20T15:37:09.032859+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -21215,14 +21215,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.709550+01:00",
-          "updated_at": "2025-03-19T12:04:54.709558+01:00",
+          "created_at": "2025-03-20T15:37:09.031195+01:00",
+          "updated_at": "2025-03-20T15:37:09.031202+01:00",
           "name": "foo.example.org",
           "contact": "hi@ho.com",
           "ttl": null,
@@ -21239,8 +21239,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.460376+01:00",
-          "updated_at": "2025-03-19T12:04:54.460385+01:00",
+          "created_at": "2025-03-20T15:37:08.831678+01:00",
+          "updated_at": "2025-03-20T15:37:08.831687+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -21281,8 +21281,8 @@
               "ipaddresses": [
                 {
                   "macaddress": "11:22:33:aa:bb:cc",
-                  "created_at": "2025-03-19T12:04:54.729053+01:00",
-                  "updated_at": "2025-03-19T12:04:54.811998+01:00",
+                  "created_at": "2025-03-20T15:37:09.046400+01:00",
+                  "updated_at": "2025-03-20T15:37:09.131859+01:00",
                   "ipaddress": "10.0.0.10",
                   "host": 14
                 }
@@ -21291,8 +21291,8 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2025-03-19T12:04:54.711653+01:00",
-                  "updated_at": "2025-03-19T12:04:54.711661+01:00",
+                  "created_at": "2025-03-20T15:37:09.032853+01:00",
+                  "updated_at": "2025-03-20T15:37:09.032859+01:00",
                   "txt": "v=spf1 -all",
                   "host": 14
                 }
@@ -21301,14 +21301,14 @@
               "srvs": [],
               "naptrs": [],
               "sshfps": [],
-              "groups": [],
+              "hostgroups": [],
               "roles": [],
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
               "communities": [],
-              "created_at": "2025-03-19T12:04:54.709550+01:00",
-              "updated_at": "2025-03-19T12:04:54.709558+01:00",
+              "created_at": "2025-03-20T15:37:09.031195+01:00",
+              "updated_at": "2025-03-20T15:37:09.031202+01:00",
               "name": "foo.example.org",
               "contact": "hi@ho.com",
               "ttl": null,
@@ -21348,8 +21348,8 @@
               "ipaddresses": [
                 {
                   "macaddress": "11:22:33:aa:bb:cc",
-                  "created_at": "2025-03-19T12:04:54.729053+01:00",
-                  "updated_at": "2025-03-19T12:04:54.811998+01:00",
+                  "created_at": "2025-03-20T15:37:09.046400+01:00",
+                  "updated_at": "2025-03-20T15:37:09.131859+01:00",
                   "ipaddress": "10.0.0.10",
                   "host": 14
                 }
@@ -21358,8 +21358,8 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2025-03-19T12:04:54.711653+01:00",
-                  "updated_at": "2025-03-19T12:04:54.711661+01:00",
+                  "created_at": "2025-03-20T15:37:09.032853+01:00",
+                  "updated_at": "2025-03-20T15:37:09.032859+01:00",
                   "txt": "v=spf1 -all",
                   "host": 14
                 }
@@ -21368,14 +21368,14 @@
               "srvs": [],
               "naptrs": [],
               "sshfps": [],
-              "groups": [],
+              "hostgroups": [],
               "roles": [],
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
               "communities": [],
-              "created_at": "2025-03-19T12:04:54.709550+01:00",
-              "updated_at": "2025-03-19T12:04:54.709558+01:00",
+              "created_at": "2025-03-20T15:37:09.031195+01:00",
+              "updated_at": "2025-03-20T15:37:09.031202+01:00",
               "name": "foo.example.org",
               "contact": "hi@ho.com",
               "ttl": null,
@@ -21415,8 +21415,8 @@
               "ipaddresses": [
                 {
                   "macaddress": "11:22:33:aa:bb:cc",
-                  "created_at": "2025-03-19T12:04:54.729053+01:00",
-                  "updated_at": "2025-03-19T12:04:54.811998+01:00",
+                  "created_at": "2025-03-20T15:37:09.046400+01:00",
+                  "updated_at": "2025-03-20T15:37:09.131859+01:00",
                   "ipaddress": "10.0.0.10",
                   "host": 14
                 }
@@ -21425,8 +21425,8 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2025-03-19T12:04:54.711653+01:00",
-                  "updated_at": "2025-03-19T12:04:54.711661+01:00",
+                  "created_at": "2025-03-20T15:37:09.032853+01:00",
+                  "updated_at": "2025-03-20T15:37:09.032859+01:00",
                   "txt": "v=spf1 -all",
                   "host": 14
                 }
@@ -21435,14 +21435,14 @@
               "srvs": [],
               "naptrs": [],
               "sshfps": [],
-              "groups": [],
+              "hostgroups": [],
               "roles": [],
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
               "communities": [],
-              "created_at": "2025-03-19T12:04:54.709550+01:00",
-              "updated_at": "2025-03-19T12:04:54.709558+01:00",
+              "created_at": "2025-03-20T15:37:09.031195+01:00",
+              "updated_at": "2025-03-20T15:37:09.031202+01:00",
               "name": "foo.example.org",
               "contact": "hi@ho.com",
               "ttl": null,
@@ -21482,8 +21482,8 @@
               "ipaddresses": [
                 {
                   "macaddress": "11:22:33:aa:bb:cc",
-                  "created_at": "2025-03-19T12:04:54.729053+01:00",
-                  "updated_at": "2025-03-19T12:04:54.811998+01:00",
+                  "created_at": "2025-03-20T15:37:09.046400+01:00",
+                  "updated_at": "2025-03-20T15:37:09.131859+01:00",
                   "ipaddress": "10.0.0.10",
                   "host": 14
                 }
@@ -21492,8 +21492,8 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2025-03-19T12:04:54.711653+01:00",
-                  "updated_at": "2025-03-19T12:04:54.711661+01:00",
+                  "created_at": "2025-03-20T15:37:09.032853+01:00",
+                  "updated_at": "2025-03-20T15:37:09.032859+01:00",
                   "txt": "v=spf1 -all",
                   "host": 14
                 }
@@ -21502,14 +21502,14 @@
               "srvs": [],
               "naptrs": [],
               "sshfps": [],
-              "groups": [],
+              "hostgroups": [],
               "roles": [],
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
               "communities": [],
-              "created_at": "2025-03-19T12:04:54.709550+01:00",
-              "updated_at": "2025-03-19T12:04:54.709558+01:00",
+              "created_at": "2025-03-20T15:37:09.031195+01:00",
+              "updated_at": "2025-03-20T15:37:09.031202+01:00",
               "name": "foo.example.org",
               "contact": "hi@ho.com",
               "ttl": null,
@@ -21543,8 +21543,8 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2025-03-19T12:04:54.729053+01:00",
-              "updated_at": "2025-03-19T12:04:54.811998+01:00",
+              "created_at": "2025-03-20T15:37:09.046400+01:00",
+              "updated_at": "2025-03-20T15:37:09.131859+01:00",
               "ipaddress": "10.0.0.10",
               "host": 14
             }
@@ -21553,8 +21553,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:54.711653+01:00",
-              "updated_at": "2025-03-19T12:04:54.711661+01:00",
+              "created_at": "2025-03-20T15:37:09.032853+01:00",
+              "updated_at": "2025-03-20T15:37:09.032859+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -21563,14 +21563,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.709550+01:00",
-          "updated_at": "2025-03-19T12:04:54.709558+01:00",
+          "created_at": "2025-03-20T15:37:09.031195+01:00",
+          "updated_at": "2025-03-20T15:37:09.031202+01:00",
           "name": "foo.example.org",
           "contact": "hi@ho.com",
           "ttl": null,
@@ -21605,18 +21605,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2025-03-19T12:04:41.191611+01:00",
-                "updated_at": "2025-03-19T12:04:41.191623+01:00",
+                "created_at": "2025-03-20T15:36:56.518688+01:00",
+                "updated_at": "2025-03-20T15:36:56.518700+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-03-19T12:04:40.912310+01:00",
-            "updated_at": "2025-03-19T12:04:54.811424+01:00",
+            "created_at": "2025-03-20T15:36:56.108293+01:00",
+            "updated_at": "2025-03-20T15:37:09.131237+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
+            "serialno_updated_at": "2025-03-20T15:36:56.561109+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -21648,8 +21648,8 @@
               "ipaddresses": [
                 {
                   "macaddress": "11:22:33:aa:bb:cc",
-                  "created_at": "2025-03-19T12:04:54.729053+01:00",
-                  "updated_at": "2025-03-19T12:04:54.811998+01:00",
+                  "created_at": "2025-03-20T15:37:09.046400+01:00",
+                  "updated_at": "2025-03-20T15:37:09.131859+01:00",
                   "ipaddress": "10.0.0.10",
                   "host": 14
                 }
@@ -21658,8 +21658,8 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2025-03-19T12:04:54.711653+01:00",
-                  "updated_at": "2025-03-19T12:04:54.711661+01:00",
+                  "created_at": "2025-03-20T15:37:09.032853+01:00",
+                  "updated_at": "2025-03-20T15:37:09.032859+01:00",
                   "txt": "v=spf1 -all",
                   "host": 14
                 }
@@ -21668,14 +21668,14 @@
               "srvs": [],
               "naptrs": [],
               "sshfps": [],
-              "groups": [],
+              "hostgroups": [],
               "roles": [],
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
               "communities": [],
-              "created_at": "2025-03-19T12:04:54.709550+01:00",
-              "updated_at": "2025-03-19T12:04:55.346834+01:00",
+              "created_at": "2025-03-20T15:37:09.031195+01:00",
+              "updated_at": "2025-03-20T15:37:09.572537+01:00",
               "name": "bar.example.org",
               "contact": "hi@ho.com",
               "ttl": null,
@@ -21709,8 +21709,8 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2025-03-19T12:04:54.729053+01:00",
-              "updated_at": "2025-03-19T12:04:54.811998+01:00",
+              "created_at": "2025-03-20T15:37:09.046400+01:00",
+              "updated_at": "2025-03-20T15:37:09.131859+01:00",
               "ipaddress": "10.0.0.10",
               "host": 14
             }
@@ -21719,8 +21719,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:54.711653+01:00",
-              "updated_at": "2025-03-19T12:04:54.711661+01:00",
+              "created_at": "2025-03-20T15:37:09.032853+01:00",
+              "updated_at": "2025-03-20T15:37:09.032859+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -21729,14 +21729,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.709550+01:00",
-          "updated_at": "2025-03-19T12:04:55.346834+01:00",
+          "created_at": "2025-03-20T15:37:09.031195+01:00",
+          "updated_at": "2025-03-20T15:37:09.572537+01:00",
           "name": "bar.example.org",
           "contact": "hi@ho.com",
           "ttl": null,
@@ -21766,8 +21766,8 @@
               "ipaddresses": [
                 {
                   "macaddress": "11:22:33:aa:bb:cc",
-                  "created_at": "2025-03-19T12:04:54.729053+01:00",
-                  "updated_at": "2025-03-19T12:04:54.811998+01:00",
+                  "created_at": "2025-03-20T15:37:09.046400+01:00",
+                  "updated_at": "2025-03-20T15:37:09.131859+01:00",
                   "ipaddress": "10.0.0.10",
                   "host": 14
                 }
@@ -21776,8 +21776,8 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2025-03-19T12:04:54.711653+01:00",
-                  "updated_at": "2025-03-19T12:04:54.711661+01:00",
+                  "created_at": "2025-03-20T15:37:09.032853+01:00",
+                  "updated_at": "2025-03-20T15:37:09.032859+01:00",
                   "txt": "v=spf1 -all",
                   "host": 14
                 }
@@ -21786,14 +21786,14 @@
               "srvs": [],
               "naptrs": [],
               "sshfps": [],
-              "groups": [],
+              "hostgroups": [],
               "roles": [],
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
               "communities": [],
-              "created_at": "2025-03-19T12:04:54.709550+01:00",
-              "updated_at": "2025-03-19T12:04:55.483308+01:00",
+              "created_at": "2025-03-20T15:37:09.031195+01:00",
+              "updated_at": "2025-03-20T15:37:09.700706+01:00",
               "name": "bar.example.org",
               "contact": "hi@ho.com",
               "ttl": null,
@@ -21827,8 +21827,8 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2025-03-19T12:04:54.729053+01:00",
-              "updated_at": "2025-03-19T12:04:54.811998+01:00",
+              "created_at": "2025-03-20T15:37:09.046400+01:00",
+              "updated_at": "2025-03-20T15:37:09.131859+01:00",
               "ipaddress": "10.0.0.10",
               "host": 14
             }
@@ -21837,8 +21837,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:54.711653+01:00",
-              "updated_at": "2025-03-19T12:04:54.711661+01:00",
+              "created_at": "2025-03-20T15:37:09.032853+01:00",
+              "updated_at": "2025-03-20T15:37:09.032859+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -21847,14 +21847,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.709550+01:00",
-          "updated_at": "2025-03-19T12:04:55.483308+01:00",
+          "created_at": "2025-03-20T15:37:09.031195+01:00",
+          "updated_at": "2025-03-20T15:37:09.700706+01:00",
           "name": "bar.example.org",
           "contact": "hi@ho.com",
           "ttl": null,
@@ -21899,8 +21899,8 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2025-03-19T12:04:54.729053+01:00",
-              "updated_at": "2025-03-19T12:04:54.811998+01:00",
+              "created_at": "2025-03-20T15:37:09.046400+01:00",
+              "updated_at": "2025-03-20T15:37:09.131859+01:00",
               "ipaddress": "10.0.0.10",
               "host": 14
             }
@@ -21909,8 +21909,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:54.711653+01:00",
-              "updated_at": "2025-03-19T12:04:54.711661+01:00",
+              "created_at": "2025-03-20T15:37:09.032853+01:00",
+              "updated_at": "2025-03-20T15:37:09.032859+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -21919,14 +21919,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.709550+01:00",
-          "updated_at": "2025-03-19T12:04:55.483308+01:00",
+          "created_at": "2025-03-20T15:37:09.031195+01:00",
+          "updated_at": "2025-03-20T15:37:09.700706+01:00",
           "name": "bar.example.org",
           "contact": "hi@ho.com",
           "ttl": null,
@@ -21956,8 +21956,8 @@
               "ipaddresses": [
                 {
                   "macaddress": "11:22:33:aa:bb:cc",
-                  "created_at": "2025-03-19T12:04:54.729053+01:00",
-                  "updated_at": "2025-03-19T12:04:54.811998+01:00",
+                  "created_at": "2025-03-20T15:37:09.046400+01:00",
+                  "updated_at": "2025-03-20T15:37:09.131859+01:00",
                   "ipaddress": "10.0.0.10",
                   "host": 14
                 }
@@ -21966,8 +21966,8 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2025-03-19T12:04:54.711653+01:00",
-                  "updated_at": "2025-03-19T12:04:54.711661+01:00",
+                  "created_at": "2025-03-20T15:37:09.032853+01:00",
+                  "updated_at": "2025-03-20T15:37:09.032859+01:00",
                   "txt": "v=spf1 -all",
                   "host": 14
                 }
@@ -21976,14 +21976,14 @@
               "srvs": [],
               "naptrs": [],
               "sshfps": [],
-              "groups": [],
+              "hostgroups": [],
               "roles": [],
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
               "communities": [],
-              "created_at": "2025-03-19T12:04:54.709550+01:00",
-              "updated_at": "2025-03-19T12:04:55.670092+01:00",
+              "created_at": "2025-03-20T15:37:09.031195+01:00",
+              "updated_at": "2025-03-20T15:37:09.906360+01:00",
               "name": "bar.example.org",
               "contact": "me@example.org",
               "ttl": null,
@@ -22017,8 +22017,8 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2025-03-19T12:04:54.729053+01:00",
-              "updated_at": "2025-03-19T12:04:54.811998+01:00",
+              "created_at": "2025-03-20T15:37:09.046400+01:00",
+              "updated_at": "2025-03-20T15:37:09.131859+01:00",
               "ipaddress": "10.0.0.10",
               "host": 14
             }
@@ -22027,8 +22027,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:54.711653+01:00",
-              "updated_at": "2025-03-19T12:04:54.711661+01:00",
+              "created_at": "2025-03-20T15:37:09.032853+01:00",
+              "updated_at": "2025-03-20T15:37:09.032859+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -22037,14 +22037,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.709550+01:00",
-          "updated_at": "2025-03-19T12:04:55.670092+01:00",
+          "created_at": "2025-03-20T15:37:09.031195+01:00",
+          "updated_at": "2025-03-20T15:37:09.906360+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -22061,8 +22061,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.460376+01:00",
-          "updated_at": "2025-03-19T12:04:54.460385+01:00",
+          "created_at": "2025-03-20T15:37:08.831678+01:00",
+          "updated_at": "2025-03-20T15:37:08.831687+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -22097,8 +22097,8 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2025-03-19T12:04:54.729053+01:00",
-              "updated_at": "2025-03-19T12:04:54.811998+01:00",
+              "created_at": "2025-03-20T15:37:09.046400+01:00",
+              "updated_at": "2025-03-20T15:37:09.131859+01:00",
               "ipaddress": "10.0.0.10",
               "host": 14
             }
@@ -22107,8 +22107,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:54.711653+01:00",
-              "updated_at": "2025-03-19T12:04:54.711661+01:00",
+              "created_at": "2025-03-20T15:37:09.032853+01:00",
+              "updated_at": "2025-03-20T15:37:09.032859+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -22117,14 +22117,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.709550+01:00",
-          "updated_at": "2025-03-19T12:04:55.670092+01:00",
+          "created_at": "2025-03-20T15:37:09.031195+01:00",
+          "updated_at": "2025-03-20T15:37:09.906360+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -22141,8 +22141,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.460376+01:00",
-          "updated_at": "2025-03-19T12:04:54.460385+01:00",
+          "created_at": "2025-03-20T15:37:08.831678+01:00",
+          "updated_at": "2025-03-20T15:37:08.831687+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -22163,8 +22163,8 @@
         "status": 201,
         "response": {
           "macaddress": "",
-          "created_at": "2025-03-19T12:04:55.834780+01:00",
-          "updated_at": "2025-03-19T12:04:55.834786+01:00",
+          "created_at": "2025-03-20T15:37:10.067731+01:00",
+          "updated_at": "2025-03-20T15:37:10.067737+01:00",
           "ipaddress": "10.0.0.12",
           "host": 14
         }
@@ -22183,15 +22183,15 @@
               "ipaddresses": [
                 {
                   "macaddress": "11:22:33:aa:bb:cc",
-                  "created_at": "2025-03-19T12:04:54.729053+01:00",
-                  "updated_at": "2025-03-19T12:04:54.811998+01:00",
+                  "created_at": "2025-03-20T15:37:09.046400+01:00",
+                  "updated_at": "2025-03-20T15:37:09.131859+01:00",
                   "ipaddress": "10.0.0.10",
                   "host": 14
                 },
                 {
                   "macaddress": "",
-                  "created_at": "2025-03-19T12:04:55.834780+01:00",
-                  "updated_at": "2025-03-19T12:04:55.834786+01:00",
+                  "created_at": "2025-03-20T15:37:10.067731+01:00",
+                  "updated_at": "2025-03-20T15:37:10.067737+01:00",
                   "ipaddress": "10.0.0.12",
                   "host": 14
                 }
@@ -22200,8 +22200,8 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2025-03-19T12:04:54.711653+01:00",
-                  "updated_at": "2025-03-19T12:04:54.711661+01:00",
+                  "created_at": "2025-03-20T15:37:09.032853+01:00",
+                  "updated_at": "2025-03-20T15:37:09.032859+01:00",
                   "txt": "v=spf1 -all",
                   "host": 14
                 }
@@ -22210,14 +22210,14 @@
               "srvs": [],
               "naptrs": [],
               "sshfps": [],
-              "groups": [],
+              "hostgroups": [],
               "roles": [],
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
               "communities": [],
-              "created_at": "2025-03-19T12:04:54.709550+01:00",
-              "updated_at": "2025-03-19T12:04:55.670092+01:00",
+              "created_at": "2025-03-20T15:37:09.031195+01:00",
+              "updated_at": "2025-03-20T15:37:09.906360+01:00",
               "name": "bar.example.org",
               "contact": "me@example.org",
               "ttl": null,
@@ -22251,15 +22251,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2025-03-19T12:04:54.729053+01:00",
-              "updated_at": "2025-03-19T12:04:54.811998+01:00",
+              "created_at": "2025-03-20T15:37:09.046400+01:00",
+              "updated_at": "2025-03-20T15:37:09.131859+01:00",
               "ipaddress": "10.0.0.10",
               "host": 14
             },
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:55.834780+01:00",
-              "updated_at": "2025-03-19T12:04:55.834786+01:00",
+              "created_at": "2025-03-20T15:37:10.067731+01:00",
+              "updated_at": "2025-03-20T15:37:10.067737+01:00",
               "ipaddress": "10.0.0.12",
               "host": 14
             }
@@ -22268,8 +22268,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:54.711653+01:00",
-              "updated_at": "2025-03-19T12:04:54.711661+01:00",
+              "created_at": "2025-03-20T15:37:09.032853+01:00",
+              "updated_at": "2025-03-20T15:37:09.032859+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -22278,14 +22278,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.709550+01:00",
-          "updated_at": "2025-03-19T12:04:55.670092+01:00",
+          "created_at": "2025-03-20T15:37:09.031195+01:00",
+          "updated_at": "2025-03-20T15:37:09.906360+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -22302,8 +22302,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.460376+01:00",
-          "updated_at": "2025-03-19T12:04:54.460385+01:00",
+          "created_at": "2025-03-20T15:37:08.831678+01:00",
+          "updated_at": "2025-03-20T15:37:08.831687+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -22325,8 +22325,8 @@
         "status": 201,
         "response": {
           "macaddress": "11:22:33:44:55:66",
-          "created_at": "2025-03-19T12:04:55.985109+01:00",
-          "updated_at": "2025-03-19T12:04:55.985117+01:00",
+          "created_at": "2025-03-20T15:37:10.204852+01:00",
+          "updated_at": "2025-03-20T15:37:10.204860+01:00",
           "ipaddress": "10.0.0.13",
           "host": 14
         }
@@ -22345,22 +22345,22 @@
               "ipaddresses": [
                 {
                   "macaddress": "11:22:33:aa:bb:cc",
-                  "created_at": "2025-03-19T12:04:54.729053+01:00",
-                  "updated_at": "2025-03-19T12:04:54.811998+01:00",
+                  "created_at": "2025-03-20T15:37:09.046400+01:00",
+                  "updated_at": "2025-03-20T15:37:09.131859+01:00",
                   "ipaddress": "10.0.0.10",
                   "host": 14
                 },
                 {
                   "macaddress": "",
-                  "created_at": "2025-03-19T12:04:55.834780+01:00",
-                  "updated_at": "2025-03-19T12:04:55.834786+01:00",
+                  "created_at": "2025-03-20T15:37:10.067731+01:00",
+                  "updated_at": "2025-03-20T15:37:10.067737+01:00",
                   "ipaddress": "10.0.0.12",
                   "host": 14
                 },
                 {
                   "macaddress": "11:22:33:44:55:66",
-                  "created_at": "2025-03-19T12:04:55.985109+01:00",
-                  "updated_at": "2025-03-19T12:04:55.985117+01:00",
+                  "created_at": "2025-03-20T15:37:10.204852+01:00",
+                  "updated_at": "2025-03-20T15:37:10.204860+01:00",
                   "ipaddress": "10.0.0.13",
                   "host": 14
                 }
@@ -22369,8 +22369,8 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2025-03-19T12:04:54.711653+01:00",
-                  "updated_at": "2025-03-19T12:04:54.711661+01:00",
+                  "created_at": "2025-03-20T15:37:09.032853+01:00",
+                  "updated_at": "2025-03-20T15:37:09.032859+01:00",
                   "txt": "v=spf1 -all",
                   "host": 14
                 }
@@ -22379,14 +22379,14 @@
               "srvs": [],
               "naptrs": [],
               "sshfps": [],
-              "groups": [],
+              "hostgroups": [],
               "roles": [],
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
               "communities": [],
-              "created_at": "2025-03-19T12:04:54.709550+01:00",
-              "updated_at": "2025-03-19T12:04:55.670092+01:00",
+              "created_at": "2025-03-20T15:37:09.031195+01:00",
+              "updated_at": "2025-03-20T15:37:09.906360+01:00",
               "name": "bar.example.org",
               "contact": "me@example.org",
               "ttl": null,
@@ -22420,22 +22420,22 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2025-03-19T12:04:54.729053+01:00",
-              "updated_at": "2025-03-19T12:04:54.811998+01:00",
+              "created_at": "2025-03-20T15:37:09.046400+01:00",
+              "updated_at": "2025-03-20T15:37:09.131859+01:00",
               "ipaddress": "10.0.0.10",
               "host": 14
             },
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:55.834780+01:00",
-              "updated_at": "2025-03-19T12:04:55.834786+01:00",
+              "created_at": "2025-03-20T15:37:10.067731+01:00",
+              "updated_at": "2025-03-20T15:37:10.067737+01:00",
               "ipaddress": "10.0.0.12",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2025-03-19T12:04:55.985109+01:00",
-              "updated_at": "2025-03-19T12:04:55.985117+01:00",
+              "created_at": "2025-03-20T15:37:10.204852+01:00",
+              "updated_at": "2025-03-20T15:37:10.204860+01:00",
               "ipaddress": "10.0.0.13",
               "host": 14
             }
@@ -22444,8 +22444,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:54.711653+01:00",
-              "updated_at": "2025-03-19T12:04:54.711661+01:00",
+              "created_at": "2025-03-20T15:37:09.032853+01:00",
+              "updated_at": "2025-03-20T15:37:09.032859+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -22454,14 +22454,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.709550+01:00",
-          "updated_at": "2025-03-19T12:04:55.670092+01:00",
+          "created_at": "2025-03-20T15:37:09.031195+01:00",
+          "updated_at": "2025-03-20T15:37:09.906360+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -22476,8 +22476,8 @@
         "status": 200,
         "response": {
           "macaddress": "",
-          "created_at": "2025-03-19T12:04:55.834780+01:00",
-          "updated_at": "2025-03-19T12:04:55.834786+01:00",
+          "created_at": "2025-03-20T15:37:10.067731+01:00",
+          "updated_at": "2025-03-20T15:37:10.067737+01:00",
           "ipaddress": "10.0.0.12",
           "host": 14
         }
@@ -22509,8 +22509,8 @@
         "status": 200,
         "response": {
           "macaddress": "",
-          "created_at": "2025-03-19T12:04:55.834780+01:00",
-          "updated_at": "2025-03-19T12:04:56.162642+01:00",
+          "created_at": "2025-03-20T15:37:10.067731+01:00",
+          "updated_at": "2025-03-20T15:37:10.369742+01:00",
           "ipaddress": "10.0.0.14",
           "host": 14
         }
@@ -22539,22 +22539,22 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2025-03-19T12:04:54.729053+01:00",
-              "updated_at": "2025-03-19T12:04:54.811998+01:00",
+              "created_at": "2025-03-20T15:37:09.046400+01:00",
+              "updated_at": "2025-03-20T15:37:09.131859+01:00",
               "ipaddress": "10.0.0.10",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2025-03-19T12:04:55.985109+01:00",
-              "updated_at": "2025-03-19T12:04:55.985117+01:00",
+              "created_at": "2025-03-20T15:37:10.204852+01:00",
+              "updated_at": "2025-03-20T15:37:10.204860+01:00",
               "ipaddress": "10.0.0.13",
               "host": 14
             },
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:55.834780+01:00",
-              "updated_at": "2025-03-19T12:04:56.162642+01:00",
+              "created_at": "2025-03-20T15:37:10.067731+01:00",
+              "updated_at": "2025-03-20T15:37:10.369742+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             }
@@ -22563,8 +22563,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:54.711653+01:00",
-              "updated_at": "2025-03-19T12:04:54.711661+01:00",
+              "created_at": "2025-03-20T15:37:09.032853+01:00",
+              "updated_at": "2025-03-20T15:37:09.032859+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -22573,14 +22573,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.709550+01:00",
-          "updated_at": "2025-03-19T12:04:55.670092+01:00",
+          "created_at": "2025-03-20T15:37:09.031195+01:00",
+          "updated_at": "2025-03-20T15:37:09.906360+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -22595,8 +22595,8 @@
         "status": 200,
         "response": {
           "macaddress": "11:22:33:44:55:66",
-          "created_at": "2025-03-19T12:04:55.985109+01:00",
-          "updated_at": "2025-03-19T12:04:55.985117+01:00",
+          "created_at": "2025-03-20T15:37:10.204852+01:00",
+          "updated_at": "2025-03-20T15:37:10.204860+01:00",
           "ipaddress": "10.0.0.13",
           "host": 14
         }
@@ -22628,8 +22628,8 @@
         "status": 200,
         "response": {
           "macaddress": "11:22:33:44:55:66",
-          "created_at": "2025-03-19T12:04:55.985109+01:00",
-          "updated_at": "2025-03-19T12:04:56.289216+01:00",
+          "created_at": "2025-03-20T15:37:10.204852+01:00",
+          "updated_at": "2025-03-20T15:37:10.496985+01:00",
           "ipaddress": "10.0.0.15",
           "host": 14
         }
@@ -22658,22 +22658,22 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2025-03-19T12:04:54.729053+01:00",
-              "updated_at": "2025-03-19T12:04:54.811998+01:00",
+              "created_at": "2025-03-20T15:37:09.046400+01:00",
+              "updated_at": "2025-03-20T15:37:09.131859+01:00",
               "ipaddress": "10.0.0.10",
               "host": 14
             },
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:55.834780+01:00",
-              "updated_at": "2025-03-19T12:04:56.162642+01:00",
+              "created_at": "2025-03-20T15:37:10.067731+01:00",
+              "updated_at": "2025-03-20T15:37:10.369742+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2025-03-19T12:04:55.985109+01:00",
-              "updated_at": "2025-03-19T12:04:56.289216+01:00",
+              "created_at": "2025-03-20T15:37:10.204852+01:00",
+              "updated_at": "2025-03-20T15:37:10.496985+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
@@ -22682,8 +22682,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:54.711653+01:00",
-              "updated_at": "2025-03-19T12:04:54.711661+01:00",
+              "created_at": "2025-03-20T15:37:09.032853+01:00",
+              "updated_at": "2025-03-20T15:37:09.032859+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -22692,14 +22692,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.709550+01:00",
-          "updated_at": "2025-03-19T12:04:55.670092+01:00",
+          "created_at": "2025-03-20T15:37:09.031195+01:00",
+          "updated_at": "2025-03-20T15:37:09.906360+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -22725,8 +22725,8 @@
       "Contact:      ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Wed Mar 19 12:04:56 2025",
-      "Updated:      Wed Mar 19 12:04:56 2025"
+      "Created:      Thu Mar 20 15:37:10 2025",
+      "Updated:      Thu Mar 20 15:37:10 2025"
     ],
     "api_requests": [
       {
@@ -22756,18 +22756,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2025-03-19T12:04:41.191611+01:00",
-                "updated_at": "2025-03-19T12:04:41.191623+01:00",
+                "created_at": "2025-03-20T15:36:56.518688+01:00",
+                "updated_at": "2025-03-20T15:36:56.518700+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-03-19T12:04:40.912310+01:00",
-            "updated_at": "2025-03-19T12:04:56.288623+01:00",
+            "created_at": "2025-03-20T15:36:56.108293+01:00",
+            "updated_at": "2025-03-20T15:37:10.496406+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
+            "serialno_updated_at": "2025-03-20T15:36:56.561109+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -22796,8 +22796,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:56.406778+01:00",
-              "updated_at": "2025-03-19T12:04:56.406784+01:00",
+              "created_at": "2025-03-20T15:37:10.614037+01:00",
+              "updated_at": "2025-03-20T15:37:10.614043+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
@@ -22806,14 +22806,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:56.405048+01:00",
-          "updated_at": "2025-03-19T12:04:56.405055+01:00",
+          "created_at": "2025-03-20T15:37:10.612175+01:00",
+          "updated_at": "2025-03-20T15:37:10.612182+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -22845,22 +22845,22 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2025-03-19T12:04:54.729053+01:00",
-              "updated_at": "2025-03-19T12:04:54.811998+01:00",
+              "created_at": "2025-03-20T15:37:09.046400+01:00",
+              "updated_at": "2025-03-20T15:37:09.131859+01:00",
               "ipaddress": "10.0.0.10",
               "host": 14
             },
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:55.834780+01:00",
-              "updated_at": "2025-03-19T12:04:56.162642+01:00",
+              "created_at": "2025-03-20T15:37:10.067731+01:00",
+              "updated_at": "2025-03-20T15:37:10.369742+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2025-03-19T12:04:55.985109+01:00",
-              "updated_at": "2025-03-19T12:04:56.289216+01:00",
+              "created_at": "2025-03-20T15:37:10.204852+01:00",
+              "updated_at": "2025-03-20T15:37:10.496985+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
@@ -22869,8 +22869,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:54.711653+01:00",
-              "updated_at": "2025-03-19T12:04:54.711661+01:00",
+              "created_at": "2025-03-20T15:37:09.032853+01:00",
+              "updated_at": "2025-03-20T15:37:09.032859+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -22879,14 +22879,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.709550+01:00",
-          "updated_at": "2025-03-19T12:04:55.670092+01:00",
+          "created_at": "2025-03-20T15:37:09.031195+01:00",
+          "updated_at": "2025-03-20T15:37:09.906360+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -22905,8 +22905,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:56.406778+01:00",
-              "updated_at": "2025-03-19T12:04:56.406784+01:00",
+              "created_at": "2025-03-20T15:37:10.614037+01:00",
+              "updated_at": "2025-03-20T15:37:10.614043+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
@@ -22915,14 +22915,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:56.405048+01:00",
-          "updated_at": "2025-03-19T12:04:56.405055+01:00",
+          "created_at": "2025-03-20T15:37:10.612175+01:00",
+          "updated_at": "2025-03-20T15:37:10.612182+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -22945,8 +22945,8 @@
         "status": 200,
         "response": {
           "macaddress": "11:22:33:aa:bb:cc",
-          "created_at": "2025-03-19T12:04:54.729053+01:00",
-          "updated_at": "2025-03-19T12:04:56.526058+01:00",
+          "created_at": "2025-03-20T15:37:09.046400+01:00",
+          "updated_at": "2025-03-20T15:37:10.736314+01:00",
           "ipaddress": "10.0.0.10",
           "host": 15
         }
@@ -22976,8 +22976,8 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2025-03-19T12:04:54.729053+01:00",
-              "updated_at": "2025-03-19T12:04:56.526058+01:00",
+              "created_at": "2025-03-20T15:37:09.046400+01:00",
+              "updated_at": "2025-03-20T15:37:10.736314+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             }
@@ -22986,8 +22986,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:56.406778+01:00",
-              "updated_at": "2025-03-19T12:04:56.406784+01:00",
+              "created_at": "2025-03-20T15:37:10.614037+01:00",
+              "updated_at": "2025-03-20T15:37:10.614043+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
@@ -22996,14 +22996,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:56.405048+01:00",
-          "updated_at": "2025-03-19T12:04:56.405055+01:00",
+          "created_at": "2025-03-20T15:37:10.612175+01:00",
+          "updated_at": "2025-03-20T15:37:10.612182+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -23035,15 +23035,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:55.834780+01:00",
-              "updated_at": "2025-03-19T12:04:56.162642+01:00",
+              "created_at": "2025-03-20T15:37:10.067731+01:00",
+              "updated_at": "2025-03-20T15:37:10.369742+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2025-03-19T12:04:55.985109+01:00",
-              "updated_at": "2025-03-19T12:04:56.289216+01:00",
+              "created_at": "2025-03-20T15:37:10.204852+01:00",
+              "updated_at": "2025-03-20T15:37:10.496985+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
@@ -23052,8 +23052,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:54.711653+01:00",
-              "updated_at": "2025-03-19T12:04:54.711661+01:00",
+              "created_at": "2025-03-20T15:37:09.032853+01:00",
+              "updated_at": "2025-03-20T15:37:09.032859+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -23062,14 +23062,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.709550+01:00",
-          "updated_at": "2025-03-19T12:04:55.670092+01:00",
+          "created_at": "2025-03-20T15:37:09.031195+01:00",
+          "updated_at": "2025-03-20T15:37:09.906360+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -23086,8 +23086,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.536879+01:00",
-          "updated_at": "2025-03-19T12:04:54.536908+01:00",
+          "created_at": "2025-03-20T15:37:08.893540+01:00",
+          "updated_at": "2025-03-20T15:37:08.893549+01:00",
           "network": "2001:db8::/64",
           "description": "dolor sit amet",
           "vlan": null,
@@ -23129,15 +23129,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:55.834780+01:00",
-              "updated_at": "2025-03-19T12:04:56.162642+01:00",
+              "created_at": "2025-03-20T15:37:10.067731+01:00",
+              "updated_at": "2025-03-20T15:37:10.369742+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2025-03-19T12:04:55.985109+01:00",
-              "updated_at": "2025-03-19T12:04:56.289216+01:00",
+              "created_at": "2025-03-20T15:37:10.204852+01:00",
+              "updated_at": "2025-03-20T15:37:10.496985+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
@@ -23146,8 +23146,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:54.711653+01:00",
-              "updated_at": "2025-03-19T12:04:54.711661+01:00",
+              "created_at": "2025-03-20T15:37:09.032853+01:00",
+              "updated_at": "2025-03-20T15:37:09.032859+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -23156,14 +23156,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.709550+01:00",
-          "updated_at": "2025-03-19T12:04:55.670092+01:00",
+          "created_at": "2025-03-20T15:37:09.031195+01:00",
+          "updated_at": "2025-03-20T15:37:09.906360+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -23180,8 +23180,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.536879+01:00",
-          "updated_at": "2025-03-19T12:04:54.536908+01:00",
+          "created_at": "2025-03-20T15:37:08.893540+01:00",
+          "updated_at": "2025-03-20T15:37:08.893549+01:00",
           "network": "2001:db8::/64",
           "description": "dolor sit amet",
           "vlan": null,
@@ -23202,8 +23202,8 @@
         "status": 201,
         "response": {
           "macaddress": "",
-          "created_at": "2025-03-19T12:04:56.791007+01:00",
-          "updated_at": "2025-03-19T12:04:56.791014+01:00",
+          "created_at": "2025-03-20T15:37:10.903559+01:00",
+          "updated_at": "2025-03-20T15:37:10.903566+01:00",
           "ipaddress": "2001:db8::11",
           "host": 14
         }
@@ -23222,22 +23222,22 @@
               "ipaddresses": [
                 {
                   "macaddress": "",
-                  "created_at": "2025-03-19T12:04:55.834780+01:00",
-                  "updated_at": "2025-03-19T12:04:56.162642+01:00",
+                  "created_at": "2025-03-20T15:37:10.067731+01:00",
+                  "updated_at": "2025-03-20T15:37:10.369742+01:00",
                   "ipaddress": "10.0.0.14",
                   "host": 14
                 },
                 {
                   "macaddress": "11:22:33:44:55:66",
-                  "created_at": "2025-03-19T12:04:55.985109+01:00",
-                  "updated_at": "2025-03-19T12:04:56.289216+01:00",
+                  "created_at": "2025-03-20T15:37:10.204852+01:00",
+                  "updated_at": "2025-03-20T15:37:10.496985+01:00",
                   "ipaddress": "10.0.0.15",
                   "host": 14
                 },
                 {
                   "macaddress": "",
-                  "created_at": "2025-03-19T12:04:56.791007+01:00",
-                  "updated_at": "2025-03-19T12:04:56.791014+01:00",
+                  "created_at": "2025-03-20T15:37:10.903559+01:00",
+                  "updated_at": "2025-03-20T15:37:10.903566+01:00",
                   "ipaddress": "2001:db8::11",
                   "host": 14
                 }
@@ -23246,8 +23246,8 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2025-03-19T12:04:54.711653+01:00",
-                  "updated_at": "2025-03-19T12:04:54.711661+01:00",
+                  "created_at": "2025-03-20T15:37:09.032853+01:00",
+                  "updated_at": "2025-03-20T15:37:09.032859+01:00",
                   "txt": "v=spf1 -all",
                   "host": 14
                 }
@@ -23256,14 +23256,14 @@
               "srvs": [],
               "naptrs": [],
               "sshfps": [],
-              "groups": [],
+              "hostgroups": [],
               "roles": [],
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
               "communities": [],
-              "created_at": "2025-03-19T12:04:54.709550+01:00",
-              "updated_at": "2025-03-19T12:04:55.670092+01:00",
+              "created_at": "2025-03-20T15:37:09.031195+01:00",
+              "updated_at": "2025-03-20T15:37:09.906360+01:00",
               "name": "bar.example.org",
               "contact": "me@example.org",
               "ttl": null,
@@ -23297,22 +23297,22 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:55.834780+01:00",
-              "updated_at": "2025-03-19T12:04:56.162642+01:00",
+              "created_at": "2025-03-20T15:37:10.067731+01:00",
+              "updated_at": "2025-03-20T15:37:10.369742+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2025-03-19T12:04:55.985109+01:00",
-              "updated_at": "2025-03-19T12:04:56.289216+01:00",
+              "created_at": "2025-03-20T15:37:10.204852+01:00",
+              "updated_at": "2025-03-20T15:37:10.496985+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             },
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:56.791007+01:00",
-              "updated_at": "2025-03-19T12:04:56.791014+01:00",
+              "created_at": "2025-03-20T15:37:10.903559+01:00",
+              "updated_at": "2025-03-20T15:37:10.903566+01:00",
               "ipaddress": "2001:db8::11",
               "host": 14
             }
@@ -23321,8 +23321,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:54.711653+01:00",
-              "updated_at": "2025-03-19T12:04:54.711661+01:00",
+              "created_at": "2025-03-20T15:37:09.032853+01:00",
+              "updated_at": "2025-03-20T15:37:09.032859+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -23331,14 +23331,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.709550+01:00",
-          "updated_at": "2025-03-19T12:04:55.670092+01:00",
+          "created_at": "2025-03-20T15:37:09.031195+01:00",
+          "updated_at": "2025-03-20T15:37:09.906360+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -23355,8 +23355,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.536879+01:00",
-          "updated_at": "2025-03-19T12:04:54.536908+01:00",
+          "created_at": "2025-03-20T15:37:08.893540+01:00",
+          "updated_at": "2025-03-20T15:37:08.893549+01:00",
           "network": "2001:db8::/64",
           "description": "dolor sit amet",
           "vlan": null,
@@ -23378,8 +23378,8 @@
         "status": 201,
         "response": {
           "macaddress": "11:22:33:44:55:67",
-          "created_at": "2025-03-19T12:04:56.923203+01:00",
-          "updated_at": "2025-03-19T12:04:56.923213+01:00",
+          "created_at": "2025-03-20T15:37:11.014871+01:00",
+          "updated_at": "2025-03-20T15:37:11.014879+01:00",
           "ipaddress": "2001:db8::12",
           "host": 14
         }
@@ -23398,29 +23398,29 @@
               "ipaddresses": [
                 {
                   "macaddress": "",
-                  "created_at": "2025-03-19T12:04:55.834780+01:00",
-                  "updated_at": "2025-03-19T12:04:56.162642+01:00",
+                  "created_at": "2025-03-20T15:37:10.067731+01:00",
+                  "updated_at": "2025-03-20T15:37:10.369742+01:00",
                   "ipaddress": "10.0.0.14",
                   "host": 14
                 },
                 {
                   "macaddress": "11:22:33:44:55:66",
-                  "created_at": "2025-03-19T12:04:55.985109+01:00",
-                  "updated_at": "2025-03-19T12:04:56.289216+01:00",
+                  "created_at": "2025-03-20T15:37:10.204852+01:00",
+                  "updated_at": "2025-03-20T15:37:10.496985+01:00",
                   "ipaddress": "10.0.0.15",
                   "host": 14
                 },
                 {
                   "macaddress": "",
-                  "created_at": "2025-03-19T12:04:56.791007+01:00",
-                  "updated_at": "2025-03-19T12:04:56.791014+01:00",
+                  "created_at": "2025-03-20T15:37:10.903559+01:00",
+                  "updated_at": "2025-03-20T15:37:10.903566+01:00",
                   "ipaddress": "2001:db8::11",
                   "host": 14
                 },
                 {
                   "macaddress": "11:22:33:44:55:67",
-                  "created_at": "2025-03-19T12:04:56.923203+01:00",
-                  "updated_at": "2025-03-19T12:04:56.923213+01:00",
+                  "created_at": "2025-03-20T15:37:11.014871+01:00",
+                  "updated_at": "2025-03-20T15:37:11.014879+01:00",
                   "ipaddress": "2001:db8::12",
                   "host": 14
                 }
@@ -23429,8 +23429,8 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2025-03-19T12:04:54.711653+01:00",
-                  "updated_at": "2025-03-19T12:04:54.711661+01:00",
+                  "created_at": "2025-03-20T15:37:09.032853+01:00",
+                  "updated_at": "2025-03-20T15:37:09.032859+01:00",
                   "txt": "v=spf1 -all",
                   "host": 14
                 }
@@ -23439,14 +23439,14 @@
               "srvs": [],
               "naptrs": [],
               "sshfps": [],
-              "groups": [],
+              "hostgroups": [],
               "roles": [],
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
               "communities": [],
-              "created_at": "2025-03-19T12:04:54.709550+01:00",
-              "updated_at": "2025-03-19T12:04:55.670092+01:00",
+              "created_at": "2025-03-20T15:37:09.031195+01:00",
+              "updated_at": "2025-03-20T15:37:09.906360+01:00",
               "name": "bar.example.org",
               "contact": "me@example.org",
               "ttl": null,
@@ -23480,29 +23480,29 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:55.834780+01:00",
-              "updated_at": "2025-03-19T12:04:56.162642+01:00",
+              "created_at": "2025-03-20T15:37:10.067731+01:00",
+              "updated_at": "2025-03-20T15:37:10.369742+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2025-03-19T12:04:55.985109+01:00",
-              "updated_at": "2025-03-19T12:04:56.289216+01:00",
+              "created_at": "2025-03-20T15:37:10.204852+01:00",
+              "updated_at": "2025-03-20T15:37:10.496985+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             },
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:56.791007+01:00",
-              "updated_at": "2025-03-19T12:04:56.791014+01:00",
+              "created_at": "2025-03-20T15:37:10.903559+01:00",
+              "updated_at": "2025-03-20T15:37:10.903566+01:00",
               "ipaddress": "2001:db8::11",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2025-03-19T12:04:56.923203+01:00",
-              "updated_at": "2025-03-19T12:04:56.923213+01:00",
+              "created_at": "2025-03-20T15:37:11.014871+01:00",
+              "updated_at": "2025-03-20T15:37:11.014879+01:00",
               "ipaddress": "2001:db8::12",
               "host": 14
             }
@@ -23511,8 +23511,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:54.711653+01:00",
-              "updated_at": "2025-03-19T12:04:54.711661+01:00",
+              "created_at": "2025-03-20T15:37:09.032853+01:00",
+              "updated_at": "2025-03-20T15:37:09.032859+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -23521,14 +23521,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.709550+01:00",
-          "updated_at": "2025-03-19T12:04:55.670092+01:00",
+          "created_at": "2025-03-20T15:37:09.031195+01:00",
+          "updated_at": "2025-03-20T15:37:09.906360+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -23545,8 +23545,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.460376+01:00",
-          "updated_at": "2025-03-19T12:04:54.460385+01:00",
+          "created_at": "2025-03-20T15:37:08.831678+01:00",
+          "updated_at": "2025-03-20T15:37:08.831687+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -23566,8 +23566,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.460376+01:00",
-          "updated_at": "2025-03-19T12:04:54.460385+01:00",
+          "created_at": "2025-03-20T15:37:08.831678+01:00",
+          "updated_at": "2025-03-20T15:37:08.831687+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -23587,8 +23587,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.536879+01:00",
-          "updated_at": "2025-03-19T12:04:54.536908+01:00",
+          "created_at": "2025-03-20T15:37:08.893540+01:00",
+          "updated_at": "2025-03-20T15:37:08.893549+01:00",
           "network": "2001:db8::/64",
           "description": "dolor sit amet",
           "vlan": null,
@@ -23608,8 +23608,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.536879+01:00",
-          "updated_at": "2025-03-19T12:04:54.536908+01:00",
+          "created_at": "2025-03-20T15:37:08.893540+01:00",
+          "updated_at": "2025-03-20T15:37:08.893549+01:00",
           "network": "2001:db8::/64",
           "description": "dolor sit amet",
           "vlan": null,
@@ -23646,29 +23646,29 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:55.834780+01:00",
-              "updated_at": "2025-03-19T12:04:56.162642+01:00",
+              "created_at": "2025-03-20T15:37:10.067731+01:00",
+              "updated_at": "2025-03-20T15:37:10.369742+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2025-03-19T12:04:55.985109+01:00",
-              "updated_at": "2025-03-19T12:04:56.289216+01:00",
+              "created_at": "2025-03-20T15:37:10.204852+01:00",
+              "updated_at": "2025-03-20T15:37:10.496985+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             },
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:56.791007+01:00",
-              "updated_at": "2025-03-19T12:04:56.791014+01:00",
+              "created_at": "2025-03-20T15:37:10.903559+01:00",
+              "updated_at": "2025-03-20T15:37:10.903566+01:00",
               "ipaddress": "2001:db8::11",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2025-03-19T12:04:56.923203+01:00",
-              "updated_at": "2025-03-19T12:04:56.923213+01:00",
+              "created_at": "2025-03-20T15:37:11.014871+01:00",
+              "updated_at": "2025-03-20T15:37:11.014879+01:00",
               "ipaddress": "2001:db8::12",
               "host": 14
             }
@@ -23677,8 +23677,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:54.711653+01:00",
-              "updated_at": "2025-03-19T12:04:54.711661+01:00",
+              "created_at": "2025-03-20T15:37:09.032853+01:00",
+              "updated_at": "2025-03-20T15:37:09.032859+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -23687,14 +23687,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.709550+01:00",
-          "updated_at": "2025-03-19T12:04:55.670092+01:00",
+          "created_at": "2025-03-20T15:37:09.031195+01:00",
+          "updated_at": "2025-03-20T15:37:09.906360+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -23726,29 +23726,29 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:55.834780+01:00",
-              "updated_at": "2025-03-19T12:04:56.162642+01:00",
+              "created_at": "2025-03-20T15:37:10.067731+01:00",
+              "updated_at": "2025-03-20T15:37:10.369742+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2025-03-19T12:04:55.985109+01:00",
-              "updated_at": "2025-03-19T12:04:56.289216+01:00",
+              "created_at": "2025-03-20T15:37:10.204852+01:00",
+              "updated_at": "2025-03-20T15:37:10.496985+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             },
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:56.791007+01:00",
-              "updated_at": "2025-03-19T12:04:56.791014+01:00",
+              "created_at": "2025-03-20T15:37:10.903559+01:00",
+              "updated_at": "2025-03-20T15:37:10.903566+01:00",
               "ipaddress": "2001:db8::11",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2025-03-19T12:04:56.923203+01:00",
-              "updated_at": "2025-03-19T12:04:56.923213+01:00",
+              "created_at": "2025-03-20T15:37:11.014871+01:00",
+              "updated_at": "2025-03-20T15:37:11.014879+01:00",
               "ipaddress": "2001:db8::12",
               "host": 14
             }
@@ -23757,8 +23757,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:54.711653+01:00",
-              "updated_at": "2025-03-19T12:04:54.711661+01:00",
+              "created_at": "2025-03-20T15:37:09.032853+01:00",
+              "updated_at": "2025-03-20T15:37:09.032859+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -23767,14 +23767,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.709550+01:00",
-          "updated_at": "2025-03-19T12:04:55.670092+01:00",
+          "created_at": "2025-03-20T15:37:09.031195+01:00",
+          "updated_at": "2025-03-20T15:37:09.906360+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -23789,8 +23789,8 @@
         "status": 200,
         "response": {
           "macaddress": "",
-          "created_at": "2025-03-19T12:04:56.791007+01:00",
-          "updated_at": "2025-03-19T12:04:56.791014+01:00",
+          "created_at": "2025-03-20T15:37:10.903559+01:00",
+          "updated_at": "2025-03-20T15:37:10.903566+01:00",
           "ipaddress": "2001:db8::11",
           "host": 14
         }
@@ -23822,8 +23822,8 @@
         "status": 200,
         "response": {
           "macaddress": "",
-          "created_at": "2025-03-19T12:04:56.791007+01:00",
-          "updated_at": "2025-03-19T12:04:57.231895+01:00",
+          "created_at": "2025-03-20T15:37:10.903559+01:00",
+          "updated_at": "2025-03-20T15:37:11.338972+01:00",
           "ipaddress": "2001:db8::13",
           "host": 14
         }
@@ -23852,29 +23852,29 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:55.834780+01:00",
-              "updated_at": "2025-03-19T12:04:56.162642+01:00",
+              "created_at": "2025-03-20T15:37:10.067731+01:00",
+              "updated_at": "2025-03-20T15:37:10.369742+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2025-03-19T12:04:55.985109+01:00",
-              "updated_at": "2025-03-19T12:04:56.289216+01:00",
+              "created_at": "2025-03-20T15:37:10.204852+01:00",
+              "updated_at": "2025-03-20T15:37:10.496985+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2025-03-19T12:04:56.923203+01:00",
-              "updated_at": "2025-03-19T12:04:56.923213+01:00",
+              "created_at": "2025-03-20T15:37:11.014871+01:00",
+              "updated_at": "2025-03-20T15:37:11.014879+01:00",
               "ipaddress": "2001:db8::12",
               "host": 14
             },
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:56.791007+01:00",
-              "updated_at": "2025-03-19T12:04:57.231895+01:00",
+              "created_at": "2025-03-20T15:37:10.903559+01:00",
+              "updated_at": "2025-03-20T15:37:11.338972+01:00",
               "ipaddress": "2001:db8::13",
               "host": 14
             }
@@ -23883,8 +23883,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:54.711653+01:00",
-              "updated_at": "2025-03-19T12:04:54.711661+01:00",
+              "created_at": "2025-03-20T15:37:09.032853+01:00",
+              "updated_at": "2025-03-20T15:37:09.032859+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -23893,14 +23893,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.709550+01:00",
-          "updated_at": "2025-03-19T12:04:55.670092+01:00",
+          "created_at": "2025-03-20T15:37:09.031195+01:00",
+          "updated_at": "2025-03-20T15:37:09.906360+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -23915,8 +23915,8 @@
         "status": 200,
         "response": {
           "macaddress": "11:22:33:44:55:67",
-          "created_at": "2025-03-19T12:04:56.923203+01:00",
-          "updated_at": "2025-03-19T12:04:56.923213+01:00",
+          "created_at": "2025-03-20T15:37:11.014871+01:00",
+          "updated_at": "2025-03-20T15:37:11.014879+01:00",
           "ipaddress": "2001:db8::12",
           "host": 14
         }
@@ -23948,8 +23948,8 @@
         "status": 200,
         "response": {
           "macaddress": "11:22:33:44:55:67",
-          "created_at": "2025-03-19T12:04:56.923203+01:00",
-          "updated_at": "2025-03-19T12:04:57.387957+01:00",
+          "created_at": "2025-03-20T15:37:11.014871+01:00",
+          "updated_at": "2025-03-20T15:37:11.463285+01:00",
           "ipaddress": "2001:db8::14",
           "host": 14
         }
@@ -23978,29 +23978,29 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:55.834780+01:00",
-              "updated_at": "2025-03-19T12:04:56.162642+01:00",
+              "created_at": "2025-03-20T15:37:10.067731+01:00",
+              "updated_at": "2025-03-20T15:37:10.369742+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2025-03-19T12:04:55.985109+01:00",
-              "updated_at": "2025-03-19T12:04:56.289216+01:00",
+              "created_at": "2025-03-20T15:37:10.204852+01:00",
+              "updated_at": "2025-03-20T15:37:10.496985+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             },
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:56.791007+01:00",
-              "updated_at": "2025-03-19T12:04:57.231895+01:00",
+              "created_at": "2025-03-20T15:37:10.903559+01:00",
+              "updated_at": "2025-03-20T15:37:11.338972+01:00",
               "ipaddress": "2001:db8::13",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2025-03-19T12:04:56.923203+01:00",
-              "updated_at": "2025-03-19T12:04:57.387957+01:00",
+              "created_at": "2025-03-20T15:37:11.014871+01:00",
+              "updated_at": "2025-03-20T15:37:11.463285+01:00",
               "ipaddress": "2001:db8::14",
               "host": 14
             }
@@ -24009,8 +24009,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:54.711653+01:00",
-              "updated_at": "2025-03-19T12:04:54.711661+01:00",
+              "created_at": "2025-03-20T15:37:09.032853+01:00",
+              "updated_at": "2025-03-20T15:37:09.032859+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -24019,14 +24019,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.709550+01:00",
-          "updated_at": "2025-03-19T12:04:55.670092+01:00",
+          "created_at": "2025-03-20T15:37:09.031195+01:00",
+          "updated_at": "2025-03-20T15:37:09.906360+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -24064,22 +24064,22 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:55.834780+01:00",
-              "updated_at": "2025-03-19T12:04:56.162642+01:00",
+              "created_at": "2025-03-20T15:37:10.067731+01:00",
+              "updated_at": "2025-03-20T15:37:10.369742+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2025-03-19T12:04:55.985109+01:00",
-              "updated_at": "2025-03-19T12:04:56.289216+01:00",
+              "created_at": "2025-03-20T15:37:10.204852+01:00",
+              "updated_at": "2025-03-20T15:37:10.496985+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2025-03-19T12:04:56.923203+01:00",
-              "updated_at": "2025-03-19T12:04:57.387957+01:00",
+              "created_at": "2025-03-20T15:37:11.014871+01:00",
+              "updated_at": "2025-03-20T15:37:11.463285+01:00",
               "ipaddress": "2001:db8::14",
               "host": 14
             }
@@ -24088,8 +24088,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:54.711653+01:00",
-              "updated_at": "2025-03-19T12:04:54.711661+01:00",
+              "created_at": "2025-03-20T15:37:09.032853+01:00",
+              "updated_at": "2025-03-20T15:37:09.032859+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -24098,14 +24098,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.709550+01:00",
-          "updated_at": "2025-03-19T12:04:55.670092+01:00",
+          "created_at": "2025-03-20T15:37:09.031195+01:00",
+          "updated_at": "2025-03-20T15:37:09.906360+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -24122,8 +24122,8 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2025-03-19T12:04:54.729053+01:00",
-              "updated_at": "2025-03-19T12:04:56.526058+01:00",
+              "created_at": "2025-03-20T15:37:09.046400+01:00",
+              "updated_at": "2025-03-20T15:37:10.736314+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             }
@@ -24132,8 +24132,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:56.406778+01:00",
-              "updated_at": "2025-03-19T12:04:56.406784+01:00",
+              "created_at": "2025-03-20T15:37:10.614037+01:00",
+              "updated_at": "2025-03-20T15:37:10.614043+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
@@ -24142,14 +24142,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:56.405048+01:00",
-          "updated_at": "2025-03-19T12:04:56.405055+01:00",
+          "created_at": "2025-03-20T15:37:10.612175+01:00",
+          "updated_at": "2025-03-20T15:37:10.612182+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -24172,8 +24172,8 @@
         "status": 200,
         "response": {
           "macaddress": "11:22:33:44:55:67",
-          "created_at": "2025-03-19T12:04:56.923203+01:00",
-          "updated_at": "2025-03-19T12:04:57.546535+01:00",
+          "created_at": "2025-03-20T15:37:11.014871+01:00",
+          "updated_at": "2025-03-20T15:37:11.607397+01:00",
           "ipaddress": "2001:db8::14",
           "host": 15
         }
@@ -24203,15 +24203,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2025-03-19T12:04:54.729053+01:00",
-              "updated_at": "2025-03-19T12:04:56.526058+01:00",
+              "created_at": "2025-03-20T15:37:09.046400+01:00",
+              "updated_at": "2025-03-20T15:37:10.736314+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2025-03-19T12:04:56.923203+01:00",
-              "updated_at": "2025-03-19T12:04:57.546535+01:00",
+              "created_at": "2025-03-20T15:37:11.014871+01:00",
+              "updated_at": "2025-03-20T15:37:11.607397+01:00",
               "ipaddress": "2001:db8::14",
               "host": 15
             }
@@ -24220,8 +24220,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:56.406778+01:00",
-              "updated_at": "2025-03-19T12:04:56.406784+01:00",
+              "created_at": "2025-03-20T15:37:10.614037+01:00",
+              "updated_at": "2025-03-20T15:37:10.614043+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
@@ -24230,14 +24230,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:56.405048+01:00",
-          "updated_at": "2025-03-19T12:04:56.405055+01:00",
+          "created_at": "2025-03-20T15:37:10.612175+01:00",
+          "updated_at": "2025-03-20T15:37:10.612182+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -24269,15 +24269,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:55.834780+01:00",
-              "updated_at": "2025-03-19T12:04:56.162642+01:00",
+              "created_at": "2025-03-20T15:37:10.067731+01:00",
+              "updated_at": "2025-03-20T15:37:10.369742+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2025-03-19T12:04:55.985109+01:00",
-              "updated_at": "2025-03-19T12:04:56.289216+01:00",
+              "created_at": "2025-03-20T15:37:10.204852+01:00",
+              "updated_at": "2025-03-20T15:37:10.496985+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
@@ -24286,8 +24286,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:54.711653+01:00",
-              "updated_at": "2025-03-19T12:04:54.711661+01:00",
+              "created_at": "2025-03-20T15:37:09.032853+01:00",
+              "updated_at": "2025-03-20T15:37:09.032859+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -24296,14 +24296,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.709550+01:00",
-          "updated_at": "2025-03-19T12:04:55.670092+01:00",
+          "created_at": "2025-03-20T15:37:09.031195+01:00",
+          "updated_at": "2025-03-20T15:37:09.906360+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -24338,18 +24338,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2025-03-19T12:04:41.191611+01:00",
-                "updated_at": "2025-03-19T12:04:41.191623+01:00",
+                "created_at": "2025-03-20T15:36:56.518688+01:00",
+                "updated_at": "2025-03-20T15:36:56.518700+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-03-19T12:04:40.912310+01:00",
-            "updated_at": "2025-03-19T12:04:57.545960+01:00",
+            "created_at": "2025-03-20T15:36:56.108293+01:00",
+            "updated_at": "2025-03-20T15:37:11.606787+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
+            "serialno_updated_at": "2025-03-20T15:36:56.561109+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -24368,8 +24368,8 @@
         },
         "status": 201,
         "response": {
-          "created_at": "2025-03-19T12:04:57.705722+01:00",
-          "updated_at": "2025-03-19T12:04:57.705730+01:00",
+          "created_at": "2025-03-20T15:37:11.745992+01:00",
+          "updated_at": "2025-03-20T15:37:11.745998+01:00",
           "name": "fubar.example.org",
           "ttl": null,
           "zone": 1,
@@ -24385,23 +24385,23 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:55.834780+01:00",
-              "updated_at": "2025-03-19T12:04:56.162642+01:00",
+              "created_at": "2025-03-20T15:37:10.067731+01:00",
+              "updated_at": "2025-03-20T15:37:10.369742+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2025-03-19T12:04:55.985109+01:00",
-              "updated_at": "2025-03-19T12:04:56.289216+01:00",
+              "created_at": "2025-03-20T15:37:10.204852+01:00",
+              "updated_at": "2025-03-20T15:37:10.496985+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
           ],
           "cnames": [
             {
-              "created_at": "2025-03-19T12:04:57.705722+01:00",
-              "updated_at": "2025-03-19T12:04:57.705730+01:00",
+              "created_at": "2025-03-20T15:37:11.745992+01:00",
+              "updated_at": "2025-03-20T15:37:11.745998+01:00",
               "name": "fubar.example.org",
               "ttl": null,
               "zone": 1,
@@ -24411,8 +24411,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:54.711653+01:00",
-              "updated_at": "2025-03-19T12:04:54.711661+01:00",
+              "created_at": "2025-03-20T15:37:09.032853+01:00",
+              "updated_at": "2025-03-20T15:37:09.032859+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -24421,14 +24421,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.709550+01:00",
-          "updated_at": "2025-03-19T12:04:55.670092+01:00",
+          "created_at": "2025-03-20T15:37:09.031195+01:00",
+          "updated_at": "2025-03-20T15:37:09.906360+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -24447,8 +24447,8 @@
           "previous": null,
           "results": [
             {
-              "created_at": "2025-03-19T12:04:57.705722+01:00",
-              "updated_at": "2025-03-19T12:04:57.705730+01:00",
+              "created_at": "2025-03-20T15:37:11.745992+01:00",
+              "updated_at": "2025-03-20T15:37:11.745998+01:00",
               "name": "fubar.example.org",
               "ttl": null,
               "zone": 1,
@@ -24481,23 +24481,23 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:55.834780+01:00",
-              "updated_at": "2025-03-19T12:04:56.162642+01:00",
+              "created_at": "2025-03-20T15:37:10.067731+01:00",
+              "updated_at": "2025-03-20T15:37:10.369742+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2025-03-19T12:04:55.985109+01:00",
-              "updated_at": "2025-03-19T12:04:56.289216+01:00",
+              "created_at": "2025-03-20T15:37:10.204852+01:00",
+              "updated_at": "2025-03-20T15:37:10.496985+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
           ],
           "cnames": [
             {
-              "created_at": "2025-03-19T12:04:57.705722+01:00",
-              "updated_at": "2025-03-19T12:04:57.705730+01:00",
+              "created_at": "2025-03-20T15:37:11.745992+01:00",
+              "updated_at": "2025-03-20T15:37:11.745998+01:00",
               "name": "fubar.example.org",
               "ttl": null,
               "zone": 1,
@@ -24507,8 +24507,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:54.711653+01:00",
-              "updated_at": "2025-03-19T12:04:54.711661+01:00",
+              "created_at": "2025-03-20T15:37:09.032853+01:00",
+              "updated_at": "2025-03-20T15:37:09.032859+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -24517,14 +24517,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.709550+01:00",
-          "updated_at": "2025-03-19T12:04:55.670092+01:00",
+          "created_at": "2025-03-20T15:37:09.031195+01:00",
+          "updated_at": "2025-03-20T15:37:09.906360+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -24541,8 +24541,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.460376+01:00",
-          "updated_at": "2025-03-19T12:04:54.460385+01:00",
+          "created_at": "2025-03-20T15:37:08.831678+01:00",
+          "updated_at": "2025-03-20T15:37:08.831687+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -24562,8 +24562,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.460376+01:00",
-          "updated_at": "2025-03-19T12:04:54.460385+01:00",
+          "created_at": "2025-03-20T15:37:08.831678+01:00",
+          "updated_at": "2025-03-20T15:37:08.831687+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -24598,23 +24598,23 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:55.834780+01:00",
-              "updated_at": "2025-03-19T12:04:56.162642+01:00",
+              "created_at": "2025-03-20T15:37:10.067731+01:00",
+              "updated_at": "2025-03-20T15:37:10.369742+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2025-03-19T12:04:55.985109+01:00",
-              "updated_at": "2025-03-19T12:04:56.289216+01:00",
+              "created_at": "2025-03-20T15:37:10.204852+01:00",
+              "updated_at": "2025-03-20T15:37:10.496985+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
           ],
           "cnames": [
             {
-              "created_at": "2025-03-19T12:04:57.705722+01:00",
-              "updated_at": "2025-03-19T12:04:57.705730+01:00",
+              "created_at": "2025-03-20T15:37:11.745992+01:00",
+              "updated_at": "2025-03-20T15:37:11.745998+01:00",
               "name": "fubar.example.org",
               "ttl": null,
               "zone": 1,
@@ -24624,8 +24624,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:54.711653+01:00",
-              "updated_at": "2025-03-19T12:04:54.711661+01:00",
+              "created_at": "2025-03-20T15:37:09.032853+01:00",
+              "updated_at": "2025-03-20T15:37:09.032859+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -24634,14 +24634,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.709550+01:00",
-          "updated_at": "2025-03-19T12:04:55.670092+01:00",
+          "created_at": "2025-03-20T15:37:09.031195+01:00",
+          "updated_at": "2025-03-20T15:37:09.906360+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -24673,23 +24673,23 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:55.834780+01:00",
-              "updated_at": "2025-03-19T12:04:56.162642+01:00",
+              "created_at": "2025-03-20T15:37:10.067731+01:00",
+              "updated_at": "2025-03-20T15:37:10.369742+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2025-03-19T12:04:55.985109+01:00",
-              "updated_at": "2025-03-19T12:04:56.289216+01:00",
+              "created_at": "2025-03-20T15:37:10.204852+01:00",
+              "updated_at": "2025-03-20T15:37:10.496985+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
           ],
           "cnames": [
             {
-              "created_at": "2025-03-19T12:04:57.705722+01:00",
-              "updated_at": "2025-03-19T12:04:57.705730+01:00",
+              "created_at": "2025-03-20T15:37:11.745992+01:00",
+              "updated_at": "2025-03-20T15:37:11.745998+01:00",
               "name": "fubar.example.org",
               "ttl": null,
               "zone": 1,
@@ -24699,8 +24699,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:54.711653+01:00",
-              "updated_at": "2025-03-19T12:04:54.711661+01:00",
+              "created_at": "2025-03-20T15:37:09.032853+01:00",
+              "updated_at": "2025-03-20T15:37:09.032859+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -24709,14 +24709,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.709550+01:00",
-          "updated_at": "2025-03-19T12:04:55.670092+01:00",
+          "created_at": "2025-03-20T15:37:09.031195+01:00",
+          "updated_at": "2025-03-20T15:37:09.906360+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -24739,8 +24739,8 @@
         "data": {},
         "status": 200,
         "response": {
-          "created_at": "2025-03-19T12:04:57.705722+01:00",
-          "updated_at": "2025-03-19T12:04:57.705730+01:00",
+          "created_at": "2025-03-20T15:37:11.745992+01:00",
+          "updated_at": "2025-03-20T15:37:11.745998+01:00",
           "name": "fubar.example.org",
           "ttl": null,
           "zone": 1,
@@ -24777,15 +24777,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2025-03-19T12:04:54.729053+01:00",
-              "updated_at": "2025-03-19T12:04:56.526058+01:00",
+              "created_at": "2025-03-20T15:37:09.046400+01:00",
+              "updated_at": "2025-03-20T15:37:10.736314+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2025-03-19T12:04:56.923203+01:00",
-              "updated_at": "2025-03-19T12:04:57.546535+01:00",
+              "created_at": "2025-03-20T15:37:11.014871+01:00",
+              "updated_at": "2025-03-20T15:37:11.607397+01:00",
               "ipaddress": "2001:db8::14",
               "host": 15
             }
@@ -24794,8 +24794,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:56.406778+01:00",
-              "updated_at": "2025-03-19T12:04:56.406784+01:00",
+              "created_at": "2025-03-20T15:37:10.614037+01:00",
+              "updated_at": "2025-03-20T15:37:10.614043+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
@@ -24804,14 +24804,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:56.405048+01:00",
-          "updated_at": "2025-03-19T12:04:56.405055+01:00",
+          "created_at": "2025-03-20T15:37:10.612175+01:00",
+          "updated_at": "2025-03-20T15:37:10.612182+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -24830,8 +24830,8 @@
         "status": 201,
         "response": {
           "host": 15,
-          "created_at": "2025-03-19T12:04:58.050990+01:00",
-          "updated_at": "2025-03-19T12:04:58.050999+01:00",
+          "created_at": "2025-03-20T15:37:12.023925+01:00",
+          "updated_at": "2025-03-20T15:37:12.023932+01:00",
           "cpu": "x86",
           "os": "Win"
         }
@@ -24850,15 +24850,15 @@
               "ipaddresses": [
                 {
                   "macaddress": "11:22:33:aa:bb:cc",
-                  "created_at": "2025-03-19T12:04:54.729053+01:00",
-                  "updated_at": "2025-03-19T12:04:56.526058+01:00",
+                  "created_at": "2025-03-20T15:37:09.046400+01:00",
+                  "updated_at": "2025-03-20T15:37:10.736314+01:00",
                   "ipaddress": "10.0.0.10",
                   "host": 15
                 },
                 {
                   "macaddress": "11:22:33:44:55:67",
-                  "created_at": "2025-03-19T12:04:56.923203+01:00",
-                  "updated_at": "2025-03-19T12:04:57.546535+01:00",
+                  "created_at": "2025-03-20T15:37:11.014871+01:00",
+                  "updated_at": "2025-03-20T15:37:11.607397+01:00",
                   "ipaddress": "2001:db8::14",
                   "host": 15
                 }
@@ -24867,8 +24867,8 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2025-03-19T12:04:56.406778+01:00",
-                  "updated_at": "2025-03-19T12:04:56.406784+01:00",
+                  "created_at": "2025-03-20T15:37:10.614037+01:00",
+                  "updated_at": "2025-03-20T15:37:10.614043+01:00",
                   "txt": "v=spf1 -all",
                   "host": 15
                 }
@@ -24877,20 +24877,20 @@
               "srvs": [],
               "naptrs": [],
               "sshfps": [],
-              "groups": [],
+              "hostgroups": [],
               "roles": [],
               "hinfo": {
                 "host": 15,
-                "created_at": "2025-03-19T12:04:58.050990+01:00",
-                "updated_at": "2025-03-19T12:04:58.050999+01:00",
+                "created_at": "2025-03-20T15:37:12.023925+01:00",
+                "updated_at": "2025-03-20T15:37:12.023932+01:00",
                 "cpu": "x86",
                 "os": "Win"
               },
               "loc": null,
               "bacnetid": null,
               "communities": [],
-              "created_at": "2025-03-19T12:04:56.405048+01:00",
-              "updated_at": "2025-03-19T12:04:56.405055+01:00",
+              "created_at": "2025-03-20T15:37:10.612175+01:00",
+              "updated_at": "2025-03-20T15:37:10.612182+01:00",
               "name": "baz.example.org",
               "contact": "",
               "ttl": null,
@@ -24924,15 +24924,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2025-03-19T12:04:54.729053+01:00",
-              "updated_at": "2025-03-19T12:04:56.526058+01:00",
+              "created_at": "2025-03-20T15:37:09.046400+01:00",
+              "updated_at": "2025-03-20T15:37:10.736314+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2025-03-19T12:04:56.923203+01:00",
-              "updated_at": "2025-03-19T12:04:57.546535+01:00",
+              "created_at": "2025-03-20T15:37:11.014871+01:00",
+              "updated_at": "2025-03-20T15:37:11.607397+01:00",
               "ipaddress": "2001:db8::14",
               "host": 15
             }
@@ -24941,8 +24941,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:56.406778+01:00",
-              "updated_at": "2025-03-19T12:04:56.406784+01:00",
+              "created_at": "2025-03-20T15:37:10.614037+01:00",
+              "updated_at": "2025-03-20T15:37:10.614043+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
@@ -24951,20 +24951,20 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": {
             "host": 15,
-            "created_at": "2025-03-19T12:04:58.050990+01:00",
-            "updated_at": "2025-03-19T12:04:58.050999+01:00",
+            "created_at": "2025-03-20T15:37:12.023925+01:00",
+            "updated_at": "2025-03-20T15:37:12.023932+01:00",
             "cpu": "x86",
             "os": "Win"
           },
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:56.405048+01:00",
-          "updated_at": "2025-03-19T12:04:56.405055+01:00",
+          "created_at": "2025-03-20T15:37:10.612175+01:00",
+          "updated_at": "2025-03-20T15:37:10.612182+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -24979,8 +24979,8 @@
         "status": 200,
         "response": {
           "host": 15,
-          "created_at": "2025-03-19T12:04:58.050990+01:00",
-          "updated_at": "2025-03-19T12:04:58.050999+01:00",
+          "created_at": "2025-03-20T15:37:12.023925+01:00",
+          "updated_at": "2025-03-20T15:37:12.023932+01:00",
           "cpu": "x86",
           "os": "Win"
         }
@@ -25009,15 +25009,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2025-03-19T12:04:54.729053+01:00",
-              "updated_at": "2025-03-19T12:04:56.526058+01:00",
+              "created_at": "2025-03-20T15:37:09.046400+01:00",
+              "updated_at": "2025-03-20T15:37:10.736314+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2025-03-19T12:04:56.923203+01:00",
-              "updated_at": "2025-03-19T12:04:57.546535+01:00",
+              "created_at": "2025-03-20T15:37:11.014871+01:00",
+              "updated_at": "2025-03-20T15:37:11.607397+01:00",
               "ipaddress": "2001:db8::14",
               "host": 15
             }
@@ -25026,8 +25026,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:56.406778+01:00",
-              "updated_at": "2025-03-19T12:04:56.406784+01:00",
+              "created_at": "2025-03-20T15:37:10.614037+01:00",
+              "updated_at": "2025-03-20T15:37:10.614043+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
@@ -25036,20 +25036,20 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": {
             "host": 15,
-            "created_at": "2025-03-19T12:04:58.050990+01:00",
-            "updated_at": "2025-03-19T12:04:58.050999+01:00",
+            "created_at": "2025-03-20T15:37:12.023925+01:00",
+            "updated_at": "2025-03-20T15:37:12.023932+01:00",
             "cpu": "x86",
             "os": "Win"
           },
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:56.405048+01:00",
-          "updated_at": "2025-03-19T12:04:56.405055+01:00",
+          "created_at": "2025-03-20T15:37:10.612175+01:00",
+          "updated_at": "2025-03-20T15:37:10.612182+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -25064,8 +25064,8 @@
         "status": 200,
         "response": {
           "host": 15,
-          "created_at": "2025-03-19T12:04:58.050990+01:00",
-          "updated_at": "2025-03-19T12:04:58.050999+01:00",
+          "created_at": "2025-03-20T15:37:12.023925+01:00",
+          "updated_at": "2025-03-20T15:37:12.023932+01:00",
           "cpu": "x86",
           "os": "Win"
         }
@@ -25100,15 +25100,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2025-03-19T12:04:54.729053+01:00",
-              "updated_at": "2025-03-19T12:04:56.526058+01:00",
+              "created_at": "2025-03-20T15:37:09.046400+01:00",
+              "updated_at": "2025-03-20T15:37:10.736314+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2025-03-19T12:04:56.923203+01:00",
-              "updated_at": "2025-03-19T12:04:57.546535+01:00",
+              "created_at": "2025-03-20T15:37:11.014871+01:00",
+              "updated_at": "2025-03-20T15:37:11.607397+01:00",
               "ipaddress": "2001:db8::14",
               "host": 15
             }
@@ -25117,8 +25117,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:56.406778+01:00",
-              "updated_at": "2025-03-19T12:04:56.406784+01:00",
+              "created_at": "2025-03-20T15:37:10.614037+01:00",
+              "updated_at": "2025-03-20T15:37:10.614043+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
@@ -25127,14 +25127,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:56.405048+01:00",
-          "updated_at": "2025-03-19T12:04:56.405055+01:00",
+          "created_at": "2025-03-20T15:37:10.612175+01:00",
+          "updated_at": "2025-03-20T15:37:10.612182+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -25152,8 +25152,8 @@
         "status": 201,
         "response": {
           "host": 15,
-          "created_at": "2025-03-19T12:04:58.273533+01:00",
-          "updated_at": "2025-03-19T12:04:58.273540+01:00",
+          "created_at": "2025-03-20T15:37:12.241809+01:00",
+          "updated_at": "2025-03-20T15:37:12.241819+01:00",
           "loc": "52 22 23.000 N 4 53 32.000 E -2.00m 0.00m 10000m 10m"
         }
       },
@@ -25171,15 +25171,15 @@
               "ipaddresses": [
                 {
                   "macaddress": "11:22:33:aa:bb:cc",
-                  "created_at": "2025-03-19T12:04:54.729053+01:00",
-                  "updated_at": "2025-03-19T12:04:56.526058+01:00",
+                  "created_at": "2025-03-20T15:37:09.046400+01:00",
+                  "updated_at": "2025-03-20T15:37:10.736314+01:00",
                   "ipaddress": "10.0.0.10",
                   "host": 15
                 },
                 {
                   "macaddress": "11:22:33:44:55:67",
-                  "created_at": "2025-03-19T12:04:56.923203+01:00",
-                  "updated_at": "2025-03-19T12:04:57.546535+01:00",
+                  "created_at": "2025-03-20T15:37:11.014871+01:00",
+                  "updated_at": "2025-03-20T15:37:11.607397+01:00",
                   "ipaddress": "2001:db8::14",
                   "host": 15
                 }
@@ -25188,8 +25188,8 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2025-03-19T12:04:56.406778+01:00",
-                  "updated_at": "2025-03-19T12:04:56.406784+01:00",
+                  "created_at": "2025-03-20T15:37:10.614037+01:00",
+                  "updated_at": "2025-03-20T15:37:10.614043+01:00",
                   "txt": "v=spf1 -all",
                   "host": 15
                 }
@@ -25198,19 +25198,19 @@
               "srvs": [],
               "naptrs": [],
               "sshfps": [],
-              "groups": [],
+              "hostgroups": [],
               "roles": [],
               "hinfo": null,
               "loc": {
                 "host": 15,
-                "created_at": "2025-03-19T12:04:58.273533+01:00",
-                "updated_at": "2025-03-19T12:04:58.273540+01:00",
+                "created_at": "2025-03-20T15:37:12.241809+01:00",
+                "updated_at": "2025-03-20T15:37:12.241819+01:00",
                 "loc": "52 22 23.000 N 4 53 32.000 E -2.00m 0.00m 10000m 10m"
               },
               "bacnetid": null,
               "communities": [],
-              "created_at": "2025-03-19T12:04:56.405048+01:00",
-              "updated_at": "2025-03-19T12:04:56.405055+01:00",
+              "created_at": "2025-03-20T15:37:10.612175+01:00",
+              "updated_at": "2025-03-20T15:37:10.612182+01:00",
               "name": "baz.example.org",
               "contact": "",
               "ttl": null,
@@ -25244,15 +25244,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2025-03-19T12:04:54.729053+01:00",
-              "updated_at": "2025-03-19T12:04:56.526058+01:00",
+              "created_at": "2025-03-20T15:37:09.046400+01:00",
+              "updated_at": "2025-03-20T15:37:10.736314+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2025-03-19T12:04:56.923203+01:00",
-              "updated_at": "2025-03-19T12:04:57.546535+01:00",
+              "created_at": "2025-03-20T15:37:11.014871+01:00",
+              "updated_at": "2025-03-20T15:37:11.607397+01:00",
               "ipaddress": "2001:db8::14",
               "host": 15
             }
@@ -25261,8 +25261,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:56.406778+01:00",
-              "updated_at": "2025-03-19T12:04:56.406784+01:00",
+              "created_at": "2025-03-20T15:37:10.614037+01:00",
+              "updated_at": "2025-03-20T15:37:10.614043+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
@@ -25271,19 +25271,19 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": {
             "host": 15,
-            "created_at": "2025-03-19T12:04:58.273533+01:00",
-            "updated_at": "2025-03-19T12:04:58.273540+01:00",
+            "created_at": "2025-03-20T15:37:12.241809+01:00",
+            "updated_at": "2025-03-20T15:37:12.241819+01:00",
             "loc": "52 22 23.000 N 4 53 32.000 E -2.00m 0.00m 10000m 10m"
           },
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:56.405048+01:00",
-          "updated_at": "2025-03-19T12:04:56.405055+01:00",
+          "created_at": "2025-03-20T15:37:10.612175+01:00",
+          "updated_at": "2025-03-20T15:37:10.612182+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -25315,15 +25315,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2025-03-19T12:04:54.729053+01:00",
-              "updated_at": "2025-03-19T12:04:56.526058+01:00",
+              "created_at": "2025-03-20T15:37:09.046400+01:00",
+              "updated_at": "2025-03-20T15:37:10.736314+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2025-03-19T12:04:56.923203+01:00",
-              "updated_at": "2025-03-19T12:04:57.546535+01:00",
+              "created_at": "2025-03-20T15:37:11.014871+01:00",
+              "updated_at": "2025-03-20T15:37:11.607397+01:00",
               "ipaddress": "2001:db8::14",
               "host": 15
             }
@@ -25332,8 +25332,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:56.406778+01:00",
-              "updated_at": "2025-03-19T12:04:56.406784+01:00",
+              "created_at": "2025-03-20T15:37:10.614037+01:00",
+              "updated_at": "2025-03-20T15:37:10.614043+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
@@ -25342,19 +25342,19 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": {
             "host": 15,
-            "created_at": "2025-03-19T12:04:58.273533+01:00",
-            "updated_at": "2025-03-19T12:04:58.273540+01:00",
+            "created_at": "2025-03-20T15:37:12.241809+01:00",
+            "updated_at": "2025-03-20T15:37:12.241819+01:00",
             "loc": "52 22 23.000 N 4 53 32.000 E -2.00m 0.00m 10000m 10m"
           },
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:56.405048+01:00",
-          "updated_at": "2025-03-19T12:04:56.405055+01:00",
+          "created_at": "2025-03-20T15:37:10.612175+01:00",
+          "updated_at": "2025-03-20T15:37:10.612182+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -25392,15 +25392,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2025-03-19T12:04:54.729053+01:00",
-              "updated_at": "2025-03-19T12:04:56.526058+01:00",
+              "created_at": "2025-03-20T15:37:09.046400+01:00",
+              "updated_at": "2025-03-20T15:37:10.736314+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2025-03-19T12:04:56.923203+01:00",
-              "updated_at": "2025-03-19T12:04:57.546535+01:00",
+              "created_at": "2025-03-20T15:37:11.014871+01:00",
+              "updated_at": "2025-03-20T15:37:11.607397+01:00",
               "ipaddress": "2001:db8::14",
               "host": 15
             }
@@ -25409,8 +25409,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:56.406778+01:00",
-              "updated_at": "2025-03-19T12:04:56.406784+01:00",
+              "created_at": "2025-03-20T15:37:10.614037+01:00",
+              "updated_at": "2025-03-20T15:37:10.614043+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
@@ -25419,14 +25419,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:56.405048+01:00",
-          "updated_at": "2025-03-19T12:04:56.405055+01:00",
+          "created_at": "2025-03-20T15:37:10.612175+01:00",
+          "updated_at": "2025-03-20T15:37:10.612182+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -25444,8 +25444,8 @@
         },
         "status": 201,
         "response": {
-          "created_at": "2025-03-19T12:04:58.495484+01:00",
-          "updated_at": "2025-03-19T12:04:58.495490+01:00",
+          "created_at": "2025-03-20T15:37:12.406028+01:00",
+          "updated_at": "2025-03-20T15:37:12.406033+01:00",
           "priority": 10,
           "mx": "mail.example.org",
           "host": 15
@@ -25476,15 +25476,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2025-03-19T12:04:54.729053+01:00",
-              "updated_at": "2025-03-19T12:04:56.526058+01:00",
+              "created_at": "2025-03-20T15:37:09.046400+01:00",
+              "updated_at": "2025-03-20T15:37:10.736314+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2025-03-19T12:04:56.923203+01:00",
-              "updated_at": "2025-03-19T12:04:57.546535+01:00",
+              "created_at": "2025-03-20T15:37:11.014871+01:00",
+              "updated_at": "2025-03-20T15:37:11.607397+01:00",
               "ipaddress": "2001:db8::14",
               "host": 15
             }
@@ -25492,8 +25492,8 @@
           "cnames": [],
           "mxs": [
             {
-              "created_at": "2025-03-19T12:04:58.495484+01:00",
-              "updated_at": "2025-03-19T12:04:58.495490+01:00",
+              "created_at": "2025-03-20T15:37:12.406028+01:00",
+              "updated_at": "2025-03-20T15:37:12.406033+01:00",
               "priority": 10,
               "mx": "mail.example.org",
               "host": 15
@@ -25501,8 +25501,8 @@
           ],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:56.406778+01:00",
-              "updated_at": "2025-03-19T12:04:56.406784+01:00",
+              "created_at": "2025-03-20T15:37:10.614037+01:00",
+              "updated_at": "2025-03-20T15:37:10.614043+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
@@ -25511,14 +25511,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:56.405048+01:00",
-          "updated_at": "2025-03-19T12:04:56.405055+01:00",
+          "created_at": "2025-03-20T15:37:10.612175+01:00",
+          "updated_at": "2025-03-20T15:37:10.612182+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -25550,15 +25550,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2025-03-19T12:04:54.729053+01:00",
-              "updated_at": "2025-03-19T12:04:56.526058+01:00",
+              "created_at": "2025-03-20T15:37:09.046400+01:00",
+              "updated_at": "2025-03-20T15:37:10.736314+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2025-03-19T12:04:56.923203+01:00",
-              "updated_at": "2025-03-19T12:04:57.546535+01:00",
+              "created_at": "2025-03-20T15:37:11.014871+01:00",
+              "updated_at": "2025-03-20T15:37:11.607397+01:00",
               "ipaddress": "2001:db8::14",
               "host": 15
             }
@@ -25566,8 +25566,8 @@
           "cnames": [],
           "mxs": [
             {
-              "created_at": "2025-03-19T12:04:58.495484+01:00",
-              "updated_at": "2025-03-19T12:04:58.495490+01:00",
+              "created_at": "2025-03-20T15:37:12.406028+01:00",
+              "updated_at": "2025-03-20T15:37:12.406033+01:00",
               "priority": 10,
               "mx": "mail.example.org",
               "host": 15
@@ -25575,8 +25575,8 @@
           ],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:56.406778+01:00",
-              "updated_at": "2025-03-19T12:04:56.406784+01:00",
+              "created_at": "2025-03-20T15:37:10.614037+01:00",
+              "updated_at": "2025-03-20T15:37:10.614043+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
@@ -25585,14 +25585,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:56.405048+01:00",
-          "updated_at": "2025-03-19T12:04:56.405055+01:00",
+          "created_at": "2025-03-20T15:37:10.612175+01:00",
+          "updated_at": "2025-03-20T15:37:10.612182+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -25609,8 +25609,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.460376+01:00",
-          "updated_at": "2025-03-19T12:04:54.460385+01:00",
+          "created_at": "2025-03-20T15:37:08.831678+01:00",
+          "updated_at": "2025-03-20T15:37:08.831687+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -25630,8 +25630,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.536879+01:00",
-          "updated_at": "2025-03-19T12:04:54.536908+01:00",
+          "created_at": "2025-03-20T15:37:08.893540+01:00",
+          "updated_at": "2025-03-20T15:37:08.893549+01:00",
           "network": "2001:db8::/64",
           "description": "dolor sit amet",
           "vlan": null,
@@ -25666,15 +25666,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2025-03-19T12:04:54.729053+01:00",
-              "updated_at": "2025-03-19T12:04:56.526058+01:00",
+              "created_at": "2025-03-20T15:37:09.046400+01:00",
+              "updated_at": "2025-03-20T15:37:10.736314+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2025-03-19T12:04:56.923203+01:00",
-              "updated_at": "2025-03-19T12:04:57.546535+01:00",
+              "created_at": "2025-03-20T15:37:11.014871+01:00",
+              "updated_at": "2025-03-20T15:37:11.607397+01:00",
               "ipaddress": "2001:db8::14",
               "host": 15
             }
@@ -25682,8 +25682,8 @@
           "cnames": [],
           "mxs": [
             {
-              "created_at": "2025-03-19T12:04:58.495484+01:00",
-              "updated_at": "2025-03-19T12:04:58.495490+01:00",
+              "created_at": "2025-03-20T15:37:12.406028+01:00",
+              "updated_at": "2025-03-20T15:37:12.406033+01:00",
               "priority": 10,
               "mx": "mail.example.org",
               "host": 15
@@ -25691,8 +25691,8 @@
           ],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:56.406778+01:00",
-              "updated_at": "2025-03-19T12:04:56.406784+01:00",
+              "created_at": "2025-03-20T15:37:10.614037+01:00",
+              "updated_at": "2025-03-20T15:37:10.614043+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
@@ -25701,14 +25701,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:56.405048+01:00",
-          "updated_at": "2025-03-19T12:04:56.405055+01:00",
+          "created_at": "2025-03-20T15:37:10.612175+01:00",
+          "updated_at": "2025-03-20T15:37:10.612182+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -25727,8 +25727,8 @@
           "previous": null,
           "results": [
             {
-              "created_at": "2025-03-19T12:04:58.495484+01:00",
-              "updated_at": "2025-03-19T12:04:58.495490+01:00",
+              "created_at": "2025-03-20T15:37:12.406028+01:00",
+              "updated_at": "2025-03-20T15:37:12.406033+01:00",
               "priority": 10,
               "mx": "mail.example.org",
               "host": 15
@@ -25766,15 +25766,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2025-03-19T12:04:54.729053+01:00",
-              "updated_at": "2025-03-19T12:04:56.526058+01:00",
+              "created_at": "2025-03-20T15:37:09.046400+01:00",
+              "updated_at": "2025-03-20T15:37:10.736314+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2025-03-19T12:04:56.923203+01:00",
-              "updated_at": "2025-03-19T12:04:57.546535+01:00",
+              "created_at": "2025-03-20T15:37:11.014871+01:00",
+              "updated_at": "2025-03-20T15:37:11.607397+01:00",
               "ipaddress": "2001:db8::14",
               "host": 15
             }
@@ -25783,8 +25783,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:56.406778+01:00",
-              "updated_at": "2025-03-19T12:04:56.406784+01:00",
+              "created_at": "2025-03-20T15:37:10.614037+01:00",
+              "updated_at": "2025-03-20T15:37:10.614043+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
@@ -25793,14 +25793,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:56.405048+01:00",
-          "updated_at": "2025-03-19T12:04:56.405055+01:00",
+          "created_at": "2025-03-20T15:37:10.612175+01:00",
+          "updated_at": "2025-03-20T15:37:10.612182+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -25834,8 +25834,8 @@
         },
         "status": 201,
         "response": {
-          "created_at": "2025-03-19T12:04:58.730998+01:00",
-          "updated_at": "2025-03-19T12:04:58.731005+01:00",
+          "created_at": "2025-03-20T15:37:12.661030+01:00",
+          "updated_at": "2025-03-20T15:37:12.661036+01:00",
           "preference": 16384,
           "order": 3,
           "flag": "u",
@@ -25870,15 +25870,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2025-03-19T12:04:54.729053+01:00",
-              "updated_at": "2025-03-19T12:04:56.526058+01:00",
+              "created_at": "2025-03-20T15:37:09.046400+01:00",
+              "updated_at": "2025-03-20T15:37:10.736314+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2025-03-19T12:04:56.923203+01:00",
-              "updated_at": "2025-03-19T12:04:57.546535+01:00",
+              "created_at": "2025-03-20T15:37:11.014871+01:00",
+              "updated_at": "2025-03-20T15:37:11.607397+01:00",
               "ipaddress": "2001:db8::14",
               "host": 15
             }
@@ -25887,8 +25887,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:56.406778+01:00",
-              "updated_at": "2025-03-19T12:04:56.406784+01:00",
+              "created_at": "2025-03-20T15:37:10.614037+01:00",
+              "updated_at": "2025-03-20T15:37:10.614043+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
@@ -25897,8 +25897,8 @@
           "srvs": [],
           "naptrs": [
             {
-              "created_at": "2025-03-19T12:04:58.730998+01:00",
-              "updated_at": "2025-03-19T12:04:58.731005+01:00",
+              "created_at": "2025-03-20T15:37:12.661030+01:00",
+              "updated_at": "2025-03-20T15:37:12.661036+01:00",
               "preference": 16384,
               "order": 3,
               "flag": "u",
@@ -25909,14 +25909,14 @@
             }
           ],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:56.405048+01:00",
-          "updated_at": "2025-03-19T12:04:56.405055+01:00",
+          "created_at": "2025-03-20T15:37:10.612175+01:00",
+          "updated_at": "2025-03-20T15:37:10.612182+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -25948,15 +25948,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2025-03-19T12:04:54.729053+01:00",
-              "updated_at": "2025-03-19T12:04:56.526058+01:00",
+              "created_at": "2025-03-20T15:37:09.046400+01:00",
+              "updated_at": "2025-03-20T15:37:10.736314+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2025-03-19T12:04:56.923203+01:00",
-              "updated_at": "2025-03-19T12:04:57.546535+01:00",
+              "created_at": "2025-03-20T15:37:11.014871+01:00",
+              "updated_at": "2025-03-20T15:37:11.607397+01:00",
               "ipaddress": "2001:db8::14",
               "host": 15
             }
@@ -25965,8 +25965,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:56.406778+01:00",
-              "updated_at": "2025-03-19T12:04:56.406784+01:00",
+              "created_at": "2025-03-20T15:37:10.614037+01:00",
+              "updated_at": "2025-03-20T15:37:10.614043+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
@@ -25975,8 +25975,8 @@
           "srvs": [],
           "naptrs": [
             {
-              "created_at": "2025-03-19T12:04:58.730998+01:00",
-              "updated_at": "2025-03-19T12:04:58.731005+01:00",
+              "created_at": "2025-03-20T15:37:12.661030+01:00",
+              "updated_at": "2025-03-20T15:37:12.661036+01:00",
               "preference": 16384,
               "order": 3,
               "flag": "u",
@@ -25987,14 +25987,14 @@
             }
           ],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:56.405048+01:00",
-          "updated_at": "2025-03-19T12:04:56.405055+01:00",
+          "created_at": "2025-03-20T15:37:10.612175+01:00",
+          "updated_at": "2025-03-20T15:37:10.612182+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -26032,15 +26032,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2025-03-19T12:04:54.729053+01:00",
-              "updated_at": "2025-03-19T12:04:56.526058+01:00",
+              "created_at": "2025-03-20T15:37:09.046400+01:00",
+              "updated_at": "2025-03-20T15:37:10.736314+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2025-03-19T12:04:56.923203+01:00",
-              "updated_at": "2025-03-19T12:04:57.546535+01:00",
+              "created_at": "2025-03-20T15:37:11.014871+01:00",
+              "updated_at": "2025-03-20T15:37:11.607397+01:00",
               "ipaddress": "2001:db8::14",
               "host": 15
             }
@@ -26049,8 +26049,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:56.406778+01:00",
-              "updated_at": "2025-03-19T12:04:56.406784+01:00",
+              "created_at": "2025-03-20T15:37:10.614037+01:00",
+              "updated_at": "2025-03-20T15:37:10.614043+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
@@ -26059,14 +26059,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:56.405048+01:00",
-          "updated_at": "2025-03-19T12:04:56.405055+01:00",
+          "created_at": "2025-03-20T15:37:10.612175+01:00",
+          "updated_at": "2025-03-20T15:37:10.612182+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -26095,8 +26095,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.460376+01:00",
-          "updated_at": "2025-03-19T12:04:54.460385+01:00",
+          "created_at": "2025-03-20T15:37:08.831678+01:00",
+          "updated_at": "2025-03-20T15:37:08.831687+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -26129,8 +26129,8 @@
         },
         "status": 201,
         "response": {
-          "created_at": "2025-03-19T12:04:58.922958+01:00",
-          "updated_at": "2025-03-19T12:04:58.922966+01:00",
+          "created_at": "2025-03-20T15:37:12.906259+01:00",
+          "updated_at": "2025-03-20T15:37:12.906267+01:00",
           "ipaddress": "10.0.0.20",
           "host": 15
         }
@@ -26176,15 +26176,15 @@
               "ipaddresses": [
                 {
                   "macaddress": "11:22:33:aa:bb:cc",
-                  "created_at": "2025-03-19T12:04:54.729053+01:00",
-                  "updated_at": "2025-03-19T12:04:56.526058+01:00",
+                  "created_at": "2025-03-20T15:37:09.046400+01:00",
+                  "updated_at": "2025-03-20T15:37:10.736314+01:00",
                   "ipaddress": "10.0.0.10",
                   "host": 15
                 },
                 {
                   "macaddress": "11:22:33:44:55:67",
-                  "created_at": "2025-03-19T12:04:56.923203+01:00",
-                  "updated_at": "2025-03-19T12:04:57.546535+01:00",
+                  "created_at": "2025-03-20T15:37:11.014871+01:00",
+                  "updated_at": "2025-03-20T15:37:11.607397+01:00",
                   "ipaddress": "2001:db8::14",
                   "host": 15
                 }
@@ -26193,16 +26193,16 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2025-03-19T12:04:56.406778+01:00",
-                  "updated_at": "2025-03-19T12:04:56.406784+01:00",
+                  "created_at": "2025-03-20T15:37:10.614037+01:00",
+                  "updated_at": "2025-03-20T15:37:10.614043+01:00",
                   "txt": "v=spf1 -all",
                   "host": 15
                 }
               ],
               "ptr_overrides": [
                 {
-                  "created_at": "2025-03-19T12:04:58.922958+01:00",
-                  "updated_at": "2025-03-19T12:04:58.922966+01:00",
+                  "created_at": "2025-03-20T15:37:12.906259+01:00",
+                  "updated_at": "2025-03-20T15:37:12.906267+01:00",
                   "ipaddress": "10.0.0.20",
                   "host": 15
                 }
@@ -26210,14 +26210,14 @@
               "srvs": [],
               "naptrs": [],
               "sshfps": [],
-              "groups": [],
+              "hostgroups": [],
               "roles": [],
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
               "communities": [],
-              "created_at": "2025-03-19T12:04:56.405048+01:00",
-              "updated_at": "2025-03-19T12:04:56.405055+01:00",
+              "created_at": "2025-03-20T15:37:10.612175+01:00",
+              "updated_at": "2025-03-20T15:37:10.612182+01:00",
               "name": "baz.example.org",
               "contact": "",
               "ttl": null,
@@ -26241,15 +26241,15 @@
               "ipaddresses": [
                 {
                   "macaddress": "11:22:33:aa:bb:cc",
-                  "created_at": "2025-03-19T12:04:54.729053+01:00",
-                  "updated_at": "2025-03-19T12:04:56.526058+01:00",
+                  "created_at": "2025-03-20T15:37:09.046400+01:00",
+                  "updated_at": "2025-03-20T15:37:10.736314+01:00",
                   "ipaddress": "10.0.0.10",
                   "host": 15
                 },
                 {
                   "macaddress": "11:22:33:44:55:67",
-                  "created_at": "2025-03-19T12:04:56.923203+01:00",
-                  "updated_at": "2025-03-19T12:04:57.546535+01:00",
+                  "created_at": "2025-03-20T15:37:11.014871+01:00",
+                  "updated_at": "2025-03-20T15:37:11.607397+01:00",
                   "ipaddress": "2001:db8::14",
                   "host": 15
                 }
@@ -26258,16 +26258,16 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2025-03-19T12:04:56.406778+01:00",
-                  "updated_at": "2025-03-19T12:04:56.406784+01:00",
+                  "created_at": "2025-03-20T15:37:10.614037+01:00",
+                  "updated_at": "2025-03-20T15:37:10.614043+01:00",
                   "txt": "v=spf1 -all",
                   "host": 15
                 }
               ],
               "ptr_overrides": [
                 {
-                  "created_at": "2025-03-19T12:04:58.922958+01:00",
-                  "updated_at": "2025-03-19T12:04:58.922966+01:00",
+                  "created_at": "2025-03-20T15:37:12.906259+01:00",
+                  "updated_at": "2025-03-20T15:37:12.906267+01:00",
                   "ipaddress": "10.0.0.20",
                   "host": 15
                 }
@@ -26275,14 +26275,14 @@
               "srvs": [],
               "naptrs": [],
               "sshfps": [],
-              "groups": [],
+              "hostgroups": [],
               "roles": [],
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
               "communities": [],
-              "created_at": "2025-03-19T12:04:56.405048+01:00",
-              "updated_at": "2025-03-19T12:04:56.405055+01:00",
+              "created_at": "2025-03-20T15:37:10.612175+01:00",
+              "updated_at": "2025-03-20T15:37:10.612182+01:00",
               "name": "baz.example.org",
               "contact": "",
               "ttl": null,
@@ -26310,8 +26310,8 @@
       "Contact:      ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Wed Mar 19 12:04:59 2025",
-      "Updated:      Wed Mar 19 12:04:59 2025"
+      "Created:      Thu Mar 20 15:37:13 2025",
+      "Updated:      Thu Mar 20 15:37:13 2025"
     ],
     "api_requests": [
       {
@@ -26341,18 +26341,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2025-03-19T12:04:41.191611+01:00",
-                "updated_at": "2025-03-19T12:04:41.191623+01:00",
+                "created_at": "2025-03-20T15:36:56.518688+01:00",
+                "updated_at": "2025-03-20T15:36:56.518700+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-03-19T12:04:40.912310+01:00",
-            "updated_at": "2025-03-19T12:04:58.921960+01:00",
+            "created_at": "2025-03-20T15:36:56.108293+01:00",
+            "updated_at": "2025-03-20T15:37:12.904516+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
+            "serialno_updated_at": "2025-03-20T15:36:56.561109+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -26381,8 +26381,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:59.135486+01:00",
-              "updated_at": "2025-03-19T12:04:59.135492+01:00",
+              "created_at": "2025-03-20T15:37:13.367518+01:00",
+              "updated_at": "2025-03-20T15:37:13.367524+01:00",
               "txt": "v=spf1 -all",
               "host": 16
             }
@@ -26391,14 +26391,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:59.133822+01:00",
-          "updated_at": "2025-03-19T12:04:59.133829+01:00",
+          "created_at": "2025-03-20T15:37:13.365750+01:00",
+          "updated_at": "2025-03-20T15:37:13.365756+01:00",
           "name": "clover.example.org",
           "contact": "",
           "ttl": null,
@@ -26430,15 +26430,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2025-03-19T12:04:54.729053+01:00",
-              "updated_at": "2025-03-19T12:04:56.526058+01:00",
+              "created_at": "2025-03-20T15:37:09.046400+01:00",
+              "updated_at": "2025-03-20T15:37:10.736314+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2025-03-19T12:04:56.923203+01:00",
-              "updated_at": "2025-03-19T12:04:57.546535+01:00",
+              "created_at": "2025-03-20T15:37:11.014871+01:00",
+              "updated_at": "2025-03-20T15:37:11.607397+01:00",
               "ipaddress": "2001:db8::14",
               "host": 15
             }
@@ -26447,16 +26447,16 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:56.406778+01:00",
-              "updated_at": "2025-03-19T12:04:56.406784+01:00",
+              "created_at": "2025-03-20T15:37:10.614037+01:00",
+              "updated_at": "2025-03-20T15:37:10.614043+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
           ],
           "ptr_overrides": [
             {
-              "created_at": "2025-03-19T12:04:58.922958+01:00",
-              "updated_at": "2025-03-19T12:04:58.922966+01:00",
+              "created_at": "2025-03-20T15:37:12.906259+01:00",
+              "updated_at": "2025-03-20T15:37:12.906267+01:00",
               "ipaddress": "10.0.0.20",
               "host": 15
             }
@@ -26464,14 +26464,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:56.405048+01:00",
-          "updated_at": "2025-03-19T12:04:56.405055+01:00",
+          "created_at": "2025-03-20T15:37:10.612175+01:00",
+          "updated_at": "2025-03-20T15:37:10.612182+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -26490,8 +26490,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:59.135486+01:00",
-              "updated_at": "2025-03-19T12:04:59.135492+01:00",
+              "created_at": "2025-03-20T15:37:13.367518+01:00",
+              "updated_at": "2025-03-20T15:37:13.367524+01:00",
               "txt": "v=spf1 -all",
               "host": 16
             }
@@ -26500,14 +26500,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:59.133822+01:00",
-          "updated_at": "2025-03-19T12:04:59.133829+01:00",
+          "created_at": "2025-03-20T15:37:13.365750+01:00",
+          "updated_at": "2025-03-20T15:37:13.365756+01:00",
           "name": "clover.example.org",
           "contact": "",
           "ttl": null,
@@ -26529,8 +26529,8 @@
         "data": {},
         "status": 200,
         "response": {
-          "created_at": "2025-03-19T12:04:58.922958+01:00",
-          "updated_at": "2025-03-19T12:04:59.254954+01:00",
+          "created_at": "2025-03-20T15:37:12.906259+01:00",
+          "updated_at": "2025-03-20T15:37:13.506160+01:00",
           "ipaddress": "10.0.0.20",
           "host": 16
         }
@@ -26561,16 +26561,16 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:59.135486+01:00",
-              "updated_at": "2025-03-19T12:04:59.135492+01:00",
+              "created_at": "2025-03-20T15:37:13.367518+01:00",
+              "updated_at": "2025-03-20T15:37:13.367524+01:00",
               "txt": "v=spf1 -all",
               "host": 16
             }
           ],
           "ptr_overrides": [
             {
-              "created_at": "2025-03-19T12:04:58.922958+01:00",
-              "updated_at": "2025-03-19T12:04:59.254954+01:00",
+              "created_at": "2025-03-20T15:37:12.906259+01:00",
+              "updated_at": "2025-03-20T15:37:13.506160+01:00",
               "ipaddress": "10.0.0.20",
               "host": 16
             }
@@ -26578,14 +26578,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:59.133822+01:00",
-          "updated_at": "2025-03-19T12:04:59.133829+01:00",
+          "created_at": "2025-03-20T15:37:13.365750+01:00",
+          "updated_at": "2025-03-20T15:37:13.365756+01:00",
           "name": "clover.example.org",
           "contact": "",
           "ttl": null,
@@ -26635,15 +26635,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2025-03-19T12:04:54.729053+01:00",
-              "updated_at": "2025-03-19T12:04:56.526058+01:00",
+              "created_at": "2025-03-20T15:37:09.046400+01:00",
+              "updated_at": "2025-03-20T15:37:10.736314+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2025-03-19T12:04:56.923203+01:00",
-              "updated_at": "2025-03-19T12:04:57.546535+01:00",
+              "created_at": "2025-03-20T15:37:11.014871+01:00",
+              "updated_at": "2025-03-20T15:37:11.607397+01:00",
               "ipaddress": "2001:db8::14",
               "host": 15
             }
@@ -26652,8 +26652,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:56.406778+01:00",
-              "updated_at": "2025-03-19T12:04:56.406784+01:00",
+              "created_at": "2025-03-20T15:37:10.614037+01:00",
+              "updated_at": "2025-03-20T15:37:10.614043+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
@@ -26662,14 +26662,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:56.405048+01:00",
-          "updated_at": "2025-03-19T12:04:56.405055+01:00",
+          "created_at": "2025-03-20T15:37:10.612175+01:00",
+          "updated_at": "2025-03-20T15:37:10.612182+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -26686,18 +26686,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2025-03-19T12:04:41.191611+01:00",
-                "updated_at": "2025-03-19T12:04:41.191623+01:00",
+                "created_at": "2025-03-20T15:36:56.518688+01:00",
+                "updated_at": "2025-03-20T15:36:56.518700+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-03-19T12:04:40.912310+01:00",
-            "updated_at": "2025-03-19T12:04:59.377812+01:00",
+            "created_at": "2025-03-20T15:36:56.108293+01:00",
+            "updated_at": "2025-03-20T15:37:13.617335+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
+            "serialno_updated_at": "2025-03-20T15:36:56.561109+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -26716,18 +26716,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2025-03-19T12:04:41.191611+01:00",
-                "updated_at": "2025-03-19T12:04:41.191623+01:00",
+                "created_at": "2025-03-20T15:36:56.518688+01:00",
+                "updated_at": "2025-03-20T15:36:56.518700+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-03-19T12:04:40.912310+01:00",
-            "updated_at": "2025-03-19T12:04:59.377812+01:00",
+            "created_at": "2025-03-20T15:36:56.108293+01:00",
+            "updated_at": "2025-03-20T15:37:13.617335+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
+            "serialno_updated_at": "2025-03-20T15:36:56.561109+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -26790,15 +26790,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2025-03-19T12:04:54.729053+01:00",
-              "updated_at": "2025-03-19T12:04:56.526058+01:00",
+              "created_at": "2025-03-20T15:37:09.046400+01:00",
+              "updated_at": "2025-03-20T15:37:10.736314+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2025-03-19T12:04:56.923203+01:00",
-              "updated_at": "2025-03-19T12:04:57.546535+01:00",
+              "created_at": "2025-03-20T15:37:11.014871+01:00",
+              "updated_at": "2025-03-20T15:37:11.607397+01:00",
               "ipaddress": "2001:db8::14",
               "host": 15
             }
@@ -26807,8 +26807,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:56.406778+01:00",
-              "updated_at": "2025-03-19T12:04:56.406784+01:00",
+              "created_at": "2025-03-20T15:37:10.614037+01:00",
+              "updated_at": "2025-03-20T15:37:10.614043+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
@@ -26817,14 +26817,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:56.405048+01:00",
-          "updated_at": "2025-03-19T12:04:56.405055+01:00",
+          "created_at": "2025-03-20T15:37:10.612175+01:00",
+          "updated_at": "2025-03-20T15:37:10.612182+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -26841,18 +26841,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2025-03-19T12:04:41.191611+01:00",
-                "updated_at": "2025-03-19T12:04:41.191623+01:00",
+                "created_at": "2025-03-20T15:36:56.518688+01:00",
+                "updated_at": "2025-03-20T15:36:56.518700+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-03-19T12:04:40.912310+01:00",
-            "updated_at": "2025-03-19T12:04:59.377812+01:00",
+            "created_at": "2025-03-20T15:36:56.108293+01:00",
+            "updated_at": "2025-03-20T15:37:13.617335+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
+            "serialno_updated_at": "2025-03-20T15:36:56.561109+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -26871,18 +26871,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2025-03-19T12:04:41.191611+01:00",
-                "updated_at": "2025-03-19T12:04:41.191623+01:00",
+                "created_at": "2025-03-20T15:36:56.518688+01:00",
+                "updated_at": "2025-03-20T15:36:56.518700+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-03-19T12:04:40.912310+01:00",
-            "updated_at": "2025-03-19T12:04:59.377812+01:00",
+            "created_at": "2025-03-20T15:36:56.108293+01:00",
+            "updated_at": "2025-03-20T15:37:13.617335+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
+            "serialno_updated_at": "2025-03-20T15:36:56.561109+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -26916,8 +26916,8 @@
         },
         "status": 201,
         "response": {
-          "created_at": "2025-03-19T12:04:59.609581+01:00",
-          "updated_at": "2025-03-19T12:04:59.609589+01:00",
+          "created_at": "2025-03-20T15:37:13.841859+01:00",
+          "updated_at": "2025-03-20T15:37:13.841864+01:00",
           "name": "_sip._tcp.example.org",
           "priority": 10,
           "weight": 5,
@@ -26953,8 +26953,8 @@
           "previous": null,
           "results": [
             {
-              "created_at": "2025-03-19T12:04:59.609581+01:00",
-              "updated_at": "2025-03-19T12:04:59.609589+01:00",
+              "created_at": "2025-03-20T15:37:13.841859+01:00",
+              "updated_at": "2025-03-20T15:37:13.841864+01:00",
               "name": "_sip._tcp.example.org",
               "priority": 10,
               "weight": 5,
@@ -26980,15 +26980,15 @@
               "ipaddresses": [
                 {
                   "macaddress": "11:22:33:aa:bb:cc",
-                  "created_at": "2025-03-19T12:04:54.729053+01:00",
-                  "updated_at": "2025-03-19T12:04:56.526058+01:00",
+                  "created_at": "2025-03-20T15:37:09.046400+01:00",
+                  "updated_at": "2025-03-20T15:37:10.736314+01:00",
                   "ipaddress": "10.0.0.10",
                   "host": 15
                 },
                 {
                   "macaddress": "11:22:33:44:55:67",
-                  "created_at": "2025-03-19T12:04:56.923203+01:00",
-                  "updated_at": "2025-03-19T12:04:57.546535+01:00",
+                  "created_at": "2025-03-20T15:37:11.014871+01:00",
+                  "updated_at": "2025-03-20T15:37:11.607397+01:00",
                   "ipaddress": "2001:db8::14",
                   "host": 15
                 }
@@ -26997,8 +26997,8 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2025-03-19T12:04:56.406778+01:00",
-                  "updated_at": "2025-03-19T12:04:56.406784+01:00",
+                  "created_at": "2025-03-20T15:37:10.614037+01:00",
+                  "updated_at": "2025-03-20T15:37:10.614043+01:00",
                   "txt": "v=spf1 -all",
                   "host": 15
                 }
@@ -27006,8 +27006,8 @@
               "ptr_overrides": [],
               "srvs": [
                 {
-                  "created_at": "2025-03-19T12:04:59.609581+01:00",
-                  "updated_at": "2025-03-19T12:04:59.609589+01:00",
+                  "created_at": "2025-03-20T15:37:13.841859+01:00",
+                  "updated_at": "2025-03-20T15:37:13.841864+01:00",
                   "name": "_sip._tcp.example.org",
                   "priority": 10,
                   "weight": 5,
@@ -27019,14 +27019,14 @@
               ],
               "naptrs": [],
               "sshfps": [],
-              "groups": [],
+              "hostgroups": [],
               "roles": [],
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
               "communities": [],
-              "created_at": "2025-03-19T12:04:56.405048+01:00",
-              "updated_at": "2025-03-19T12:04:56.405055+01:00",
+              "created_at": "2025-03-20T15:37:10.612175+01:00",
+              "updated_at": "2025-03-20T15:37:10.612182+01:00",
               "name": "baz.example.org",
               "contact": "",
               "ttl": null,
@@ -27060,15 +27060,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2025-03-19T12:04:54.729053+01:00",
-              "updated_at": "2025-03-19T12:04:56.526058+01:00",
+              "created_at": "2025-03-20T15:37:09.046400+01:00",
+              "updated_at": "2025-03-20T15:37:10.736314+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2025-03-19T12:04:56.923203+01:00",
-              "updated_at": "2025-03-19T12:04:57.546535+01:00",
+              "created_at": "2025-03-20T15:37:11.014871+01:00",
+              "updated_at": "2025-03-20T15:37:11.607397+01:00",
               "ipaddress": "2001:db8::14",
               "host": 15
             }
@@ -27077,8 +27077,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:56.406778+01:00",
-              "updated_at": "2025-03-19T12:04:56.406784+01:00",
+              "created_at": "2025-03-20T15:37:10.614037+01:00",
+              "updated_at": "2025-03-20T15:37:10.614043+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
@@ -27086,8 +27086,8 @@
           "ptr_overrides": [],
           "srvs": [
             {
-              "created_at": "2025-03-19T12:04:59.609581+01:00",
-              "updated_at": "2025-03-19T12:04:59.609589+01:00",
+              "created_at": "2025-03-20T15:37:13.841859+01:00",
+              "updated_at": "2025-03-20T15:37:13.841864+01:00",
               "name": "_sip._tcp.example.org",
               "priority": 10,
               "weight": 5,
@@ -27099,14 +27099,14 @@
           ],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:56.405048+01:00",
-          "updated_at": "2025-03-19T12:04:56.405055+01:00",
+          "created_at": "2025-03-20T15:37:10.612175+01:00",
+          "updated_at": "2025-03-20T15:37:10.612182+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -27125,8 +27125,8 @@
           "previous": null,
           "results": [
             {
-              "created_at": "2025-03-19T12:04:59.609581+01:00",
-              "updated_at": "2025-03-19T12:04:59.609589+01:00",
+              "created_at": "2025-03-20T15:37:13.841859+01:00",
+              "updated_at": "2025-03-20T15:37:13.841864+01:00",
               "name": "_sip._tcp.example.org",
               "priority": 10,
               "weight": 5,
@@ -27168,15 +27168,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:55.834780+01:00",
-              "updated_at": "2025-03-19T12:04:56.162642+01:00",
+              "created_at": "2025-03-20T15:37:10.067731+01:00",
+              "updated_at": "2025-03-20T15:37:10.369742+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2025-03-19T12:04:55.985109+01:00",
-              "updated_at": "2025-03-19T12:04:56.289216+01:00",
+              "created_at": "2025-03-20T15:37:10.204852+01:00",
+              "updated_at": "2025-03-20T15:37:10.496985+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
@@ -27185,8 +27185,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:54.711653+01:00",
-              "updated_at": "2025-03-19T12:04:54.711661+01:00",
+              "created_at": "2025-03-20T15:37:09.032853+01:00",
+              "updated_at": "2025-03-20T15:37:09.032859+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -27195,14 +27195,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.709550+01:00",
-          "updated_at": "2025-03-19T12:04:55.670092+01:00",
+          "created_at": "2025-03-20T15:37:09.031195+01:00",
+          "updated_at": "2025-03-20T15:37:09.906360+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -27233,8 +27233,8 @@
         },
         "status": 201,
         "response": {
-          "created_at": "2025-03-19T12:04:59.845247+01:00",
-          "updated_at": "2025-03-19T12:04:59.845254+01:00",
+          "created_at": "2025-03-20T15:37:14.077311+01:00",
+          "updated_at": "2025-03-20T15:37:14.077318+01:00",
           "ttl": null,
           "algorithm": 1,
           "hash_type": 1,
@@ -27267,15 +27267,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:55.834780+01:00",
-              "updated_at": "2025-03-19T12:04:56.162642+01:00",
+              "created_at": "2025-03-20T15:37:10.067731+01:00",
+              "updated_at": "2025-03-20T15:37:10.369742+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2025-03-19T12:04:55.985109+01:00",
-              "updated_at": "2025-03-19T12:04:56.289216+01:00",
+              "created_at": "2025-03-20T15:37:10.204852+01:00",
+              "updated_at": "2025-03-20T15:37:10.496985+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
@@ -27284,8 +27284,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:54.711653+01:00",
-              "updated_at": "2025-03-19T12:04:54.711661+01:00",
+              "created_at": "2025-03-20T15:37:09.032853+01:00",
+              "updated_at": "2025-03-20T15:37:09.032859+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -27295,8 +27295,8 @@
           "naptrs": [],
           "sshfps": [
             {
-              "created_at": "2025-03-19T12:04:59.845247+01:00",
-              "updated_at": "2025-03-19T12:04:59.845254+01:00",
+              "created_at": "2025-03-20T15:37:14.077311+01:00",
+              "updated_at": "2025-03-20T15:37:14.077318+01:00",
               "ttl": null,
               "algorithm": 1,
               "hash_type": 1,
@@ -27304,14 +27304,14 @@
               "host": 14
             }
           ],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.709550+01:00",
-          "updated_at": "2025-03-19T12:04:55.670092+01:00",
+          "created_at": "2025-03-20T15:37:09.031195+01:00",
+          "updated_at": "2025-03-20T15:37:09.906360+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -27343,15 +27343,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:55.834780+01:00",
-              "updated_at": "2025-03-19T12:04:56.162642+01:00",
+              "created_at": "2025-03-20T15:37:10.067731+01:00",
+              "updated_at": "2025-03-20T15:37:10.369742+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2025-03-19T12:04:55.985109+01:00",
-              "updated_at": "2025-03-19T12:04:56.289216+01:00",
+              "created_at": "2025-03-20T15:37:10.204852+01:00",
+              "updated_at": "2025-03-20T15:37:10.496985+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
@@ -27360,8 +27360,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:54.711653+01:00",
-              "updated_at": "2025-03-19T12:04:54.711661+01:00",
+              "created_at": "2025-03-20T15:37:09.032853+01:00",
+              "updated_at": "2025-03-20T15:37:09.032859+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -27371,8 +27371,8 @@
           "naptrs": [],
           "sshfps": [
             {
-              "created_at": "2025-03-19T12:04:59.845247+01:00",
-              "updated_at": "2025-03-19T12:04:59.845254+01:00",
+              "created_at": "2025-03-20T15:37:14.077311+01:00",
+              "updated_at": "2025-03-20T15:37:14.077318+01:00",
               "ttl": null,
               "algorithm": 1,
               "hash_type": 1,
@@ -27380,14 +27380,14 @@
               "host": 14
             }
           ],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.709550+01:00",
-          "updated_at": "2025-03-19T12:04:55.670092+01:00",
+          "created_at": "2025-03-20T15:37:09.031195+01:00",
+          "updated_at": "2025-03-20T15:37:09.906360+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -27431,15 +27431,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:55.834780+01:00",
-              "updated_at": "2025-03-19T12:04:56.162642+01:00",
+              "created_at": "2025-03-20T15:37:10.067731+01:00",
+              "updated_at": "2025-03-20T15:37:10.369742+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2025-03-19T12:04:55.985109+01:00",
-              "updated_at": "2025-03-19T12:04:56.289216+01:00",
+              "created_at": "2025-03-20T15:37:10.204852+01:00",
+              "updated_at": "2025-03-20T15:37:10.496985+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
@@ -27448,8 +27448,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:54.711653+01:00",
-              "updated_at": "2025-03-19T12:04:54.711661+01:00",
+              "created_at": "2025-03-20T15:37:09.032853+01:00",
+              "updated_at": "2025-03-20T15:37:09.032859+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -27459,8 +27459,8 @@
           "naptrs": [],
           "sshfps": [
             {
-              "created_at": "2025-03-19T12:04:59.845247+01:00",
-              "updated_at": "2025-03-19T12:04:59.845254+01:00",
+              "created_at": "2025-03-20T15:37:14.077311+01:00",
+              "updated_at": "2025-03-20T15:37:14.077318+01:00",
               "ttl": null,
               "algorithm": 1,
               "hash_type": 1,
@@ -27468,14 +27468,14 @@
               "host": 14
             }
           ],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.709550+01:00",
-          "updated_at": "2025-03-19T12:04:55.670092+01:00",
+          "created_at": "2025-03-20T15:37:09.031195+01:00",
+          "updated_at": "2025-03-20T15:37:09.906360+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -27513,15 +27513,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:55.834780+01:00",
-              "updated_at": "2025-03-19T12:04:56.162642+01:00",
+              "created_at": "2025-03-20T15:37:10.067731+01:00",
+              "updated_at": "2025-03-20T15:37:10.369742+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2025-03-19T12:04:55.985109+01:00",
-              "updated_at": "2025-03-19T12:04:56.289216+01:00",
+              "created_at": "2025-03-20T15:37:10.204852+01:00",
+              "updated_at": "2025-03-20T15:37:10.496985+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
@@ -27530,8 +27530,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:54.711653+01:00",
-              "updated_at": "2025-03-19T12:04:54.711661+01:00",
+              "created_at": "2025-03-20T15:37:09.032853+01:00",
+              "updated_at": "2025-03-20T15:37:09.032859+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -27540,14 +27540,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.709550+01:00",
-          "updated_at": "2025-03-19T12:04:55.670092+01:00",
+          "created_at": "2025-03-20T15:37:09.031195+01:00",
+          "updated_at": "2025-03-20T15:37:09.906360+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -27577,15 +27577,15 @@
               "ipaddresses": [
                 {
                   "macaddress": "",
-                  "created_at": "2025-03-19T12:04:55.834780+01:00",
-                  "updated_at": "2025-03-19T12:04:56.162642+01:00",
+                  "created_at": "2025-03-20T15:37:10.067731+01:00",
+                  "updated_at": "2025-03-20T15:37:10.369742+01:00",
                   "ipaddress": "10.0.0.14",
                   "host": 14
                 },
                 {
                   "macaddress": "11:22:33:44:55:66",
-                  "created_at": "2025-03-19T12:04:55.985109+01:00",
-                  "updated_at": "2025-03-19T12:04:56.289216+01:00",
+                  "created_at": "2025-03-20T15:37:10.204852+01:00",
+                  "updated_at": "2025-03-20T15:37:10.496985+01:00",
                   "ipaddress": "10.0.0.15",
                   "host": 14
                 }
@@ -27594,8 +27594,8 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2025-03-19T12:04:54.711653+01:00",
-                  "updated_at": "2025-03-19T12:04:54.711661+01:00",
+                  "created_at": "2025-03-20T15:37:09.032853+01:00",
+                  "updated_at": "2025-03-20T15:37:09.032859+01:00",
                   "txt": "v=spf1 -all",
                   "host": 14
                 }
@@ -27604,14 +27604,14 @@
               "srvs": [],
               "naptrs": [],
               "sshfps": [],
-              "groups": [],
+              "hostgroups": [],
               "roles": [],
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
               "communities": [],
-              "created_at": "2025-03-19T12:04:54.709550+01:00",
-              "updated_at": "2025-03-19T12:05:00.112462+01:00",
+              "created_at": "2025-03-20T15:37:09.031195+01:00",
+              "updated_at": "2025-03-20T15:37:14.370319+01:00",
               "name": "bar.example.org",
               "contact": "me@example.org",
               "ttl": 3600,
@@ -27645,15 +27645,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:55.834780+01:00",
-              "updated_at": "2025-03-19T12:04:56.162642+01:00",
+              "created_at": "2025-03-20T15:37:10.067731+01:00",
+              "updated_at": "2025-03-20T15:37:10.369742+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2025-03-19T12:04:55.985109+01:00",
-              "updated_at": "2025-03-19T12:04:56.289216+01:00",
+              "created_at": "2025-03-20T15:37:10.204852+01:00",
+              "updated_at": "2025-03-20T15:37:10.496985+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
@@ -27662,8 +27662,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:54.711653+01:00",
-              "updated_at": "2025-03-19T12:04:54.711661+01:00",
+              "created_at": "2025-03-20T15:37:09.032853+01:00",
+              "updated_at": "2025-03-20T15:37:09.032859+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -27672,14 +27672,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.709550+01:00",
-          "updated_at": "2025-03-19T12:05:00.112462+01:00",
+          "created_at": "2025-03-20T15:37:09.031195+01:00",
+          "updated_at": "2025-03-20T15:37:14.370319+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": 3600,
@@ -27711,15 +27711,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:55.834780+01:00",
-              "updated_at": "2025-03-19T12:04:56.162642+01:00",
+              "created_at": "2025-03-20T15:37:10.067731+01:00",
+              "updated_at": "2025-03-20T15:37:10.369742+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2025-03-19T12:04:55.985109+01:00",
-              "updated_at": "2025-03-19T12:04:56.289216+01:00",
+              "created_at": "2025-03-20T15:37:10.204852+01:00",
+              "updated_at": "2025-03-20T15:37:10.496985+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
@@ -27728,8 +27728,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:54.711653+01:00",
-              "updated_at": "2025-03-19T12:04:54.711661+01:00",
+              "created_at": "2025-03-20T15:37:09.032853+01:00",
+              "updated_at": "2025-03-20T15:37:09.032859+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -27738,14 +27738,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.709550+01:00",
-          "updated_at": "2025-03-19T12:05:00.112462+01:00",
+          "created_at": "2025-03-20T15:37:09.031195+01:00",
+          "updated_at": "2025-03-20T15:37:14.370319+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": 3600,
@@ -27775,15 +27775,15 @@
               "ipaddresses": [
                 {
                   "macaddress": "",
-                  "created_at": "2025-03-19T12:04:55.834780+01:00",
-                  "updated_at": "2025-03-19T12:04:56.162642+01:00",
+                  "created_at": "2025-03-20T15:37:10.067731+01:00",
+                  "updated_at": "2025-03-20T15:37:10.369742+01:00",
                   "ipaddress": "10.0.0.14",
                   "host": 14
                 },
                 {
                   "macaddress": "11:22:33:44:55:66",
-                  "created_at": "2025-03-19T12:04:55.985109+01:00",
-                  "updated_at": "2025-03-19T12:04:56.289216+01:00",
+                  "created_at": "2025-03-20T15:37:10.204852+01:00",
+                  "updated_at": "2025-03-20T15:37:10.496985+01:00",
                   "ipaddress": "10.0.0.15",
                   "host": 14
                 }
@@ -27792,8 +27792,8 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2025-03-19T12:04:54.711653+01:00",
-                  "updated_at": "2025-03-19T12:04:54.711661+01:00",
+                  "created_at": "2025-03-20T15:37:09.032853+01:00",
+                  "updated_at": "2025-03-20T15:37:09.032859+01:00",
                   "txt": "v=spf1 -all",
                   "host": 14
                 }
@@ -27802,14 +27802,14 @@
               "srvs": [],
               "naptrs": [],
               "sshfps": [],
-              "groups": [],
+              "hostgroups": [],
               "roles": [],
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
               "communities": [],
-              "created_at": "2025-03-19T12:04:54.709550+01:00",
-              "updated_at": "2025-03-19T12:05:00.353453+01:00",
+              "created_at": "2025-03-20T15:37:09.031195+01:00",
+              "updated_at": "2025-03-20T15:37:14.531758+01:00",
               "name": "bar.example.org",
               "contact": "me@example.org",
               "ttl": null,
@@ -27843,15 +27843,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:55.834780+01:00",
-              "updated_at": "2025-03-19T12:04:56.162642+01:00",
+              "created_at": "2025-03-20T15:37:10.067731+01:00",
+              "updated_at": "2025-03-20T15:37:10.369742+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2025-03-19T12:04:55.985109+01:00",
-              "updated_at": "2025-03-19T12:04:56.289216+01:00",
+              "created_at": "2025-03-20T15:37:10.204852+01:00",
+              "updated_at": "2025-03-20T15:37:10.496985+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
@@ -27860,8 +27860,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:54.711653+01:00",
-              "updated_at": "2025-03-19T12:04:54.711661+01:00",
+              "created_at": "2025-03-20T15:37:09.032853+01:00",
+              "updated_at": "2025-03-20T15:37:09.032859+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -27870,14 +27870,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.709550+01:00",
-          "updated_at": "2025-03-19T12:05:00.353453+01:00",
+          "created_at": "2025-03-20T15:37:09.031195+01:00",
+          "updated_at": "2025-03-20T15:37:14.531758+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -27894,8 +27894,8 @@
         },
         "status": 201,
         "response": {
-          "created_at": "2025-03-19T12:05:00.453028+01:00",
-          "updated_at": "2025-03-19T12:05:00.453035+01:00",
+          "created_at": "2025-03-20T15:37:14.633849+01:00",
+          "updated_at": "2025-03-20T15:37:14.633855+01:00",
           "txt": "Lorem ipsum dolor sit amet",
           "host": 14
         }
@@ -27925,15 +27925,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:55.834780+01:00",
-              "updated_at": "2025-03-19T12:04:56.162642+01:00",
+              "created_at": "2025-03-20T15:37:10.067731+01:00",
+              "updated_at": "2025-03-20T15:37:10.369742+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2025-03-19T12:04:55.985109+01:00",
-              "updated_at": "2025-03-19T12:04:56.289216+01:00",
+              "created_at": "2025-03-20T15:37:10.204852+01:00",
+              "updated_at": "2025-03-20T15:37:10.496985+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
@@ -27942,14 +27942,14 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:54.711653+01:00",
-              "updated_at": "2025-03-19T12:04:54.711661+01:00",
+              "created_at": "2025-03-20T15:37:09.032853+01:00",
+              "updated_at": "2025-03-20T15:37:09.032859+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             },
             {
-              "created_at": "2025-03-19T12:05:00.453028+01:00",
-              "updated_at": "2025-03-19T12:05:00.453035+01:00",
+              "created_at": "2025-03-20T15:37:14.633849+01:00",
+              "updated_at": "2025-03-20T15:37:14.633855+01:00",
               "txt": "Lorem ipsum dolor sit amet",
               "host": 14
             }
@@ -27958,14 +27958,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.709550+01:00",
-          "updated_at": "2025-03-19T12:05:00.353453+01:00",
+          "created_at": "2025-03-20T15:37:09.031195+01:00",
+          "updated_at": "2025-03-20T15:37:14.531758+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -27997,15 +27997,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:55.834780+01:00",
-              "updated_at": "2025-03-19T12:04:56.162642+01:00",
+              "created_at": "2025-03-20T15:37:10.067731+01:00",
+              "updated_at": "2025-03-20T15:37:10.369742+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2025-03-19T12:04:55.985109+01:00",
-              "updated_at": "2025-03-19T12:04:56.289216+01:00",
+              "created_at": "2025-03-20T15:37:10.204852+01:00",
+              "updated_at": "2025-03-20T15:37:10.496985+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
@@ -28014,14 +28014,14 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:54.711653+01:00",
-              "updated_at": "2025-03-19T12:04:54.711661+01:00",
+              "created_at": "2025-03-20T15:37:09.032853+01:00",
+              "updated_at": "2025-03-20T15:37:09.032859+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             },
             {
-              "created_at": "2025-03-19T12:05:00.453028+01:00",
-              "updated_at": "2025-03-19T12:05:00.453035+01:00",
+              "created_at": "2025-03-20T15:37:14.633849+01:00",
+              "updated_at": "2025-03-20T15:37:14.633855+01:00",
               "txt": "Lorem ipsum dolor sit amet",
               "host": 14
             }
@@ -28030,14 +28030,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.709550+01:00",
-          "updated_at": "2025-03-19T12:05:00.353453+01:00",
+          "created_at": "2025-03-20T15:37:09.031195+01:00",
+          "updated_at": "2025-03-20T15:37:14.531758+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -28081,15 +28081,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:55.834780+01:00",
-              "updated_at": "2025-03-19T12:04:56.162642+01:00",
+              "created_at": "2025-03-20T15:37:10.067731+01:00",
+              "updated_at": "2025-03-20T15:37:10.369742+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2025-03-19T12:04:55.985109+01:00",
-              "updated_at": "2025-03-19T12:04:56.289216+01:00",
+              "created_at": "2025-03-20T15:37:10.204852+01:00",
+              "updated_at": "2025-03-20T15:37:10.496985+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
@@ -28098,14 +28098,14 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:54.711653+01:00",
-              "updated_at": "2025-03-19T12:04:54.711661+01:00",
+              "created_at": "2025-03-20T15:37:09.032853+01:00",
+              "updated_at": "2025-03-20T15:37:09.032859+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             },
             {
-              "created_at": "2025-03-19T12:05:00.453028+01:00",
-              "updated_at": "2025-03-19T12:05:00.453035+01:00",
+              "created_at": "2025-03-20T15:37:14.633849+01:00",
+              "updated_at": "2025-03-20T15:37:14.633855+01:00",
               "txt": "Lorem ipsum dolor sit amet",
               "host": 14
             }
@@ -28114,14 +28114,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.709550+01:00",
-          "updated_at": "2025-03-19T12:05:00.353453+01:00",
+          "created_at": "2025-03-20T15:37:09.031195+01:00",
+          "updated_at": "2025-03-20T15:37:14.531758+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -28140,8 +28140,8 @@
           "previous": null,
           "results": [
             {
-              "created_at": "2025-03-19T12:05:00.453028+01:00",
-              "updated_at": "2025-03-19T12:05:00.453035+01:00",
+              "created_at": "2025-03-20T15:37:14.633849+01:00",
+              "updated_at": "2025-03-20T15:37:14.633855+01:00",
               "txt": "Lorem ipsum dolor sit amet",
               "host": 14
             }
@@ -28172,8 +28172,8 @@
       "Contact:      ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Wed Mar 19 12:05:00 2025",
-      "Updated:      Wed Mar 19 12:05:00 2025"
+      "Created:      Thu Mar 20 15:37:14 2025",
+      "Updated:      Thu Mar 20 15:37:14 2025"
     ],
     "api_requests": [
       {
@@ -28203,18 +28203,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2025-03-19T12:04:41.191611+01:00",
-                "updated_at": "2025-03-19T12:04:41.191623+01:00",
+                "created_at": "2025-03-20T15:36:56.518688+01:00",
+                "updated_at": "2025-03-20T15:36:56.518700+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-03-19T12:04:40.912310+01:00",
-            "updated_at": "2025-03-19T12:05:00.607912+01:00",
+            "created_at": "2025-03-20T15:36:56.108293+01:00",
+            "updated_at": "2025-03-20T15:37:14.772485+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
+            "serialno_updated_at": "2025-03-20T15:36:56.561109+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -28243,8 +28243,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:05:00.715226+01:00",
-              "updated_at": "2025-03-19T12:05:00.715232+01:00",
+              "created_at": "2025-03-20T15:37:14.850666+01:00",
+              "updated_at": "2025-03-20T15:37:14.850672+01:00",
               "txt": "v=spf1 -all",
               "host": 17
             }
@@ -28253,14 +28253,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:05:00.713318+01:00",
-          "updated_at": "2025-03-19T12:05:00.713326+01:00",
+          "created_at": "2025-03-20T15:37:14.849027+01:00",
+          "updated_at": "2025-03-20T15:37:14.849034+01:00",
           "name": "*.example.org",
           "contact": "",
           "ttl": null,
@@ -28294,8 +28294,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:05:00.715226+01:00",
-              "updated_at": "2025-03-19T12:05:00.715232+01:00",
+              "created_at": "2025-03-20T15:37:14.850666+01:00",
+              "updated_at": "2025-03-20T15:37:14.850672+01:00",
               "txt": "v=spf1 -all",
               "host": 17
             }
@@ -28304,14 +28304,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:05:00.713318+01:00",
-          "updated_at": "2025-03-19T12:05:00.713326+01:00",
+          "created_at": "2025-03-20T15:37:14.849027+01:00",
+          "updated_at": "2025-03-20T15:37:14.849034+01:00",
           "name": "*.example.org",
           "contact": "",
           "ttl": null,
@@ -28349,15 +28349,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:04:55.834780+01:00",
-              "updated_at": "2025-03-19T12:04:56.162642+01:00",
+              "created_at": "2025-03-20T15:37:10.067731+01:00",
+              "updated_at": "2025-03-20T15:37:10.369742+01:00",
               "ipaddress": "10.0.0.14",
               "host": 14
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2025-03-19T12:04:55.985109+01:00",
-              "updated_at": "2025-03-19T12:04:56.289216+01:00",
+              "created_at": "2025-03-20T15:37:10.204852+01:00",
+              "updated_at": "2025-03-20T15:37:10.496985+01:00",
               "ipaddress": "10.0.0.15",
               "host": 14
             }
@@ -28366,8 +28366,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:54.711653+01:00",
-              "updated_at": "2025-03-19T12:04:54.711661+01:00",
+              "created_at": "2025-03-20T15:37:09.032853+01:00",
+              "updated_at": "2025-03-20T15:37:09.032859+01:00",
               "txt": "v=spf1 -all",
               "host": 14
             }
@@ -28376,14 +28376,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.709550+01:00",
-          "updated_at": "2025-03-19T12:05:00.353453+01:00",
+          "created_at": "2025-03-20T15:37:09.031195+01:00",
+          "updated_at": "2025-03-20T15:37:14.531758+01:00",
           "name": "bar.example.org",
           "contact": "me@example.org",
           "ttl": null,
@@ -28400,8 +28400,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.460376+01:00",
-          "updated_at": "2025-03-19T12:04:54.460385+01:00",
+          "created_at": "2025-03-20T15:37:08.831678+01:00",
+          "updated_at": "2025-03-20T15:37:08.831687+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -28421,8 +28421,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.460376+01:00",
-          "updated_at": "2025-03-19T12:04:54.460385+01:00",
+          "created_at": "2025-03-20T15:37:08.831678+01:00",
+          "updated_at": "2025-03-20T15:37:08.831687+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -28463,15 +28463,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2025-03-19T12:04:54.729053+01:00",
-              "updated_at": "2025-03-19T12:04:56.526058+01:00",
+              "created_at": "2025-03-20T15:37:09.046400+01:00",
+              "updated_at": "2025-03-20T15:37:10.736314+01:00",
               "ipaddress": "10.0.0.10",
               "host": 15
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2025-03-19T12:04:56.923203+01:00",
-              "updated_at": "2025-03-19T12:04:57.546535+01:00",
+              "created_at": "2025-03-20T15:37:11.014871+01:00",
+              "updated_at": "2025-03-20T15:37:11.607397+01:00",
               "ipaddress": "2001:db8::14",
               "host": 15
             }
@@ -28480,8 +28480,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:56.406778+01:00",
-              "updated_at": "2025-03-19T12:04:56.406784+01:00",
+              "created_at": "2025-03-20T15:37:10.614037+01:00",
+              "updated_at": "2025-03-20T15:37:10.614043+01:00",
               "txt": "v=spf1 -all",
               "host": 15
             }
@@ -28490,14 +28490,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:56.405048+01:00",
-          "updated_at": "2025-03-19T12:04:56.405055+01:00",
+          "created_at": "2025-03-20T15:37:10.612175+01:00",
+          "updated_at": "2025-03-20T15:37:10.612182+01:00",
           "name": "baz.example.org",
           "contact": "",
           "ttl": null,
@@ -28514,8 +28514,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.460376+01:00",
-          "updated_at": "2025-03-19T12:04:54.460385+01:00",
+          "created_at": "2025-03-20T15:37:08.831678+01:00",
+          "updated_at": "2025-03-20T15:37:08.831687+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -28535,8 +28535,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.536879+01:00",
-          "updated_at": "2025-03-19T12:04:54.536908+01:00",
+          "created_at": "2025-03-20T15:37:08.893540+01:00",
+          "updated_at": "2025-03-20T15:37:08.893549+01:00",
           "network": "2001:db8::/64",
           "description": "dolor sit amet",
           "vlan": null,
@@ -28579,8 +28579,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:04:59.135486+01:00",
-              "updated_at": "2025-03-19T12:04:59.135492+01:00",
+              "created_at": "2025-03-20T15:37:13.367518+01:00",
+              "updated_at": "2025-03-20T15:37:13.367524+01:00",
               "txt": "v=spf1 -all",
               "host": 16
             }
@@ -28589,14 +28589,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:59.133822+01:00",
-          "updated_at": "2025-03-19T12:04:59.133829+01:00",
+          "created_at": "2025-03-20T15:37:13.365750+01:00",
+          "updated_at": "2025-03-20T15:37:13.365756+01:00",
           "name": "clover.example.org",
           "contact": "",
           "ttl": null,
@@ -28631,8 +28631,8 @@
       "              10.0.0.4   aa:bb:cc:cc:bb:aa   ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Wed Mar 19 12:05:01 2025",
-      "Updated:      Wed Mar 19 12:05:01 2025"
+      "Created:      Thu Mar 20 15:37:15 2025",
+      "Updated:      Thu Mar 20 15:37:15 2025"
     ],
     "api_requests": [
       {
@@ -28674,18 +28674,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2025-03-19T12:04:41.191611+01:00",
-                "updated_at": "2025-03-19T12:04:41.191623+01:00",
+                "created_at": "2025-03-20T15:36:56.518688+01:00",
+                "updated_at": "2025-03-20T15:36:56.518700+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-03-19T12:04:40.912310+01:00",
-            "updated_at": "2025-03-19T12:05:01.115311+01:00",
+            "created_at": "2025-03-20T15:36:56.108293+01:00",
+            "updated_at": "2025-03-20T15:37:15.235256+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
+            "serialno_updated_at": "2025-03-20T15:36:56.561109+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -28704,8 +28704,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.460376+01:00",
-          "updated_at": "2025-03-19T12:04:54.460385+01:00",
+          "created_at": "2025-03-20T15:37:08.831678+01:00",
+          "updated_at": "2025-03-20T15:37:08.831687+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -28734,8 +28734,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:05:01.250192+01:00",
-              "updated_at": "2025-03-19T12:05:01.250197+01:00",
+              "created_at": "2025-03-20T15:37:15.478403+01:00",
+              "updated_at": "2025-03-20T15:37:15.478410+01:00",
               "ipaddress": "10.0.0.4",
               "host": 18
             }
@@ -28744,8 +28744,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:05:01.236001+01:00",
-              "updated_at": "2025-03-19T12:05:01.236007+01:00",
+              "created_at": "2025-03-20T15:37:15.459787+01:00",
+              "updated_at": "2025-03-20T15:37:15.459794+01:00",
               "txt": "v=spf1 -all",
               "host": 18
             }
@@ -28754,14 +28754,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:05:01.234306+01:00",
-          "updated_at": "2025-03-19T12:05:01.234313+01:00",
+          "created_at": "2025-03-20T15:37:15.457521+01:00",
+          "updated_at": "2025-03-20T15:37:15.457529+01:00",
           "name": "directok.example.org",
           "contact": "",
           "ttl": null,
@@ -28796,8 +28796,8 @@
         "status": 200,
         "response": {
           "macaddress": "aa:bb:cc:cc:bb:aa",
-          "created_at": "2025-03-19T12:05:01.250192+01:00",
-          "updated_at": "2025-03-19T12:05:01.327374+01:00",
+          "created_at": "2025-03-20T15:37:15.478403+01:00",
+          "updated_at": "2025-03-20T15:37:15.645796+01:00",
           "ipaddress": "10.0.0.4",
           "host": 18
         }
@@ -28816,8 +28816,8 @@
               "ipaddresses": [
                 {
                   "macaddress": "aa:bb:cc:cc:bb:aa",
-                  "created_at": "2025-03-19T12:05:01.250192+01:00",
-                  "updated_at": "2025-03-19T12:05:01.327374+01:00",
+                  "created_at": "2025-03-20T15:37:15.478403+01:00",
+                  "updated_at": "2025-03-20T15:37:15.645796+01:00",
                   "ipaddress": "10.0.0.4",
                   "host": 18
                 }
@@ -28826,8 +28826,8 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2025-03-19T12:05:01.236001+01:00",
-                  "updated_at": "2025-03-19T12:05:01.236007+01:00",
+                  "created_at": "2025-03-20T15:37:15.459787+01:00",
+                  "updated_at": "2025-03-20T15:37:15.459794+01:00",
                   "txt": "v=spf1 -all",
                   "host": 18
                 }
@@ -28836,14 +28836,14 @@
               "srvs": [],
               "naptrs": [],
               "sshfps": [],
-              "groups": [],
+              "hostgroups": [],
               "roles": [],
               "hinfo": null,
               "loc": null,
               "bacnetid": null,
               "communities": [],
-              "created_at": "2025-03-19T12:05:01.234306+01:00",
-              "updated_at": "2025-03-19T12:05:01.234313+01:00",
+              "created_at": "2025-03-20T15:37:15.457521+01:00",
+              "updated_at": "2025-03-20T15:37:15.457529+01:00",
               "name": "directok.example.org",
               "contact": "",
               "ttl": null,
@@ -28862,8 +28862,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.460376+01:00",
-          "updated_at": "2025-03-19T12:04:54.460385+01:00",
+          "created_at": "2025-03-20T15:37:08.831678+01:00",
+          "updated_at": "2025-03-20T15:37:08.831687+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -28933,8 +28933,8 @@
           "ipaddresses": [
             {
               "macaddress": "aa:bb:cc:cc:bb:aa",
-              "created_at": "2025-03-19T12:05:01.250192+01:00",
-              "updated_at": "2025-03-19T12:05:01.327374+01:00",
+              "created_at": "2025-03-20T15:37:15.478403+01:00",
+              "updated_at": "2025-03-20T15:37:15.645796+01:00",
               "ipaddress": "10.0.0.4",
               "host": 18
             }
@@ -28943,8 +28943,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:05:01.236001+01:00",
-              "updated_at": "2025-03-19T12:05:01.236007+01:00",
+              "created_at": "2025-03-20T15:37:15.459787+01:00",
+              "updated_at": "2025-03-20T15:37:15.459794+01:00",
               "txt": "v=spf1 -all",
               "host": 18
             }
@@ -28953,14 +28953,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:05:01.234306+01:00",
-          "updated_at": "2025-03-19T12:05:01.234313+01:00",
+          "created_at": "2025-03-20T15:37:15.457521+01:00",
+          "updated_at": "2025-03-20T15:37:15.457529+01:00",
           "name": "directok.example.org",
           "contact": "",
           "ttl": null,
@@ -28995,8 +28995,8 @@
       "              10.0.0.10   <not set>   ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Wed Mar 19 12:05:01 2025",
-      "Updated:      Wed Mar 19 12:05:01 2025"
+      "Created:      Thu Mar 20 15:37:16 2025",
+      "Updated:      Thu Mar 20 15:37:16 2025"
     ],
     "api_requests": [
       {
@@ -29026,18 +29026,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2025-03-19T12:04:41.191611+01:00",
-                "updated_at": "2025-03-19T12:04:41.191623+01:00",
+                "created_at": "2025-03-20T15:36:56.518688+01:00",
+                "updated_at": "2025-03-20T15:36:56.518700+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-03-19T12:04:40.912310+01:00",
-            "updated_at": "2025-03-19T12:05:01.506085+01:00",
+            "created_at": "2025-03-20T15:36:56.108293+01:00",
+            "updated_at": "2025-03-20T15:37:15.973904+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
+            "serialno_updated_at": "2025-03-20T15:36:56.561109+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -29056,8 +29056,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.460376+01:00",
-          "updated_at": "2025-03-19T12:04:54.460385+01:00",
+          "created_at": "2025-03-20T15:37:08.831678+01:00",
+          "updated_at": "2025-03-20T15:37:08.831687+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -29087,8 +29087,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:05:01.616418+01:00",
-              "updated_at": "2025-03-19T12:05:01.616423+01:00",
+              "created_at": "2025-03-20T15:37:16.117363+01:00",
+              "updated_at": "2025-03-20T15:37:16.117370+01:00",
               "ipaddress": "10.0.0.10",
               "host": 19
             }
@@ -29097,8 +29097,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:05:01.602073+01:00",
-              "updated_at": "2025-03-19T12:05:01.602079+01:00",
+              "created_at": "2025-03-20T15:37:16.100910+01:00",
+              "updated_at": "2025-03-20T15:37:16.100916+01:00",
               "txt": "v=spf1 -all",
               "host": 19
             }
@@ -29107,14 +29107,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:05:01.599947+01:00",
-          "updated_at": "2025-03-19T12:05:01.599955+01:00",
+          "created_at": "2025-03-20T15:37:16.097290+01:00",
+          "updated_at": "2025-03-20T15:37:16.097314+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -29131,8 +29131,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.460376+01:00",
-          "updated_at": "2025-03-19T12:04:54.460385+01:00",
+          "created_at": "2025-03-20T15:37:08.831678+01:00",
+          "updated_at": "2025-03-20T15:37:08.831687+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -29167,8 +29167,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:05:01.616418+01:00",
-              "updated_at": "2025-03-19T12:05:01.616423+01:00",
+              "created_at": "2025-03-20T15:37:16.117363+01:00",
+              "updated_at": "2025-03-20T15:37:16.117370+01:00",
               "ipaddress": "10.0.0.10",
               "host": 19
             }
@@ -29177,8 +29177,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:05:01.602073+01:00",
-              "updated_at": "2025-03-19T12:05:01.602079+01:00",
+              "created_at": "2025-03-20T15:37:16.100910+01:00",
+              "updated_at": "2025-03-20T15:37:16.100916+01:00",
               "txt": "v=spf1 -all",
               "host": 19
             }
@@ -29187,14 +29187,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:05:01.599947+01:00",
-          "updated_at": "2025-03-19T12:05:01.599955+01:00",
+          "created_at": "2025-03-20T15:37:16.097290+01:00",
+          "updated_at": "2025-03-20T15:37:16.097314+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -29212,8 +29212,8 @@
         },
         "status": 201,
         "response": {
-          "created_at": "2025-03-19T12:05:01.716103+01:00",
-          "updated_at": "2025-03-19T12:05:01.716110+01:00",
+          "created_at": "2025-03-20T15:37:16.236535+01:00",
+          "updated_at": "2025-03-20T15:37:16.236542+01:00",
           "priority": 10,
           "mx": "mail.example.org",
           "host": 19
@@ -29243,8 +29243,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:05:01.616418+01:00",
-              "updated_at": "2025-03-19T12:05:01.616423+01:00",
+              "created_at": "2025-03-20T15:37:16.117363+01:00",
+              "updated_at": "2025-03-20T15:37:16.117370+01:00",
               "ipaddress": "10.0.0.10",
               "host": 19
             }
@@ -29252,8 +29252,8 @@
           "cnames": [],
           "mxs": [
             {
-              "created_at": "2025-03-19T12:05:01.716103+01:00",
-              "updated_at": "2025-03-19T12:05:01.716110+01:00",
+              "created_at": "2025-03-20T15:37:16.236535+01:00",
+              "updated_at": "2025-03-20T15:37:16.236542+01:00",
               "priority": 10,
               "mx": "mail.example.org",
               "host": 19
@@ -29261,8 +29261,8 @@
           ],
           "txts": [
             {
-              "created_at": "2025-03-19T12:05:01.602073+01:00",
-              "updated_at": "2025-03-19T12:05:01.602079+01:00",
+              "created_at": "2025-03-20T15:37:16.100910+01:00",
+              "updated_at": "2025-03-20T15:37:16.100916+01:00",
               "txt": "v=spf1 -all",
               "host": 19
             }
@@ -29271,14 +29271,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:05:01.599947+01:00",
-          "updated_at": "2025-03-19T12:05:01.599955+01:00",
+          "created_at": "2025-03-20T15:37:16.097290+01:00",
+          "updated_at": "2025-03-20T15:37:16.097314+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -29310,8 +29310,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:05:01.616418+01:00",
-              "updated_at": "2025-03-19T12:05:01.616423+01:00",
+              "created_at": "2025-03-20T15:37:16.117363+01:00",
+              "updated_at": "2025-03-20T15:37:16.117370+01:00",
               "ipaddress": "10.0.0.10",
               "host": 19
             }
@@ -29319,8 +29319,8 @@
           "cnames": [],
           "mxs": [
             {
-              "created_at": "2025-03-19T12:05:01.716103+01:00",
-              "updated_at": "2025-03-19T12:05:01.716110+01:00",
+              "created_at": "2025-03-20T15:37:16.236535+01:00",
+              "updated_at": "2025-03-20T15:37:16.236542+01:00",
               "priority": 10,
               "mx": "mail.example.org",
               "host": 19
@@ -29328,8 +29328,8 @@
           ],
           "txts": [
             {
-              "created_at": "2025-03-19T12:05:01.602073+01:00",
-              "updated_at": "2025-03-19T12:05:01.602079+01:00",
+              "created_at": "2025-03-20T15:37:16.100910+01:00",
+              "updated_at": "2025-03-20T15:37:16.100916+01:00",
               "txt": "v=spf1 -all",
               "host": 19
             }
@@ -29338,14 +29338,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:05:01.599947+01:00",
-          "updated_at": "2025-03-19T12:05:01.599955+01:00",
+          "created_at": "2025-03-20T15:37:16.097290+01:00",
+          "updated_at": "2025-03-20T15:37:16.097314+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -29380,8 +29380,8 @@
       "              10.0.0.10   <not set>   ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Wed Mar 19 12:05:01 2025",
-      "Updated:      Wed Mar 19 12:05:01 2025"
+      "Created:      Thu Mar 20 15:37:16 2025",
+      "Updated:      Thu Mar 20 15:37:16 2025"
     ],
     "api_requests": [
       {
@@ -29411,18 +29411,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2025-03-19T12:04:41.191611+01:00",
-                "updated_at": "2025-03-19T12:04:41.191623+01:00",
+                "created_at": "2025-03-20T15:36:56.518688+01:00",
+                "updated_at": "2025-03-20T15:36:56.518700+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-03-19T12:04:40.912310+01:00",
-            "updated_at": "2025-03-19T12:05:01.817618+01:00",
+            "created_at": "2025-03-20T15:36:56.108293+01:00",
+            "updated_at": "2025-03-20T15:37:16.427521+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
+            "serialno_updated_at": "2025-03-20T15:36:56.561109+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -29441,8 +29441,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.460376+01:00",
-          "updated_at": "2025-03-19T12:04:54.460385+01:00",
+          "created_at": "2025-03-20T15:37:08.831678+01:00",
+          "updated_at": "2025-03-20T15:37:08.831687+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -29472,8 +29472,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:05:01.923335+01:00",
-              "updated_at": "2025-03-19T12:05:01.923340+01:00",
+              "created_at": "2025-03-20T15:37:16.550411+01:00",
+              "updated_at": "2025-03-20T15:37:16.550417+01:00",
               "ipaddress": "10.0.0.10",
               "host": 20
             }
@@ -29482,8 +29482,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:05:01.909650+01:00",
-              "updated_at": "2025-03-19T12:05:01.909656+01:00",
+              "created_at": "2025-03-20T15:37:16.533508+01:00",
+              "updated_at": "2025-03-20T15:37:16.533514+01:00",
               "txt": "v=spf1 -all",
               "host": 20
             }
@@ -29492,14 +29492,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:05:01.908027+01:00",
-          "updated_at": "2025-03-19T12:05:01.908034+01:00",
+          "created_at": "2025-03-20T15:37:16.531554+01:00",
+          "updated_at": "2025-03-20T15:37:16.531564+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -29516,8 +29516,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.460376+01:00",
-          "updated_at": "2025-03-19T12:04:54.460385+01:00",
+          "created_at": "2025-03-20T15:37:08.831678+01:00",
+          "updated_at": "2025-03-20T15:37:08.831687+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -29552,8 +29552,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:05:01.923335+01:00",
-              "updated_at": "2025-03-19T12:05:01.923340+01:00",
+              "created_at": "2025-03-20T15:37:16.550411+01:00",
+              "updated_at": "2025-03-20T15:37:16.550417+01:00",
               "ipaddress": "10.0.0.10",
               "host": 20
             }
@@ -29562,8 +29562,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:05:01.909650+01:00",
-              "updated_at": "2025-03-19T12:05:01.909656+01:00",
+              "created_at": "2025-03-20T15:37:16.533508+01:00",
+              "updated_at": "2025-03-20T15:37:16.533514+01:00",
               "txt": "v=spf1 -all",
               "host": 20
             }
@@ -29572,14 +29572,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:05:01.908027+01:00",
-          "updated_at": "2025-03-19T12:05:01.908034+01:00",
+          "created_at": "2025-03-20T15:37:16.531554+01:00",
+          "updated_at": "2025-03-20T15:37:16.531564+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -29608,8 +29608,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.460376+01:00",
-          "updated_at": "2025-03-19T12:04:54.460385+01:00",
+          "created_at": "2025-03-20T15:37:08.831678+01:00",
+          "updated_at": "2025-03-20T15:37:08.831687+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -29642,8 +29642,8 @@
         },
         "status": 201,
         "response": {
-          "created_at": "2025-03-19T12:05:02.068574+01:00",
-          "updated_at": "2025-03-19T12:05:02.068581+01:00",
+          "created_at": "2025-03-20T15:37:16.698840+01:00",
+          "updated_at": "2025-03-20T15:37:16.698846+01:00",
           "ipaddress": "10.0.0.11",
           "host": 20
         }
@@ -29672,8 +29672,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:05:01.923335+01:00",
-              "updated_at": "2025-03-19T12:05:01.923340+01:00",
+              "created_at": "2025-03-20T15:37:16.550411+01:00",
+              "updated_at": "2025-03-20T15:37:16.550417+01:00",
               "ipaddress": "10.0.0.10",
               "host": 20
             }
@@ -29682,16 +29682,16 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:05:01.909650+01:00",
-              "updated_at": "2025-03-19T12:05:01.909656+01:00",
+              "created_at": "2025-03-20T15:37:16.533508+01:00",
+              "updated_at": "2025-03-20T15:37:16.533514+01:00",
               "txt": "v=spf1 -all",
               "host": 20
             }
           ],
           "ptr_overrides": [
             {
-              "created_at": "2025-03-19T12:05:02.068574+01:00",
-              "updated_at": "2025-03-19T12:05:02.068581+01:00",
+              "created_at": "2025-03-20T15:37:16.698840+01:00",
+              "updated_at": "2025-03-20T15:37:16.698846+01:00",
               "ipaddress": "10.0.0.11",
               "host": 20
             }
@@ -29699,14 +29699,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:05:01.908027+01:00",
-          "updated_at": "2025-03-19T12:05:01.908034+01:00",
+          "created_at": "2025-03-20T15:37:16.531554+01:00",
+          "updated_at": "2025-03-20T15:37:16.531564+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -29739,8 +29739,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:05:01.923335+01:00",
-              "updated_at": "2025-03-19T12:05:01.923340+01:00",
+              "created_at": "2025-03-20T15:37:16.550411+01:00",
+              "updated_at": "2025-03-20T15:37:16.550417+01:00",
               "ipaddress": "10.0.0.10",
               "host": 20
             }
@@ -29749,16 +29749,16 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:05:01.909650+01:00",
-              "updated_at": "2025-03-19T12:05:01.909656+01:00",
+              "created_at": "2025-03-20T15:37:16.533508+01:00",
+              "updated_at": "2025-03-20T15:37:16.533514+01:00",
               "txt": "v=spf1 -all",
               "host": 20
             }
           ],
           "ptr_overrides": [
             {
-              "created_at": "2025-03-19T12:05:02.068574+01:00",
-              "updated_at": "2025-03-19T12:05:02.068581+01:00",
+              "created_at": "2025-03-20T15:37:16.698840+01:00",
+              "updated_at": "2025-03-20T15:37:16.698846+01:00",
               "ipaddress": "10.0.0.11",
               "host": 20
             }
@@ -29766,14 +29766,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:05:01.908027+01:00",
-          "updated_at": "2025-03-19T12:05:01.908034+01:00",
+          "created_at": "2025-03-20T15:37:16.531554+01:00",
+          "updated_at": "2025-03-20T15:37:16.531564+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -29808,8 +29808,8 @@
       "              10.0.0.10   <not set>   ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Wed Mar 19 12:05:02 2025",
-      "Updated:      Wed Mar 19 12:05:02 2025"
+      "Created:      Thu Mar 20 15:37:16 2025",
+      "Updated:      Thu Mar 20 15:37:16 2025"
     ],
     "api_requests": [
       {
@@ -29839,18 +29839,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2025-03-19T12:04:41.191611+01:00",
-                "updated_at": "2025-03-19T12:04:41.191623+01:00",
+                "created_at": "2025-03-20T15:36:56.518688+01:00",
+                "updated_at": "2025-03-20T15:36:56.518700+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-03-19T12:04:40.912310+01:00",
-            "updated_at": "2025-03-19T12:05:02.215243+01:00",
+            "created_at": "2025-03-20T15:36:56.108293+01:00",
+            "updated_at": "2025-03-20T15:37:16.796331+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
+            "serialno_updated_at": "2025-03-20T15:36:56.561109+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -29869,8 +29869,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.460376+01:00",
-          "updated_at": "2025-03-19T12:04:54.460385+01:00",
+          "created_at": "2025-03-20T15:37:08.831678+01:00",
+          "updated_at": "2025-03-20T15:37:08.831687+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -29900,8 +29900,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:05:02.327419+01:00",
-              "updated_at": "2025-03-19T12:05:02.327425+01:00",
+              "created_at": "2025-03-20T15:37:16.899482+01:00",
+              "updated_at": "2025-03-20T15:37:16.899488+01:00",
               "ipaddress": "10.0.0.10",
               "host": 21
             }
@@ -29910,8 +29910,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:05:02.311876+01:00",
-              "updated_at": "2025-03-19T12:05:02.311882+01:00",
+              "created_at": "2025-03-20T15:37:16.886093+01:00",
+              "updated_at": "2025-03-20T15:37:16.886099+01:00",
               "txt": "v=spf1 -all",
               "host": 21
             }
@@ -29920,14 +29920,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:05:02.309948+01:00",
-          "updated_at": "2025-03-19T12:05:02.309955+01:00",
+          "created_at": "2025-03-20T15:37:16.884519+01:00",
+          "updated_at": "2025-03-20T15:37:16.884525+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -29944,8 +29944,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.460376+01:00",
-          "updated_at": "2025-03-19T12:04:54.460385+01:00",
+          "created_at": "2025-03-20T15:37:08.831678+01:00",
+          "updated_at": "2025-03-20T15:37:08.831687+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -29980,8 +29980,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:05:02.327419+01:00",
-              "updated_at": "2025-03-19T12:05:02.327425+01:00",
+              "created_at": "2025-03-20T15:37:16.899482+01:00",
+              "updated_at": "2025-03-20T15:37:16.899488+01:00",
               "ipaddress": "10.0.0.10",
               "host": 21
             }
@@ -29990,8 +29990,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:05:02.311876+01:00",
-              "updated_at": "2025-03-19T12:05:02.311882+01:00",
+              "created_at": "2025-03-20T15:37:16.886093+01:00",
+              "updated_at": "2025-03-20T15:37:16.886099+01:00",
               "txt": "v=spf1 -all",
               "host": 21
             }
@@ -30000,14 +30000,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:05:02.309948+01:00",
-          "updated_at": "2025-03-19T12:05:02.309955+01:00",
+          "created_at": "2025-03-20T15:37:16.884519+01:00",
+          "updated_at": "2025-03-20T15:37:16.884525+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -30041,8 +30041,8 @@
         },
         "status": 201,
         "response": {
-          "created_at": "2025-03-19T12:05:02.475604+01:00",
-          "updated_at": "2025-03-19T12:05:02.475612+01:00",
+          "created_at": "2025-03-20T15:37:17.027772+01:00",
+          "updated_at": "2025-03-20T15:37:17.027778+01:00",
           "preference": 16384,
           "order": 3,
           "flag": "u",
@@ -30076,8 +30076,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:05:02.327419+01:00",
-              "updated_at": "2025-03-19T12:05:02.327425+01:00",
+              "created_at": "2025-03-20T15:37:16.899482+01:00",
+              "updated_at": "2025-03-20T15:37:16.899488+01:00",
               "ipaddress": "10.0.0.10",
               "host": 21
             }
@@ -30086,8 +30086,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:05:02.311876+01:00",
-              "updated_at": "2025-03-19T12:05:02.311882+01:00",
+              "created_at": "2025-03-20T15:37:16.886093+01:00",
+              "updated_at": "2025-03-20T15:37:16.886099+01:00",
               "txt": "v=spf1 -all",
               "host": 21
             }
@@ -30096,8 +30096,8 @@
           "srvs": [],
           "naptrs": [
             {
-              "created_at": "2025-03-19T12:05:02.475604+01:00",
-              "updated_at": "2025-03-19T12:05:02.475612+01:00",
+              "created_at": "2025-03-20T15:37:17.027772+01:00",
+              "updated_at": "2025-03-20T15:37:17.027778+01:00",
               "preference": 16384,
               "order": 3,
               "flag": "u",
@@ -30108,14 +30108,14 @@
             }
           ],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:05:02.309948+01:00",
-          "updated_at": "2025-03-19T12:05:02.309955+01:00",
+          "created_at": "2025-03-20T15:37:16.884519+01:00",
+          "updated_at": "2025-03-20T15:37:16.884525+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -30148,8 +30148,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:05:02.327419+01:00",
-              "updated_at": "2025-03-19T12:05:02.327425+01:00",
+              "created_at": "2025-03-20T15:37:16.899482+01:00",
+              "updated_at": "2025-03-20T15:37:16.899488+01:00",
               "ipaddress": "10.0.0.10",
               "host": 21
             }
@@ -30158,8 +30158,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:05:02.311876+01:00",
-              "updated_at": "2025-03-19T12:05:02.311882+01:00",
+              "created_at": "2025-03-20T15:37:16.886093+01:00",
+              "updated_at": "2025-03-20T15:37:16.886099+01:00",
               "txt": "v=spf1 -all",
               "host": 21
             }
@@ -30168,8 +30168,8 @@
           "srvs": [],
           "naptrs": [
             {
-              "created_at": "2025-03-19T12:05:02.475604+01:00",
-              "updated_at": "2025-03-19T12:05:02.475612+01:00",
+              "created_at": "2025-03-20T15:37:17.027772+01:00",
+              "updated_at": "2025-03-20T15:37:17.027778+01:00",
               "preference": 16384,
               "order": 3,
               "flag": "u",
@@ -30180,14 +30180,14 @@
             }
           ],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:05:02.309948+01:00",
-          "updated_at": "2025-03-19T12:05:02.309955+01:00",
+          "created_at": "2025-03-20T15:37:16.884519+01:00",
+          "updated_at": "2025-03-20T15:37:16.884525+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -30222,8 +30222,8 @@
       "              10.0.0.10   <not set>   ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Wed Mar 19 12:05:02 2025",
-      "Updated:      Wed Mar 19 12:05:02 2025"
+      "Created:      Thu Mar 20 15:37:17 2025",
+      "Updated:      Thu Mar 20 15:37:17 2025"
     ],
     "api_requests": [
       {
@@ -30253,18 +30253,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2025-03-19T12:04:41.191611+01:00",
-                "updated_at": "2025-03-19T12:04:41.191623+01:00",
+                "created_at": "2025-03-20T15:36:56.518688+01:00",
+                "updated_at": "2025-03-20T15:36:56.518700+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-03-19T12:04:40.912310+01:00",
-            "updated_at": "2025-03-19T12:05:02.587272+01:00",
+            "created_at": "2025-03-20T15:36:56.108293+01:00",
+            "updated_at": "2025-03-20T15:37:17.127530+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
+            "serialno_updated_at": "2025-03-20T15:36:56.561109+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -30283,8 +30283,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.460376+01:00",
-          "updated_at": "2025-03-19T12:04:54.460385+01:00",
+          "created_at": "2025-03-20T15:37:08.831678+01:00",
+          "updated_at": "2025-03-20T15:37:08.831687+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -30314,8 +30314,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:05:02.704953+01:00",
-              "updated_at": "2025-03-19T12:05:02.704959+01:00",
+              "created_at": "2025-03-20T15:37:17.234686+01:00",
+              "updated_at": "2025-03-20T15:37:17.234691+01:00",
               "ipaddress": "10.0.0.10",
               "host": 22
             }
@@ -30324,8 +30324,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:05:02.689059+01:00",
-              "updated_at": "2025-03-19T12:05:02.689065+01:00",
+              "created_at": "2025-03-20T15:37:17.221204+01:00",
+              "updated_at": "2025-03-20T15:37:17.221210+01:00",
               "txt": "v=spf1 -all",
               "host": 22
             }
@@ -30334,14 +30334,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:05:02.687061+01:00",
-          "updated_at": "2025-03-19T12:05:02.687069+01:00",
+          "created_at": "2025-03-20T15:37:17.219580+01:00",
+          "updated_at": "2025-03-20T15:37:17.219587+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -30358,8 +30358,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.460376+01:00",
-          "updated_at": "2025-03-19T12:04:54.460385+01:00",
+          "created_at": "2025-03-20T15:37:08.831678+01:00",
+          "updated_at": "2025-03-20T15:37:08.831687+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -30394,8 +30394,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:05:02.704953+01:00",
-              "updated_at": "2025-03-19T12:05:02.704959+01:00",
+              "created_at": "2025-03-20T15:37:17.234686+01:00",
+              "updated_at": "2025-03-20T15:37:17.234691+01:00",
               "ipaddress": "10.0.0.10",
               "host": 22
             }
@@ -30404,8 +30404,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:05:02.689059+01:00",
-              "updated_at": "2025-03-19T12:05:02.689065+01:00",
+              "created_at": "2025-03-20T15:37:17.221204+01:00",
+              "updated_at": "2025-03-20T15:37:17.221210+01:00",
               "txt": "v=spf1 -all",
               "host": 22
             }
@@ -30414,14 +30414,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:05:02.687061+01:00",
-          "updated_at": "2025-03-19T12:05:02.687069+01:00",
+          "created_at": "2025-03-20T15:37:17.219580+01:00",
+          "updated_at": "2025-03-20T15:37:17.219587+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -30438,18 +30438,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2025-03-19T12:04:41.191611+01:00",
-                "updated_at": "2025-03-19T12:04:41.191623+01:00",
+                "created_at": "2025-03-20T15:36:56.518688+01:00",
+                "updated_at": "2025-03-20T15:36:56.518700+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-03-19T12:04:40.912310+01:00",
-            "updated_at": "2025-03-19T12:05:02.703999+01:00",
+            "created_at": "2025-03-20T15:36:56.108293+01:00",
+            "updated_at": "2025-03-20T15:37:17.234200+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
+            "serialno_updated_at": "2025-03-20T15:36:56.561109+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -30468,18 +30468,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2025-03-19T12:04:41.191611+01:00",
-                "updated_at": "2025-03-19T12:04:41.191623+01:00",
+                "created_at": "2025-03-20T15:36:56.518688+01:00",
+                "updated_at": "2025-03-20T15:36:56.518700+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-03-19T12:04:40.912310+01:00",
-            "updated_at": "2025-03-19T12:05:02.703999+01:00",
+            "created_at": "2025-03-20T15:36:56.108293+01:00",
+            "updated_at": "2025-03-20T15:37:17.234200+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
+            "serialno_updated_at": "2025-03-20T15:36:56.561109+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -30513,8 +30513,8 @@
         },
         "status": 201,
         "response": {
-          "created_at": "2025-03-19T12:05:02.876109+01:00",
-          "updated_at": "2025-03-19T12:05:02.876117+01:00",
+          "created_at": "2025-03-20T15:37:17.398710+01:00",
+          "updated_at": "2025-03-20T15:37:17.398716+01:00",
           "name": "_sip._tcp.example.org",
           "priority": 10,
           "weight": 5,
@@ -30548,8 +30548,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:05:02.704953+01:00",
-              "updated_at": "2025-03-19T12:05:02.704959+01:00",
+              "created_at": "2025-03-20T15:37:17.234686+01:00",
+              "updated_at": "2025-03-20T15:37:17.234691+01:00",
               "ipaddress": "10.0.0.10",
               "host": 22
             }
@@ -30558,8 +30558,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:05:02.689059+01:00",
-              "updated_at": "2025-03-19T12:05:02.689065+01:00",
+              "created_at": "2025-03-20T15:37:17.221204+01:00",
+              "updated_at": "2025-03-20T15:37:17.221210+01:00",
               "txt": "v=spf1 -all",
               "host": 22
             }
@@ -30567,8 +30567,8 @@
           "ptr_overrides": [],
           "srvs": [
             {
-              "created_at": "2025-03-19T12:05:02.876109+01:00",
-              "updated_at": "2025-03-19T12:05:02.876117+01:00",
+              "created_at": "2025-03-20T15:37:17.398710+01:00",
+              "updated_at": "2025-03-20T15:37:17.398716+01:00",
               "name": "_sip._tcp.example.org",
               "priority": 10,
               "weight": 5,
@@ -30580,14 +30580,14 @@
           ],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:05:02.687061+01:00",
-          "updated_at": "2025-03-19T12:05:02.687069+01:00",
+          "created_at": "2025-03-20T15:37:17.219580+01:00",
+          "updated_at": "2025-03-20T15:37:17.219587+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -30620,8 +30620,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:05:02.704953+01:00",
-              "updated_at": "2025-03-19T12:05:02.704959+01:00",
+              "created_at": "2025-03-20T15:37:17.234686+01:00",
+              "updated_at": "2025-03-20T15:37:17.234691+01:00",
               "ipaddress": "10.0.0.10",
               "host": 22
             }
@@ -30630,8 +30630,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:05:02.689059+01:00",
-              "updated_at": "2025-03-19T12:05:02.689065+01:00",
+              "created_at": "2025-03-20T15:37:17.221204+01:00",
+              "updated_at": "2025-03-20T15:37:17.221210+01:00",
               "txt": "v=spf1 -all",
               "host": 22
             }
@@ -30639,8 +30639,8 @@
           "ptr_overrides": [],
           "srvs": [
             {
-              "created_at": "2025-03-19T12:05:02.876109+01:00",
-              "updated_at": "2025-03-19T12:05:02.876117+01:00",
+              "created_at": "2025-03-20T15:37:17.398710+01:00",
+              "updated_at": "2025-03-20T15:37:17.398716+01:00",
               "name": "_sip._tcp.example.org",
               "priority": 10,
               "weight": 5,
@@ -30652,14 +30652,14 @@
           ],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:05:02.687061+01:00",
-          "updated_at": "2025-03-19T12:05:02.687069+01:00",
+          "created_at": "2025-03-20T15:37:17.219580+01:00",
+          "updated_at": "2025-03-20T15:37:17.219587+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -30694,8 +30694,8 @@
       "              10.0.0.10   <not set>   ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Wed Mar 19 12:05:03 2025",
-      "Updated:      Wed Mar 19 12:05:03 2025"
+      "Created:      Thu Mar 20 15:37:17 2025",
+      "Updated:      Thu Mar 20 15:37:17 2025"
     ],
     "api_requests": [
       {
@@ -30725,18 +30725,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2025-03-19T12:04:41.191611+01:00",
-                "updated_at": "2025-03-19T12:04:41.191623+01:00",
+                "created_at": "2025-03-20T15:36:56.518688+01:00",
+                "updated_at": "2025-03-20T15:36:56.518700+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-03-19T12:04:40.912310+01:00",
-            "updated_at": "2025-03-19T12:05:02.976839+01:00",
+            "created_at": "2025-03-20T15:36:56.108293+01:00",
+            "updated_at": "2025-03-20T15:37:17.503494+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
+            "serialno_updated_at": "2025-03-20T15:36:56.561109+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -30755,8 +30755,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.460376+01:00",
-          "updated_at": "2025-03-19T12:04:54.460385+01:00",
+          "created_at": "2025-03-20T15:37:08.831678+01:00",
+          "updated_at": "2025-03-20T15:37:08.831687+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -30786,8 +30786,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:05:03.084656+01:00",
-              "updated_at": "2025-03-19T12:05:03.084661+01:00",
+              "created_at": "2025-03-20T15:37:17.628931+01:00",
+              "updated_at": "2025-03-20T15:37:17.628937+01:00",
               "ipaddress": "10.0.0.10",
               "host": 23
             }
@@ -30796,8 +30796,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:05:03.070328+01:00",
-              "updated_at": "2025-03-19T12:05:03.070334+01:00",
+              "created_at": "2025-03-20T15:37:17.613299+01:00",
+              "updated_at": "2025-03-20T15:37:17.613305+01:00",
               "txt": "v=spf1 -all",
               "host": 23
             }
@@ -30806,14 +30806,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:05:03.068593+01:00",
-          "updated_at": "2025-03-19T12:05:03.068600+01:00",
+          "created_at": "2025-03-20T15:37:17.611590+01:00",
+          "updated_at": "2025-03-20T15:37:17.611597+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -30830,8 +30830,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.460376+01:00",
-          "updated_at": "2025-03-19T12:04:54.460385+01:00",
+          "created_at": "2025-03-20T15:37:08.831678+01:00",
+          "updated_at": "2025-03-20T15:37:08.831687+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -30866,8 +30866,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:05:03.084656+01:00",
-              "updated_at": "2025-03-19T12:05:03.084661+01:00",
+              "created_at": "2025-03-20T15:37:17.628931+01:00",
+              "updated_at": "2025-03-20T15:37:17.628937+01:00",
               "ipaddress": "10.0.0.10",
               "host": 23
             }
@@ -30876,8 +30876,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:05:03.070328+01:00",
-              "updated_at": "2025-03-19T12:05:03.070334+01:00",
+              "created_at": "2025-03-20T15:37:17.613299+01:00",
+              "updated_at": "2025-03-20T15:37:17.613305+01:00",
               "txt": "v=spf1 -all",
               "host": 23
             }
@@ -30886,14 +30886,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:05:03.068593+01:00",
-          "updated_at": "2025-03-19T12:05:03.068600+01:00",
+          "created_at": "2025-03-20T15:37:17.611590+01:00",
+          "updated_at": "2025-03-20T15:37:17.611597+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -30928,18 +30928,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2025-03-19T12:04:41.191611+01:00",
-                "updated_at": "2025-03-19T12:04:41.191623+01:00",
+                "created_at": "2025-03-20T15:36:56.518688+01:00",
+                "updated_at": "2025-03-20T15:36:56.518700+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-03-19T12:04:40.912310+01:00",
-            "updated_at": "2025-03-19T12:05:03.084178+01:00",
+            "created_at": "2025-03-20T15:36:56.108293+01:00",
+            "updated_at": "2025-03-20T15:37:17.628437+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
+            "serialno_updated_at": "2025-03-20T15:36:56.561109+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -30958,8 +30958,8 @@
         },
         "status": 201,
         "response": {
-          "created_at": "2025-03-19T12:05:03.235816+01:00",
-          "updated_at": "2025-03-19T12:05:03.235823+01:00",
+          "created_at": "2025-03-20T15:37:17.770061+01:00",
+          "updated_at": "2025-03-20T15:37:17.770067+01:00",
           "name": "fubar.example.org",
           "ttl": null,
           "zone": 1,
@@ -30975,16 +30975,16 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:05:03.084656+01:00",
-              "updated_at": "2025-03-19T12:05:03.084661+01:00",
+              "created_at": "2025-03-20T15:37:17.628931+01:00",
+              "updated_at": "2025-03-20T15:37:17.628937+01:00",
               "ipaddress": "10.0.0.10",
               "host": 23
             }
           ],
           "cnames": [
             {
-              "created_at": "2025-03-19T12:05:03.235816+01:00",
-              "updated_at": "2025-03-19T12:05:03.235823+01:00",
+              "created_at": "2025-03-20T15:37:17.770061+01:00",
+              "updated_at": "2025-03-20T15:37:17.770067+01:00",
               "name": "fubar.example.org",
               "ttl": null,
               "zone": 1,
@@ -30994,8 +30994,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:05:03.070328+01:00",
-              "updated_at": "2025-03-19T12:05:03.070334+01:00",
+              "created_at": "2025-03-20T15:37:17.613299+01:00",
+              "updated_at": "2025-03-20T15:37:17.613305+01:00",
               "txt": "v=spf1 -all",
               "host": 23
             }
@@ -31004,14 +31004,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:05:03.068593+01:00",
-          "updated_at": "2025-03-19T12:05:03.068600+01:00",
+          "created_at": "2025-03-20T15:37:17.611590+01:00",
+          "updated_at": "2025-03-20T15:37:17.611597+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -31030,8 +31030,8 @@
           "previous": null,
           "results": [
             {
-              "created_at": "2025-03-19T12:05:03.235816+01:00",
-              "updated_at": "2025-03-19T12:05:03.235823+01:00",
+              "created_at": "2025-03-20T15:37:17.770061+01:00",
+              "updated_at": "2025-03-20T15:37:17.770067+01:00",
               "name": "fubar.example.org",
               "ttl": null,
               "zone": 1,
@@ -31064,16 +31064,16 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:05:03.084656+01:00",
-              "updated_at": "2025-03-19T12:05:03.084661+01:00",
+              "created_at": "2025-03-20T15:37:17.628931+01:00",
+              "updated_at": "2025-03-20T15:37:17.628937+01:00",
               "ipaddress": "10.0.0.10",
               "host": 23
             }
           ],
           "cnames": [
             {
-              "created_at": "2025-03-19T12:05:03.235816+01:00",
-              "updated_at": "2025-03-19T12:05:03.235823+01:00",
+              "created_at": "2025-03-20T15:37:17.770061+01:00",
+              "updated_at": "2025-03-20T15:37:17.770067+01:00",
               "name": "fubar.example.org",
               "ttl": null,
               "zone": 1,
@@ -31083,8 +31083,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:05:03.070328+01:00",
-              "updated_at": "2025-03-19T12:05:03.070334+01:00",
+              "created_at": "2025-03-20T15:37:17.613299+01:00",
+              "updated_at": "2025-03-20T15:37:17.613305+01:00",
               "txt": "v=spf1 -all",
               "host": 23
             }
@@ -31093,14 +31093,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:05:03.068593+01:00",
-          "updated_at": "2025-03-19T12:05:03.068600+01:00",
+          "created_at": "2025-03-20T15:37:17.611590+01:00",
+          "updated_at": "2025-03-20T15:37:17.611597+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -31132,16 +31132,16 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:05:03.084656+01:00",
-              "updated_at": "2025-03-19T12:05:03.084661+01:00",
+              "created_at": "2025-03-20T15:37:17.628931+01:00",
+              "updated_at": "2025-03-20T15:37:17.628937+01:00",
               "ipaddress": "10.0.0.10",
               "host": 23
             }
           ],
           "cnames": [
             {
-              "created_at": "2025-03-19T12:05:03.235816+01:00",
-              "updated_at": "2025-03-19T12:05:03.235823+01:00",
+              "created_at": "2025-03-20T15:37:17.770061+01:00",
+              "updated_at": "2025-03-20T15:37:17.770067+01:00",
               "name": "fubar.example.org",
               "ttl": null,
               "zone": 1,
@@ -31151,8 +31151,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:05:03.070328+01:00",
-              "updated_at": "2025-03-19T12:05:03.070334+01:00",
+              "created_at": "2025-03-20T15:37:17.613299+01:00",
+              "updated_at": "2025-03-20T15:37:17.613305+01:00",
               "txt": "v=spf1 -all",
               "host": 23
             }
@@ -31161,14 +31161,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:05:03.068593+01:00",
-          "updated_at": "2025-03-19T12:05:03.068600+01:00",
+          "created_at": "2025-03-20T15:37:17.611590+01:00",
+          "updated_at": "2025-03-20T15:37:17.611597+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -31203,8 +31203,8 @@
       "              10.0.0.10   <not set>   ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Wed Mar 19 12:05:03 2025",
-      "Updated:      Wed Mar 19 12:05:03 2025"
+      "Created:      Thu Mar 20 15:37:18 2025",
+      "Updated:      Thu Mar 20 15:37:18 2025"
     ],
     "api_requests": [
       {
@@ -31234,18 +31234,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2025-03-19T12:04:41.191611+01:00",
-                "updated_at": "2025-03-19T12:04:41.191623+01:00",
+                "created_at": "2025-03-20T15:36:56.518688+01:00",
+                "updated_at": "2025-03-20T15:36:56.518700+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-03-19T12:04:40.912310+01:00",
-            "updated_at": "2025-03-19T12:05:03.383021+01:00",
+            "created_at": "2025-03-20T15:36:56.108293+01:00",
+            "updated_at": "2025-03-20T15:37:17.928202+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
+            "serialno_updated_at": "2025-03-20T15:36:56.561109+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -31264,8 +31264,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.460376+01:00",
-          "updated_at": "2025-03-19T12:04:54.460385+01:00",
+          "created_at": "2025-03-20T15:37:08.831678+01:00",
+          "updated_at": "2025-03-20T15:37:08.831687+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -31295,8 +31295,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:05:03.498600+01:00",
-              "updated_at": "2025-03-19T12:05:03.498607+01:00",
+              "created_at": "2025-03-20T15:37:18.038054+01:00",
+              "updated_at": "2025-03-20T15:37:18.038060+01:00",
               "ipaddress": "10.0.0.10",
               "host": 24
             }
@@ -31305,8 +31305,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:05:03.478745+01:00",
-              "updated_at": "2025-03-19T12:05:03.478753+01:00",
+              "created_at": "2025-03-20T15:37:18.023922+01:00",
+              "updated_at": "2025-03-20T15:37:18.023927+01:00",
               "txt": "v=spf1 -all",
               "host": 24
             }
@@ -31315,14 +31315,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:05:03.476320+01:00",
-          "updated_at": "2025-03-19T12:05:03.476330+01:00",
+          "created_at": "2025-03-20T15:37:18.022297+01:00",
+          "updated_at": "2025-03-20T15:37:18.022304+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -31339,8 +31339,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.460376+01:00",
-          "updated_at": "2025-03-19T12:04:54.460385+01:00",
+          "created_at": "2025-03-20T15:37:08.831678+01:00",
+          "updated_at": "2025-03-20T15:37:08.831687+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -31375,8 +31375,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:05:03.498600+01:00",
-              "updated_at": "2025-03-19T12:05:03.498607+01:00",
+              "created_at": "2025-03-20T15:37:18.038054+01:00",
+              "updated_at": "2025-03-20T15:37:18.038060+01:00",
               "ipaddress": "10.0.0.10",
               "host": 24
             }
@@ -31385,8 +31385,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-19T12:05:03.478745+01:00",
-              "updated_at": "2025-03-19T12:05:03.478753+01:00",
+              "created_at": "2025-03-20T15:37:18.023922+01:00",
+              "updated_at": "2025-03-20T15:37:18.023927+01:00",
               "txt": "v=spf1 -all",
               "host": 24
             }
@@ -31395,14 +31395,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:05:03.476320+01:00",
-          "updated_at": "2025-03-19T12:05:03.476330+01:00",
+          "created_at": "2025-03-20T15:37:18.022297+01:00",
+          "updated_at": "2025-03-20T15:37:18.022304+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -31420,8 +31420,8 @@
         },
         "status": 201,
         "response": {
-          "created_at": "2025-03-19T12:05:03.596595+01:00",
-          "updated_at": "2025-03-19T12:05:03.596602+01:00",
+          "created_at": "2025-03-20T15:37:18.127716+01:00",
+          "updated_at": "2025-03-20T15:37:18.127723+01:00",
           "priority": 10,
           "mx": "mail.example.org",
           "host": 24
@@ -31451,8 +31451,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:05:03.498600+01:00",
-              "updated_at": "2025-03-19T12:05:03.498607+01:00",
+              "created_at": "2025-03-20T15:37:18.038054+01:00",
+              "updated_at": "2025-03-20T15:37:18.038060+01:00",
               "ipaddress": "10.0.0.10",
               "host": 24
             }
@@ -31460,8 +31460,8 @@
           "cnames": [],
           "mxs": [
             {
-              "created_at": "2025-03-19T12:05:03.596595+01:00",
-              "updated_at": "2025-03-19T12:05:03.596602+01:00",
+              "created_at": "2025-03-20T15:37:18.127716+01:00",
+              "updated_at": "2025-03-20T15:37:18.127723+01:00",
               "priority": 10,
               "mx": "mail.example.org",
               "host": 24
@@ -31469,8 +31469,8 @@
           ],
           "txts": [
             {
-              "created_at": "2025-03-19T12:05:03.478745+01:00",
-              "updated_at": "2025-03-19T12:05:03.478753+01:00",
+              "created_at": "2025-03-20T15:37:18.023922+01:00",
+              "updated_at": "2025-03-20T15:37:18.023927+01:00",
               "txt": "v=spf1 -all",
               "host": 24
             }
@@ -31479,14 +31479,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:05:03.476320+01:00",
-          "updated_at": "2025-03-19T12:05:03.476330+01:00",
+          "created_at": "2025-03-20T15:37:18.022297+01:00",
+          "updated_at": "2025-03-20T15:37:18.022304+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -31515,8 +31515,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-03-19T12:04:54.460376+01:00",
-          "updated_at": "2025-03-19T12:04:54.460385+01:00",
+          "created_at": "2025-03-20T15:37:08.831678+01:00",
+          "updated_at": "2025-03-20T15:37:08.831687+01:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -31549,8 +31549,8 @@
         },
         "status": 201,
         "response": {
-          "created_at": "2025-03-19T12:05:03.695706+01:00",
-          "updated_at": "2025-03-19T12:05:03.695714+01:00",
+          "created_at": "2025-03-20T15:37:18.247526+01:00",
+          "updated_at": "2025-03-20T15:37:18.247538+01:00",
           "ipaddress": "10.0.0.11",
           "host": 24
         }
@@ -31579,8 +31579,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:05:03.498600+01:00",
-              "updated_at": "2025-03-19T12:05:03.498607+01:00",
+              "created_at": "2025-03-20T15:37:18.038054+01:00",
+              "updated_at": "2025-03-20T15:37:18.038060+01:00",
               "ipaddress": "10.0.0.10",
               "host": 24
             }
@@ -31588,8 +31588,8 @@
           "cnames": [],
           "mxs": [
             {
-              "created_at": "2025-03-19T12:05:03.596595+01:00",
-              "updated_at": "2025-03-19T12:05:03.596602+01:00",
+              "created_at": "2025-03-20T15:37:18.127716+01:00",
+              "updated_at": "2025-03-20T15:37:18.127723+01:00",
               "priority": 10,
               "mx": "mail.example.org",
               "host": 24
@@ -31597,16 +31597,16 @@
           ],
           "txts": [
             {
-              "created_at": "2025-03-19T12:05:03.478745+01:00",
-              "updated_at": "2025-03-19T12:05:03.478753+01:00",
+              "created_at": "2025-03-20T15:37:18.023922+01:00",
+              "updated_at": "2025-03-20T15:37:18.023927+01:00",
               "txt": "v=spf1 -all",
               "host": 24
             }
           ],
           "ptr_overrides": [
             {
-              "created_at": "2025-03-19T12:05:03.695706+01:00",
-              "updated_at": "2025-03-19T12:05:03.695714+01:00",
+              "created_at": "2025-03-20T15:37:18.247526+01:00",
+              "updated_at": "2025-03-20T15:37:18.247538+01:00",
               "ipaddress": "10.0.0.11",
               "host": 24
             }
@@ -31614,14 +31614,14 @@
           "srvs": [],
           "naptrs": [],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:05:03.476320+01:00",
-          "updated_at": "2025-03-19T12:05:03.476330+01:00",
+          "created_at": "2025-03-20T15:37:18.022297+01:00",
+          "updated_at": "2025-03-20T15:37:18.022304+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -31655,8 +31655,8 @@
         },
         "status": 201,
         "response": {
-          "created_at": "2025-03-19T12:05:03.765291+01:00",
-          "updated_at": "2025-03-19T12:05:03.765297+01:00",
+          "created_at": "2025-03-20T15:37:18.396860+01:00",
+          "updated_at": "2025-03-20T15:37:18.396877+01:00",
           "preference": 16384,
           "order": 3,
           "flag": "u",
@@ -31690,8 +31690,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:05:03.498600+01:00",
-              "updated_at": "2025-03-19T12:05:03.498607+01:00",
+              "created_at": "2025-03-20T15:37:18.038054+01:00",
+              "updated_at": "2025-03-20T15:37:18.038060+01:00",
               "ipaddress": "10.0.0.10",
               "host": 24
             }
@@ -31699,8 +31699,8 @@
           "cnames": [],
           "mxs": [
             {
-              "created_at": "2025-03-19T12:05:03.596595+01:00",
-              "updated_at": "2025-03-19T12:05:03.596602+01:00",
+              "created_at": "2025-03-20T15:37:18.127716+01:00",
+              "updated_at": "2025-03-20T15:37:18.127723+01:00",
               "priority": 10,
               "mx": "mail.example.org",
               "host": 24
@@ -31708,16 +31708,16 @@
           ],
           "txts": [
             {
-              "created_at": "2025-03-19T12:05:03.478745+01:00",
-              "updated_at": "2025-03-19T12:05:03.478753+01:00",
+              "created_at": "2025-03-20T15:37:18.023922+01:00",
+              "updated_at": "2025-03-20T15:37:18.023927+01:00",
               "txt": "v=spf1 -all",
               "host": 24
             }
           ],
           "ptr_overrides": [
             {
-              "created_at": "2025-03-19T12:05:03.695706+01:00",
-              "updated_at": "2025-03-19T12:05:03.695714+01:00",
+              "created_at": "2025-03-20T15:37:18.247526+01:00",
+              "updated_at": "2025-03-20T15:37:18.247538+01:00",
               "ipaddress": "10.0.0.11",
               "host": 24
             }
@@ -31725,8 +31725,8 @@
           "srvs": [],
           "naptrs": [
             {
-              "created_at": "2025-03-19T12:05:03.765291+01:00",
-              "updated_at": "2025-03-19T12:05:03.765297+01:00",
+              "created_at": "2025-03-20T15:37:18.396860+01:00",
+              "updated_at": "2025-03-20T15:37:18.396877+01:00",
               "preference": 16384,
               "order": 3,
               "flag": "u",
@@ -31737,14 +31737,14 @@
             }
           ],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:05:03.476320+01:00",
-          "updated_at": "2025-03-19T12:05:03.476330+01:00",
+          "created_at": "2025-03-20T15:37:18.022297+01:00",
+          "updated_at": "2025-03-20T15:37:18.022304+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -31761,18 +31761,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2025-03-19T12:04:41.191611+01:00",
-                "updated_at": "2025-03-19T12:04:41.191623+01:00",
+                "created_at": "2025-03-20T15:36:56.518688+01:00",
+                "updated_at": "2025-03-20T15:36:56.518700+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-03-19T12:04:40.912310+01:00",
-            "updated_at": "2025-03-19T12:05:03.764498+01:00",
+            "created_at": "2025-03-20T15:36:56.108293+01:00",
+            "updated_at": "2025-03-20T15:37:18.394802+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
+            "serialno_updated_at": "2025-03-20T15:36:56.561109+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -31791,18 +31791,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2025-03-19T12:04:41.191611+01:00",
-                "updated_at": "2025-03-19T12:04:41.191623+01:00",
+                "created_at": "2025-03-20T15:36:56.518688+01:00",
+                "updated_at": "2025-03-20T15:36:56.518700+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-03-19T12:04:40.912310+01:00",
-            "updated_at": "2025-03-19T12:05:03.764498+01:00",
+            "created_at": "2025-03-20T15:36:56.108293+01:00",
+            "updated_at": "2025-03-20T15:37:18.394802+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
+            "serialno_updated_at": "2025-03-20T15:36:56.561109+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -31836,8 +31836,8 @@
         },
         "status": 201,
         "response": {
-          "created_at": "2025-03-19T12:05:03.874575+01:00",
-          "updated_at": "2025-03-19T12:05:03.874581+01:00",
+          "created_at": "2025-03-20T15:37:18.538040+01:00",
+          "updated_at": "2025-03-20T15:37:18.538052+01:00",
           "name": "_sip._tcp.example.org",
           "priority": 10,
           "weight": 5,
@@ -31871,8 +31871,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:05:03.498600+01:00",
-              "updated_at": "2025-03-19T12:05:03.498607+01:00",
+              "created_at": "2025-03-20T15:37:18.038054+01:00",
+              "updated_at": "2025-03-20T15:37:18.038060+01:00",
               "ipaddress": "10.0.0.10",
               "host": 24
             }
@@ -31880,8 +31880,8 @@
           "cnames": [],
           "mxs": [
             {
-              "created_at": "2025-03-19T12:05:03.596595+01:00",
-              "updated_at": "2025-03-19T12:05:03.596602+01:00",
+              "created_at": "2025-03-20T15:37:18.127716+01:00",
+              "updated_at": "2025-03-20T15:37:18.127723+01:00",
               "priority": 10,
               "mx": "mail.example.org",
               "host": 24
@@ -31889,24 +31889,24 @@
           ],
           "txts": [
             {
-              "created_at": "2025-03-19T12:05:03.478745+01:00",
-              "updated_at": "2025-03-19T12:05:03.478753+01:00",
+              "created_at": "2025-03-20T15:37:18.023922+01:00",
+              "updated_at": "2025-03-20T15:37:18.023927+01:00",
               "txt": "v=spf1 -all",
               "host": 24
             }
           ],
           "ptr_overrides": [
             {
-              "created_at": "2025-03-19T12:05:03.695706+01:00",
-              "updated_at": "2025-03-19T12:05:03.695714+01:00",
+              "created_at": "2025-03-20T15:37:18.247526+01:00",
+              "updated_at": "2025-03-20T15:37:18.247538+01:00",
               "ipaddress": "10.0.0.11",
               "host": 24
             }
           ],
           "srvs": [
             {
-              "created_at": "2025-03-19T12:05:03.874575+01:00",
-              "updated_at": "2025-03-19T12:05:03.874581+01:00",
+              "created_at": "2025-03-20T15:37:18.538040+01:00",
+              "updated_at": "2025-03-20T15:37:18.538052+01:00",
               "name": "_sip._tcp.example.org",
               "priority": 10,
               "weight": 5,
@@ -31918,8 +31918,8 @@
           ],
           "naptrs": [
             {
-              "created_at": "2025-03-19T12:05:03.765291+01:00",
-              "updated_at": "2025-03-19T12:05:03.765297+01:00",
+              "created_at": "2025-03-20T15:37:18.396860+01:00",
+              "updated_at": "2025-03-20T15:37:18.396877+01:00",
               "preference": 16384,
               "order": 3,
               "flag": "u",
@@ -31930,14 +31930,14 @@
             }
           ],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:05:03.476320+01:00",
-          "updated_at": "2025-03-19T12:05:03.476330+01:00",
+          "created_at": "2025-03-20T15:37:18.022297+01:00",
+          "updated_at": "2025-03-20T15:37:18.022304+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -31972,18 +31972,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2025-03-19T12:04:41.191611+01:00",
-                "updated_at": "2025-03-19T12:04:41.191623+01:00",
+                "created_at": "2025-03-20T15:36:56.518688+01:00",
+                "updated_at": "2025-03-20T15:36:56.518700+01:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-03-19T12:04:40.912310+01:00",
-            "updated_at": "2025-03-19T12:05:03.873771+01:00",
+            "created_at": "2025-03-20T15:36:56.108293+01:00",
+            "updated_at": "2025-03-20T15:37:18.537197+01:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-03-19T12:04:41.242987+01:00",
+            "serialno_updated_at": "2025-03-20T15:36:56.561109+01:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -32002,8 +32002,8 @@
         },
         "status": 201,
         "response": {
-          "created_at": "2025-03-19T12:05:03.975069+01:00",
-          "updated_at": "2025-03-19T12:05:03.975076+01:00",
+          "created_at": "2025-03-20T15:37:18.683749+01:00",
+          "updated_at": "2025-03-20T15:37:18.683755+01:00",
           "name": "fubar.example.org",
           "ttl": null,
           "zone": 1,
@@ -32019,16 +32019,16 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:05:03.498600+01:00",
-              "updated_at": "2025-03-19T12:05:03.498607+01:00",
+              "created_at": "2025-03-20T15:37:18.038054+01:00",
+              "updated_at": "2025-03-20T15:37:18.038060+01:00",
               "ipaddress": "10.0.0.10",
               "host": 24
             }
           ],
           "cnames": [
             {
-              "created_at": "2025-03-19T12:05:03.975069+01:00",
-              "updated_at": "2025-03-19T12:05:03.975076+01:00",
+              "created_at": "2025-03-20T15:37:18.683749+01:00",
+              "updated_at": "2025-03-20T15:37:18.683755+01:00",
               "name": "fubar.example.org",
               "ttl": null,
               "zone": 1,
@@ -32037,8 +32037,8 @@
           ],
           "mxs": [
             {
-              "created_at": "2025-03-19T12:05:03.596595+01:00",
-              "updated_at": "2025-03-19T12:05:03.596602+01:00",
+              "created_at": "2025-03-20T15:37:18.127716+01:00",
+              "updated_at": "2025-03-20T15:37:18.127723+01:00",
               "priority": 10,
               "mx": "mail.example.org",
               "host": 24
@@ -32046,24 +32046,24 @@
           ],
           "txts": [
             {
-              "created_at": "2025-03-19T12:05:03.478745+01:00",
-              "updated_at": "2025-03-19T12:05:03.478753+01:00",
+              "created_at": "2025-03-20T15:37:18.023922+01:00",
+              "updated_at": "2025-03-20T15:37:18.023927+01:00",
               "txt": "v=spf1 -all",
               "host": 24
             }
           ],
           "ptr_overrides": [
             {
-              "created_at": "2025-03-19T12:05:03.695706+01:00",
-              "updated_at": "2025-03-19T12:05:03.695714+01:00",
+              "created_at": "2025-03-20T15:37:18.247526+01:00",
+              "updated_at": "2025-03-20T15:37:18.247538+01:00",
               "ipaddress": "10.0.0.11",
               "host": 24
             }
           ],
           "srvs": [
             {
-              "created_at": "2025-03-19T12:05:03.874575+01:00",
-              "updated_at": "2025-03-19T12:05:03.874581+01:00",
+              "created_at": "2025-03-20T15:37:18.538040+01:00",
+              "updated_at": "2025-03-20T15:37:18.538052+01:00",
               "name": "_sip._tcp.example.org",
               "priority": 10,
               "weight": 5,
@@ -32075,8 +32075,8 @@
           ],
           "naptrs": [
             {
-              "created_at": "2025-03-19T12:05:03.765291+01:00",
-              "updated_at": "2025-03-19T12:05:03.765297+01:00",
+              "created_at": "2025-03-20T15:37:18.396860+01:00",
+              "updated_at": "2025-03-20T15:37:18.396877+01:00",
               "preference": 16384,
               "order": 3,
               "flag": "u",
@@ -32087,14 +32087,14 @@
             }
           ],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:05:03.476320+01:00",
-          "updated_at": "2025-03-19T12:05:03.476330+01:00",
+          "created_at": "2025-03-20T15:37:18.022297+01:00",
+          "updated_at": "2025-03-20T15:37:18.022304+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -32113,8 +32113,8 @@
           "previous": null,
           "results": [
             {
-              "created_at": "2025-03-19T12:05:03.975069+01:00",
-              "updated_at": "2025-03-19T12:05:03.975076+01:00",
+              "created_at": "2025-03-20T15:37:18.683749+01:00",
+              "updated_at": "2025-03-20T15:37:18.683755+01:00",
               "name": "fubar.example.org",
               "ttl": null,
               "zone": 1,
@@ -32147,16 +32147,16 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:05:03.498600+01:00",
-              "updated_at": "2025-03-19T12:05:03.498607+01:00",
+              "created_at": "2025-03-20T15:37:18.038054+01:00",
+              "updated_at": "2025-03-20T15:37:18.038060+01:00",
               "ipaddress": "10.0.0.10",
               "host": 24
             }
           ],
           "cnames": [
             {
-              "created_at": "2025-03-19T12:05:03.975069+01:00",
-              "updated_at": "2025-03-19T12:05:03.975076+01:00",
+              "created_at": "2025-03-20T15:37:18.683749+01:00",
+              "updated_at": "2025-03-20T15:37:18.683755+01:00",
               "name": "fubar.example.org",
               "ttl": null,
               "zone": 1,
@@ -32165,8 +32165,8 @@
           ],
           "mxs": [
             {
-              "created_at": "2025-03-19T12:05:03.596595+01:00",
-              "updated_at": "2025-03-19T12:05:03.596602+01:00",
+              "created_at": "2025-03-20T15:37:18.127716+01:00",
+              "updated_at": "2025-03-20T15:37:18.127723+01:00",
               "priority": 10,
               "mx": "mail.example.org",
               "host": 24
@@ -32174,24 +32174,24 @@
           ],
           "txts": [
             {
-              "created_at": "2025-03-19T12:05:03.478745+01:00",
-              "updated_at": "2025-03-19T12:05:03.478753+01:00",
+              "created_at": "2025-03-20T15:37:18.023922+01:00",
+              "updated_at": "2025-03-20T15:37:18.023927+01:00",
               "txt": "v=spf1 -all",
               "host": 24
             }
           ],
           "ptr_overrides": [
             {
-              "created_at": "2025-03-19T12:05:03.695706+01:00",
-              "updated_at": "2025-03-19T12:05:03.695714+01:00",
+              "created_at": "2025-03-20T15:37:18.247526+01:00",
+              "updated_at": "2025-03-20T15:37:18.247538+01:00",
               "ipaddress": "10.0.0.11",
               "host": 24
             }
           ],
           "srvs": [
             {
-              "created_at": "2025-03-19T12:05:03.874575+01:00",
-              "updated_at": "2025-03-19T12:05:03.874581+01:00",
+              "created_at": "2025-03-20T15:37:18.538040+01:00",
+              "updated_at": "2025-03-20T15:37:18.538052+01:00",
               "name": "_sip._tcp.example.org",
               "priority": 10,
               "weight": 5,
@@ -32203,8 +32203,8 @@
           ],
           "naptrs": [
             {
-              "created_at": "2025-03-19T12:05:03.765291+01:00",
-              "updated_at": "2025-03-19T12:05:03.765297+01:00",
+              "created_at": "2025-03-20T15:37:18.396860+01:00",
+              "updated_at": "2025-03-20T15:37:18.396877+01:00",
               "preference": 16384,
               "order": 3,
               "flag": "u",
@@ -32215,14 +32215,14 @@
             }
           ],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:05:03.476320+01:00",
-          "updated_at": "2025-03-19T12:05:03.476330+01:00",
+          "created_at": "2025-03-20T15:37:18.022297+01:00",
+          "updated_at": "2025-03-20T15:37:18.022304+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,
@@ -32257,16 +32257,16 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-19T12:05:03.498600+01:00",
-              "updated_at": "2025-03-19T12:05:03.498607+01:00",
+              "created_at": "2025-03-20T15:37:18.038054+01:00",
+              "updated_at": "2025-03-20T15:37:18.038060+01:00",
               "ipaddress": "10.0.0.10",
               "host": 24
             }
           ],
           "cnames": [
             {
-              "created_at": "2025-03-19T12:05:03.975069+01:00",
-              "updated_at": "2025-03-19T12:05:03.975076+01:00",
+              "created_at": "2025-03-20T15:37:18.683749+01:00",
+              "updated_at": "2025-03-20T15:37:18.683755+01:00",
               "name": "fubar.example.org",
               "ttl": null,
               "zone": 1,
@@ -32275,8 +32275,8 @@
           ],
           "mxs": [
             {
-              "created_at": "2025-03-19T12:05:03.596595+01:00",
-              "updated_at": "2025-03-19T12:05:03.596602+01:00",
+              "created_at": "2025-03-20T15:37:18.127716+01:00",
+              "updated_at": "2025-03-20T15:37:18.127723+01:00",
               "priority": 10,
               "mx": "mail.example.org",
               "host": 24
@@ -32284,24 +32284,24 @@
           ],
           "txts": [
             {
-              "created_at": "2025-03-19T12:05:03.478745+01:00",
-              "updated_at": "2025-03-19T12:05:03.478753+01:00",
+              "created_at": "2025-03-20T15:37:18.023922+01:00",
+              "updated_at": "2025-03-20T15:37:18.023927+01:00",
               "txt": "v=spf1 -all",
               "host": 24
             }
           ],
           "ptr_overrides": [
             {
-              "created_at": "2025-03-19T12:05:03.695706+01:00",
-              "updated_at": "2025-03-19T12:05:03.695714+01:00",
+              "created_at": "2025-03-20T15:37:18.247526+01:00",
+              "updated_at": "2025-03-20T15:37:18.247538+01:00",
               "ipaddress": "10.0.0.11",
               "host": 24
             }
           ],
           "srvs": [
             {
-              "created_at": "2025-03-19T12:05:03.874575+01:00",
-              "updated_at": "2025-03-19T12:05:03.874581+01:00",
+              "created_at": "2025-03-20T15:37:18.538040+01:00",
+              "updated_at": "2025-03-20T15:37:18.538052+01:00",
               "name": "_sip._tcp.example.org",
               "priority": 10,
               "weight": 5,
@@ -32313,8 +32313,8 @@
           ],
           "naptrs": [
             {
-              "created_at": "2025-03-19T12:05:03.765291+01:00",
-              "updated_at": "2025-03-19T12:05:03.765297+01:00",
+              "created_at": "2025-03-20T15:37:18.396860+01:00",
+              "updated_at": "2025-03-20T15:37:18.396877+01:00",
               "preference": 16384,
               "order": 3,
               "flag": "u",
@@ -32325,14 +32325,14 @@
             }
           ],
           "sshfps": [],
-          "groups": [],
+          "hostgroups": [],
           "roles": [],
           "hinfo": null,
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-19T12:05:03.476320+01:00",
-          "updated_at": "2025-03-19T12:05:03.476330+01:00",
+          "created_at": "2025-03-20T15:37:18.022297+01:00",
+          "updated_at": "2025-03-20T15:37:18.022304+01:00",
           "name": "foo.example.org",
           "contact": "foo@example.org",
           "ttl": null,

--- a/mreg_cli/api/models.py
+++ b/mreg_cli/api/models.py
@@ -3484,38 +3484,9 @@ class Host(FrozenModelWithTimestamps, WithTTL, WithHistory, APIMixin):
 
         return False
 
-    def get_naptrs(self) -> list[NAPTR]:
-        """Return a list of NAPTR records."""
-        return NAPTR.get_list_by_field("host", self.id)
-
-    def get_srvs(self) -> list[Srv]:
-        """Return a list of SRV records."""
-        return Srv.get_list_by_field("host", self.id)
-
-    def get_sshfps(self) -> list[SSHFP]:
-        """Return a list of SSHFP records."""
-        return SSHFP.get_list_by_field("host", self.id)
-
     def get_roles(self) -> list[Role]:
         """List all roles for the host."""
         return Role.get_list_by_field("hosts", self.id)
-
-    def bacnet(self) -> BacnetID | None:
-        """Return the BacnetID for the host."""
-        if not self.bacnetid:
-            return None
-
-        return BacnetID.get_by_id(self.bacnetid)
-
-    def has_mx_with_priority(self, mx_arg: str, priority: int) -> MX | None:
-        """Check if the host has an MX record.
-
-        :param mx: The MX record to check for.
-        :param priority: The priority of the MX record.
-
-        :returns: True if the host has the MX record, False otherwise.
-        """
-        return next((mx for mx in self.mxs if mx.has_mx_with_priority(mx_arg, priority)), None)
 
     def get_hostgroups(self, traverse: bool = False) -> list[HostGroup]:
         """Return all hostgroups for the host.
@@ -3533,6 +3504,23 @@ class Host(FrozenModelWithTimestamps, WithTTL, WithHistory, APIMixin):
                 groups.extend(group.get_all_parents())
 
         return sorted(groups, key=lambda group: group.name)
+
+    def bacnet(self) -> BacnetID | None:
+        """Return the BacnetID for the host."""
+        if not self.bacnetid:
+            return None
+
+        return BacnetID.get_by_id(self.bacnetid)
+
+    def has_mx_with_priority(self, mx_arg: str, priority: int) -> MX | None:
+        """Check if the host has an MX record.
+
+        :param mx: The MX record to check for.
+        :param priority: The priority of the MX record.
+
+        :returns: True if the host has the MX record, False otherwise.
+        """
+        return next((mx for mx in self.mxs if mx.has_mx_with_priority(mx_arg, priority)), None)
 
     def output(self, names: bool = False, traverse_hostgroups: bool = False):
         """Output host information to the console with padding."""

--- a/mreg_cli/api/models.py
+++ b/mreg_cli/api/models.py
@@ -3776,7 +3776,6 @@ class HostGroup(FrozenModelWithTimestamps, WithName, WithHistory, APIMixin):
     groups: NameList
     hosts: NameList
     owners: NameList
-    network_communities: list[Community] = []
 
     history_resource: ClassVar[HistoryResource] = HistoryResource.Group
 

--- a/mreg_cli/api/models.py
+++ b/mreg_cli/api/models.py
@@ -1281,7 +1281,7 @@ class Role(HostPolicy, WithHistory):
             manager.add_line("No atom members")
 
     @classmethod
-    def output_multiple(cls, roles: list[Role], padding: int = 14) -> None:
+    def output_multiple(cls, roles: list[Role] | list[str], padding: int = 14) -> None:
         """Output multiple roles to the console.
 
         :param roles: List of roles to output.
@@ -1290,9 +1290,14 @@ class Role(HostPolicy, WithHistory):
         if not roles:
             return
 
-        OutputManager().add_line(
-            "{1:<{0}}{2}".format(padding, "Roles:", ", ".join([role.name for role in roles]))
-        )
+        rolenames: list[str] = []
+        for role in roles:
+            if isinstance(role, str):
+                rolenames.append(role)
+            else:
+                rolenames.append(role.name)
+
+        OutputManager().add_line("{1:<{0}}{2}".format(padding, "Roles:", ", ".join(rolenames)))
 
     @classmethod
     def output_multiple_table(cls, roles: list[Role], _padding: int = 14) -> None:
@@ -2950,6 +2955,11 @@ class Host(FrozenModelWithTimestamps, WithTTL, WithHistory, APIMixin):
     bacnetid: int | None = None
     contact: str
     ttl: int | None = None
+    srvs: list[Srv] = []
+    naptrs: list[NAPTR] = []
+    sshfps: list[SSHFP] = []
+    roles: list[str] = []
+    hostgroups: list[str] = []
     comment: str
 
     communities: list[HostCommmunity] = []
@@ -3474,19 +3484,19 @@ class Host(FrozenModelWithTimestamps, WithTTL, WithHistory, APIMixin):
 
         return False
 
-    def naptrs(self) -> list[NAPTR]:
+    def get_naptrs(self) -> list[NAPTR]:
         """Return a list of NAPTR records."""
         return NAPTR.get_list_by_field("host", self.id)
 
-    def srvs(self) -> list[Srv]:
+    def get_srvs(self) -> list[Srv]:
         """Return a list of SRV records."""
         return Srv.get_list_by_field("host", self.id)
 
-    def sshfps(self) -> list[SSHFP]:
+    def get_sshfps(self) -> list[SSHFP]:
         """Return a list of SSHFP records."""
         return SSHFP.get_list_by_field("host", self.id)
 
-    def roles(self) -> list[Role]:
+    def get_roles(self) -> list[Role]:
         """List all roles for the host."""
         return Role.get_list_by_field("hosts", self.id)
 
@@ -3507,7 +3517,7 @@ class Host(FrozenModelWithTimestamps, WithTTL, WithHistory, APIMixin):
         """
         return next((mx for mx in self.mxs if mx.has_mx_with_priority(mx_arg, priority)), None)
 
-    def hostgroups(self, traverse: bool = False) -> list[HostGroup]:
+    def get_hostgroups(self, traverse: bool = False) -> list[HostGroup]:
         """Return all hostgroups for the host.
 
         :param traverse: If True, traverse the parent groups and include them in the list.
@@ -3551,15 +3561,19 @@ class Host(FrozenModelWithTimestamps, WithTTL, WithHistory, APIMixin):
         self.output_cnames(padding=padding)
 
         TXT.output_multiple(self.txts, padding=padding)
-        Srv.output_multiple(self.srvs(), padding=padding)
-        NAPTR.output_multiple(self.naptrs(), padding=padding)
-        SSHFP.output_multiple(self.sshfps(), padding=padding)
+        Srv.output_multiple(self.srvs, padding=padding)
+        NAPTR.output_multiple(self.naptrs, padding=padding)
+        SSHFP.output_multiple(self.sshfps, padding=padding)
 
         if self.bacnetid is not None:  # This may be zero.
             output_manager.add_line(f"{'Bacnet ID:':<{padding}}{self.bacnetid}")
 
-        Role.output_multiple(self.roles(), padding=padding)
-        HostGroup.output_multiple(self.hostgroups(traverse=traverse_hostgroups), padding=padding)
+        Role.output_multiple(self.roles, padding=padding)
+        if traverse_hostgroups:
+            hostgroups = self.get_hostgroups(traverse=True)
+        else:
+            hostgroups = self.hostgroups
+        HostGroup.output_multiple(hostgroups, padding=padding)
 
         self.output_timestamps()
 
@@ -3662,14 +3676,14 @@ class Host(FrozenModelWithTimestamps, WithTTL, WithHistory, APIMixin):
 
     def output_roles(self, _padding: int = 14) -> None:
         """Output the roles for the host."""
-        roles = self.roles()
+        roles = self.roles
         manager = OutputManager()
         if not roles:
             manager.add_line(f"Host {self.name} has no roles")
         else:
             manager.add_line(f"Roles for {self.name}:")
             for role in roles:
-                manager.add_line(f"  {role.name}")
+                manager.add_line(f"  {role}")
 
     def __str__(self) -> str:
         """Return the host name as a string."""
@@ -3785,7 +3799,7 @@ class HostGroup(FrozenModelWithTimestamps, WithName, WithHistory, APIMixin):
 
     @classmethod
     def output_multiple(
-        cls, hostgroups: list[HostGroup], padding: int = 14, multiline: bool = False
+        cls, hostgroups: list[HostGroup] | list[str], padding: int = 14, multiline: bool = False
     ) -> None:
         """Output multiple hostgroups to the console.
 
@@ -3797,13 +3811,19 @@ class HostGroup(FrozenModelWithTimestamps, WithName, WithHistory, APIMixin):
         if not hostgroups:
             return
 
+        groups: list[str] = []
+        for hg in hostgroups:
+            if isinstance(hg, str):
+                groups.append(hg)
+            else:
+                groups.append(hg.name)
+
         if multiline:
             manager.add_line("Groups:")
-            for group in hostgroups:
-                manager.add_line(f"  {group.name}")
+            for group in groups:
+                manager.add_line(f"  {group}")
         else:
-            groups = ", ".join(sorted([group.name for group in hostgroups]))
-            manager.add_line("{1:<{0}}{2}".format(padding, "Groups:", groups))
+            manager.add_line("{1:<{0}}{2}".format(padding, "Groups:", ", ".join(sorted(groups))))
 
     def set_description(self, description: str) -> Self:
         """Set the description for the hostgroup.

--- a/mreg_cli/commands/group.py
+++ b/mreg_cli/commands/group.py
@@ -243,7 +243,9 @@ def host_list(args: argparse.Namespace) -> None:
     :param args: argparse.Namespace (host, traverse-hostgroups)
     """
     host = Host.get_by_any_means_or_raise(args.host)
-    HostGroup.output_multiple(host.hostgroups(traverse=args.traverse_hostgroups), multiline=True)
+    HostGroup.output_multiple(
+        host.get_hostgroups(traverse=args.traverse_hostgroups), multiline=True
+    )
 
 
 @command_registry.register_command(

--- a/mreg_cli/commands/host_submodules/core.py
+++ b/mreg_cli/commands/host_submodules/core.py
@@ -287,7 +287,7 @@ def remove(args: argparse.Namespace) -> None:
 
     # Require force if host has any NAPTR records. Delete the NAPTR records if
     # force
-    naptrs = host.naptrs()
+    naptrs = host.naptrs
     if len(naptrs) > 0:
         if not forced("naptr"):
             warnings.append(f"  {len(naptrs)} NAPTR records, override with 'naptr'")
@@ -303,7 +303,7 @@ def remove(args: argparse.Namespace) -> None:
                 )
 
     # Require force if host has any SRV records. Delete the SRV records if force
-    srvs = host.srvs()
+    srvs = host.srvs
     if len(srvs) > 0:
         if not forced("srv"):
             warnings.append(f"  {len(srvs)} SRV records, override with 'srv'")

--- a/mreg_cli/commands/host_submodules/rr.py
+++ b/mreg_cli/commands/host_submodules/rr.py
@@ -399,7 +399,7 @@ def naptr_remove(args: argparse.Namespace) -> None:
     :param args: argparse.Namespace (name, preference, order, flag, service, regex, replacement)
     """
     host = Host.get_by_any_means_or_raise(args.name)
-    naptrs = host.naptrs()
+    naptrs = host.naptrs
 
     to_delete: list[NAPTR] = []
 
@@ -440,7 +440,7 @@ def naptr_show(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name)
     """
-    NAPTR.output_multiple(Host.get_by_any_means_or_raise(args.name).naptrs())
+    NAPTR.output_multiple(Host.get_by_any_means_or_raise(args.name).naptrs)
 
 
 @command_registry.register_command(
@@ -768,7 +768,7 @@ def sshfp_remove(args: argparse.Namespace) -> None:
             SSHFP.get_by_query_unique_or_raise({"fingerprint": args.fingerprint, "host": host.id})
         ]
     else:
-        sshfps = host.sshfps()
+        sshfps = host.sshfps
 
     if not sshfps:
         raise EntityNotFound(f"No matching SSHFP records for {host}")
@@ -795,7 +795,7 @@ def sshfp_show(args: argparse.Namespace) -> None:
     :param args: argparse.Namespace (name)
     """
     host = Host.get_by_any_means_or_raise(args.name)
-    sshfps = host.sshfps()
+    sshfps = host.sshfps
 
     if not sshfps:
         raise EntityNotFound(f"No SSHFP records for {host}")

--- a/mreg_cli/commands/policy.py
+++ b/mreg_cli/commands/policy.py
@@ -332,11 +332,11 @@ def host_copy(args: argparse.Namespace) -> None:
     """
     source_name: str = args.source
     source = Host.get_by_any_means_or_raise(source_name)
-    source_roles = set(source.roles())
+    source_roles = set(source.get_roles())
 
     for destination_name in args.destination:
         destination = Host.get_by_any_means_or_raise(destination_name)
-        destination_roles = set(destination.roles())
+        destination_roles = set(destination.get_roles())
         OutputManager().add_line(f"Copying roles from from {source_name} to {destination_name}")
 
         # Check if role already exists in destination

--- a/mreg_cli/utilities/api.py
+++ b/mreg_cli/utilities/api.py
@@ -295,7 +295,7 @@ def _request_wrapper(
         result.status_code == 500
         and (operation_type == "post" or operation_type == "patch")
         and params == {}
-        and data is not None
+        and data
     ):
         result = func(url, params={}, timeout=HTTP_TIMEOUT, data=data)
 


### PR DESCRIPTION
Adds support for the expanded /hosts endpoint output introduced in unioslo/mreg#572. Integration tests were performed against the container image produced here locally: https://github.com/unioslo/mreg/actions/runs/13944068027

The test suite will not pass here until we have merged unioslo/mreg#572.