### PR TITLE
Re-raise `LoginFailedError` in `prompt_for_password_and_login`

### DIFF
--- a/mreg_cli/utilities/api.py
+++ b/mreg_cli/utilities/api.py
@@ -151,6 +151,8 @@ def prompt_for_password_and_login(user: str, url: str, catch_exception: bool = T
     except CliError as e:
         if catch_exception:
             e.print_and_log()
+        if isinstance(e, LoginFailedError):
+            raise e
         else:
             raise LoginFailedError("Updating token failed.") from e
 


### PR DESCRIPTION
If we have already raised a `LoginFailedError` in `auth_and_update_token()`, we should not obscure it with another error with a less precise message.