### PR TITLE
Fix help padding for long commands

### DIFF
--- a/mreg_cli/help_formatter.py
+++ b/mreg_cli/help_formatter.py
@@ -27,9 +27,11 @@ class CustomHelpFormatter(argparse.HelpFormatter):
             formatted_action = "commands:\n"
 
             # Format each subcommand
+            longest_subcommand = len(max(action.choices.keys(), key=len))
+            padding = max(longest_subcommand, 20)
             for subcommand, parser in action.choices.items():
                 subcommand_help = parser.description if parser.description else ""
-                formatted_subcommand = f"  {subcommand:<20} {subcommand_help}"
+                formatted_subcommand = f"  {subcommand:<{padding}} {subcommand_help}"
                 formatted_action += formatted_subcommand + "\n"
 
             return formatted_action


### PR DESCRIPTION
This PR fixes padding of command names when calling `<command group> -help`.

The current static padding length of 20 is insufficient for certain commands that exceed 20 characters in length. This PR uses `max(20, len(longest_command))` to determine the number of spaces to pad with.

Current (master) `network -help`:

```
commands:
  create               Create a new network
  info                 Display network info for one or more networks.
  find                 Search for networks based on a range of search parameters
  list_unused_addresses Lists all the unused addresses for a network
  list_used_addresses  Lists all the used addresses for a network
  remove               Remove network
  add_excluded_range   Add an excluded range to a network
  remove_excluded_range Remove an excluded range to a network
  list_excluded_ranges List excluded ranges for a network
  set_category         Set category tag for network
  set_description      Set description for network
  set_dns_delegated    Set that DNS-administration is being handled elsewhere.
  set_frozen           Freeze a network.
  set_location         Set location tag for network
  set_reserved         Set number of reserved hosts.
  set_vlan             Set VLAN for network
  unset_dns_delegated  Set that DNS-administration is not being handled elsewhere.
  unset_frozen         Unfreeze a network.
```
  
This PR `network -help`:
  
```
commands:
  create                Create a new network
  info                  Display network info for one or more networks.
  find                  Search for networks based on a range of search parameters
  list_unused_addresses Lists all the unused addresses for a network
  list_used_addresses   Lists all the used addresses for a network
  remove                Remove network
  add_excluded_range    Add an excluded range to a network
  remove_excluded_range Remove an excluded range to a network
  list_excluded_ranges  List excluded ranges for a network
  set_category          Set category tag for network
  set_description       Set description for network
  set_dns_delegated     Set that DNS-administration is being handled elsewhere.
  set_frozen            Freeze a network.
  set_location          Set location tag for network
  set_reserved          Set number of reserved hosts.
  set_vlan              Set VLAN for network
  unset_dns_delegated   Set that DNS-administration is not being handled elsewhere.
  unset_frozen          Unfreeze a network.
  ```
  
  The problem of mismatched padding is even more apparent on branch [network-communities](https://github.com/unioslo/mreg-cli/tree/network-communities), hence why we probably didn't catch this until now.