### PR TITLE
Keep new test suite log when not in CI

### DIFF
--- a/ci/run_testsuite_and_record_V2.sh
+++ b/ci/run_testsuite_and_record_V2.sh
@@ -28,7 +28,6 @@ function cleanup {
 	docker ps -a | grep "mreg-" | awk '{print $1}' | xargs -r docker stop
 	docker ps -a | grep "mreg-" | awk '{print $1}' | xargs -r docker rm
 	docker images | grep "mreg-" | awk '{print $1}' | xargs -r docker rmi
-	rm -f new_testsuite_log.json
 	echo "cleanup done."
 }
 trap cleanup EXIT
@@ -81,8 +80,10 @@ if [[ -n "$GITHUB_ACTIONS" ]]; then
 	docker run --rm --tty --entrypoint bash finished-mreg-tests -c 'cd /build/ci; /root/.local/bin/uv run diff.py testsuite-result.json new_testsuite_log.json'
 	exit $?
 else
+	set +e
 	docker run -it --name finished-mreg-tests --entrypoint bash finished-mreg-tests -c 'cd /build/ci; /root/.local/bin/uv run diff.py testsuite-result.json new_testsuite_log.json --review'
 	EXITCODE=$?
+	docker cp finished-mreg-tests:/build/ci/new_testsuite_log.json .
 	docker cp finished-mreg-tests:/build/ci/testsuite-result.json .
 	exit $EXITCODE
 fi


### PR DESCRIPTION
When a manual diff resolution is required (such as when adding/removing commands), we need to extract the new test suite results from the container to do so. This PR ensures the `new_testsuite_log.json` file is always copied over from the container. 