### PR TITLE
Require force for `host {a,aaaa}_remove` with CNAME arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- `host {a,aaaa}_remove` now requires `-force` if the argument is a CNAME.
 
 ## [1.2.4](https://github.com/unioslo/mreg-cli/releases/tag/1.2.4) - 2025-01-30
 

--- a/mreg_cli/commands/host_submodules/a_aaaa.py
+++ b/mreg_cli/commands/host_submodules/a_aaaa.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import argparse
 
-from mreg_cli.api.fields import MacAddress
+from mreg_cli.api.fields import HostName, MacAddress
 from mreg_cli.api.models import Host, HostList, IPAddress, Network, NetworkOrIP
 from mreg_cli.commands.host import registry as command_registry
 from mreg_cli.exceptions import (
@@ -146,11 +146,10 @@ def _ip_remove(name: str, ipaddr: str, ipversion: IP_Version, force: bool = Fals
     # Check if we fetched the host via a CNAME.
     # Ensure arg name ends with configured domain
     # (e.g. "foo" -> "foo.example.com")
-    name = name_with_domain(name)
-
+    name_hostname = HostName.parse_or_raise(name)
     for cname in host.cnames:
-        if not force and name == cname.name.casefold():
-            raise ForceMissing(f"{name} is a CNAME for {host.name}, must force.")
+        if not force and name_hostname == cname.name.casefold():
+            raise ForceMissing(f"{name_hostname} is a CNAME for {host.name}, must force.")
 
     if host_ip.delete():
         OutputManager().add_ok(f"Removed ipaddress {ipaddr} from {host}")

--- a/mreg_cli/commands/host_submodules/a_aaaa.py
+++ b/mreg_cli/commands/host_submodules/a_aaaa.py
@@ -29,7 +29,6 @@ from mreg_cli.exceptions import (
 )
 from mreg_cli.outputmanager import OutputManager
 from mreg_cli.types import Flag, IP_AddressT, IP_Version
-from mreg_cli.utilities.shared import name_with_domain
 
 
 def _bail_if_ip_in_use_and_not_force(ip: IP_AddressT) -> None:

--- a/mreg_cli/utilities/shared.py
+++ b/mreg_cli/utilities/shared.py
@@ -63,20 +63,3 @@ def sizeof_fmt(num: float, suffix: str = "B"):
             return f"{num:3.1f}{unit}{suffix}"
         num /= 1024.0
     return f"{num:.1f}Yi{suffix}"
-
-
-def name_with_domain(name: str) -> str:
-    """Append the default domain to the name if missing.
-
-    Folds case of the name for consistency.
-
-    :param name: The name to convert.
-    :return: The name with the default domain appended if it was missing.
-    """
-    from mreg_cli.config import MregCliConfig
-
-    domain = MregCliConfig().get_default_domain()
-    name = name.casefold()
-    if not name.endswith(domain):
-        name = f"{name}.{domain.lstrip('.')}"
-    return name

--- a/mreg_cli/utilities/shared.py
+++ b/mreg_cli/utilities/shared.py
@@ -63,3 +63,20 @@ def sizeof_fmt(num: float, suffix: str = "B"):
             return f"{num:3.1f}{unit}{suffix}"
         num /= 1024.0
     return f"{num:.1f}Yi{suffix}"
+
+
+def name_with_domain(name: str) -> str:
+    """Append the default domain to the name if missing.
+
+    Folds case of the name for consistency.
+
+    :param name: The name to convert.
+    :return: The name with the default domain appended if it was missing.
+    """
+    from mreg_cli.config import MregCliConfig
+
+    domain = MregCliConfig().get_default_domain()
+    name = name.casefold()
+    if not name.endswith(domain):
+        name = f"{name}.{domain.lstrip('.')}"
+    return name


### PR DESCRIPTION
This PR adds a `-force` requirement when `host {a,aaaa}_remove` is called with a CNAME argument.

We should probably update the test suite with tests for this, but I would rather not make changes to the test suite while #369 is in progress. The issue #385 has been created as a reminder.