### PR TITLE
Format DRF error message on failed login

### DIFF
--- a/mreg_cli/api/errors.py
+++ b/mreg_cli/api/errors.py
@@ -1,0 +1,133 @@
+"""Parsing of error responses from the MREG API."""
+
+from __future__ import annotations
+
+import logging
+from typing import Union
+
+from pydantic import BaseModel, ConfigDict, ValidationError
+from requests import Response
+
+from mreg_cli.types import get_type_adapter
+
+logger = logging.getLogger(__name__)
+
+
+class _BaseMregResponse(BaseModel):
+    """Base class for errors stemming from Django Rest Framework (DRF) responses."""
+
+    # Strict matching for model fields in subclasses
+    model_config = ConfigDict(extra="forbid")
+
+    def as_string(self) -> str:
+        """Return the error as a string."""
+        return ""
+
+    def fmt_error(self, field: str, messages: list[str]) -> str:
+        """Format the error message.
+
+        :param field: The field name.
+        :param messages: The list of error messages.
+        :returns: A formatted error message.
+        """
+        return f"{field}: {', '.join(messages)}"
+
+    def join_errors(self, errors: list[str], sep: str = "; ") -> str:
+        """Join the errors into a single string.
+
+        :param errors: The list of errors to join.
+        :param sep: The separator to use between errors.
+        :returns: A string with the errors joined together.
+        """
+        return sep.join(errors)
+
+
+class DetailErrorResponse(_BaseMregResponse):
+    """DRF error response model with a 'detail' key."""
+
+    detail: str
+
+    def as_string(self) -> str:
+        """Return the error as a string."""
+        return self.detail
+
+    @classmethod
+    def to_string(cls, resp: Response) -> str | None:
+        """Attempt to get the detail string from the response.
+
+        :param resp: The response object to parse.
+
+        :returns: The detail string or None if resonse cannot be parsed.
+        """
+        try:
+            return cls.model_validate_json(resp.text).detail
+        except ValidationError:
+            pass
+
+
+class NonFieldErrorResponse(_BaseMregResponse):
+    """MREG error response model with a 'non_field_errors' key.
+
+    This class of error responses are typically returned for validation errors.
+    <https://www.django-rest-framework.org/api-guide/exceptions/>
+    """
+
+    non_field_errors: dict[str, list[str]] = {}
+    """Each key is a field name and the value is a list of error messages."""
+
+    def as_string(self) -> str:
+        """Return the error as a string."""
+        errors: list[str] = []
+        for field, messages in self.non_field_errors.items():
+            errors.append(self.fmt_error(field, messages))
+        return self.join_errors(errors)
+
+
+class FieldErrorResponse(_BaseMregResponse):
+    """MREG error response model where fields with errors are used as keys.
+
+    Roughly maps to a ValidationError in DRF:
+    <https://www.django-rest-framework.org/api-guide/exceptions/#validationerror>
+    """
+
+    # Match all fields in the error response
+    model_config = ConfigDict(extra="allow")
+
+    def as_string(self) -> str:
+        """Return the error as a string."""
+        extra = self.model_extra
+        if not extra:
+            return ""
+
+        errors: list[str] = []
+        for k, v in extra.items():
+            if isinstance(v, list):
+                errors.append(self.fmt_error(k, [str(i) for i in v]))  # pyright: ignore[reportUnknownVariableType, reportUnknownArgumentType]
+            else:
+                errors.append(f"{k}: {v}")
+        return self.join_errors(errors)
+
+
+MREGErrorResponse = Union[
+    DetailErrorResponse,
+    NonFieldErrorResponse,
+    # NOTE: DO NOT INSERT ANY TYPES AFTER THIS POINT!
+    # FieldErrorResponse should always be specified last
+    # because it matches any response with a JSON object
+    FieldErrorResponse,
+]
+
+
+def parse_mreg_error_response(resp: Response) -> MREGErrorResponse | None:
+    """Parse an MREG error response.
+
+    :param resp: The response object to parse.
+
+    :returns: A MREGErrorResponse object or None if it cannot be parsed.
+    """
+    t = get_type_adapter(MREGErrorResponse)
+    try:
+        return t.validate_json(resp.text)
+    except ValidationError:
+        logger.error("Failed to parse response text '%s' from %s", resp.text, resp.url)
+    return None

--- a/mreg_cli/api/models.py
+++ b/mreg_cli/api/models.py
@@ -17,7 +17,6 @@ from pydantic import (
     field_validator,
 )
 from pydantic import ValidationError as PydanticValidationError
-from requests import Response
 from typing_extensions import Unpack
 
 from mreg_cli.api.abstracts import APIMixin, FrozenModel, FrozenModelWithTimestamps
@@ -3766,22 +3765,3 @@ class UserInfo(BaseModel):
             outputmanager.add_line(f"  {group}")
 
         UserPermission.output_multiple(self.permissions)
-
-
-class ErrorResponse(FrozenModel):
-    """DRF error response model."""
-
-    detail: str
-
-    @classmethod
-    def to_string(cls, resp: Response) -> str | None:
-        """Attempt to get the detail string from the response.
-
-        :param resp: The response object to parse.
-
-        :returns: The detail string or None if resonse cannot be parsed.
-        """
-        try:
-            return cls.model_validate_json(resp.text).detail
-        except ValidationError:
-            pass

--- a/mreg_cli/api/models.py
+++ b/mreg_cli/api/models.py
@@ -17,6 +17,7 @@ from pydantic import (
     field_validator,
 )
 from pydantic import ValidationError as PydanticValidationError
+from requests import Response
 from typing_extensions import Unpack
 
 from mreg_cli.api.abstracts import APIMixin, FrozenModel, FrozenModelWithTimestamps
@@ -3765,3 +3766,22 @@ class UserInfo(BaseModel):
             outputmanager.add_line(f"  {group}")
 
         UserPermission.output_multiple(self.permissions)
+
+
+class ErrorResponse(FrozenModel):
+    """DRF error response model."""
+
+    detail: str
+
+    @classmethod
+    def to_string(cls, resp: Response) -> str | None:
+        """Attempt to get the detail string from the response.
+
+        :param resp: The response object to parse.
+
+        :returns: The detail string or None if resonse cannot be parsed.
+        """
+        try:
+            return cls.model_validate_json(resp.text).detail
+        except ValidationError:
+            pass

--- a/mreg_cli/utilities/api.py
+++ b/mreg_cli/utilities/api.py
@@ -193,8 +193,6 @@ def auth_and_update_token(username: str, password: str) -> None:
 
     if not result.ok:
         err = parse_mreg_error_response(result)
-        # We don't have an error response with a "detail" field
-
         if err:
             msg = err.as_string()
         else:

--- a/mreg_cli/utilities/api.py
+++ b/mreg_cli/utilities/api.py
@@ -193,15 +193,15 @@ def auth_and_update_token(username: str, password: str) -> None:
         error(err)
 
     if not result.ok:
-        err_msg = ErrorResponse.to_string(result)
+        err = ErrorResponse.to_string(result)
         # We don't have an error response with a "detail" field
-        if not err_msg:
+        if not err:
             logger.error("Failed to login: %s", result.text)
             if "non_field_errors" in result.text:
-                err_msg = "Invalid username/password"
+                err = "Invalid username/password"
             else:
-                err_msg = result.text
-        raise LoginFailedError(err_msg)
+                err = result.text
+        raise LoginFailedError(err)
 
     token = result.json()["token"]
     logger.info("Token updated for %s @ %s", username, tokenurl)

--- a/mreg_cli/utilities/api.py
+++ b/mreg_cli/utilities/api.py
@@ -196,11 +196,12 @@ def auth_and_update_token(username: str, password: str) -> None:
         err = ErrorResponse.to_string(result)
         # We don't have an error response with a "detail" field
         if not err:
-            logger.error("Failed to login: %s", result.text)
-            if "non_field_errors" in result.text:
+            body = result.text
+            logger.error("Failed to login: %s", body)
+            if "non_field_errors" in body:
                 err = "Invalid username/password"
             else:
-                err = result.text
+                err = body
         raise LoginFailedError(err)
 
     token = result.json()["token"]


### PR DESCRIPTION
**NOTE:** This PR should probably be scrapped in favor of #386.


----


#377 changed the login error handling to propagate the original Django error. However, we did not account for the fact that DRF returns a JSON response with a single `"detail"` field. This resulted in the following error message:

```
Connecting to https://mreg.example.com
Password for pederhan: ******
Login failed: {'detail': 'Incorrect authentication credentials.'}
```

This PR attempts to extract the `"detail"` value before constructing the exception:

```
Connecting to https://mreg.example.com
Password for pederhan: ******
Login failed: Incorrect authentication credentials.
```

## Refactored fallback for errors without `"detail"` field

Currently, we have a specific check for 400 responses including `non_field_errors`:

https://github.com/unioslo/mreg-cli/blob/9f14d178194077f5852d673e36e23615d482e908/mreg_cli/utilities/api.py#L197-L201

This has the side-effect of raising no exception at all if the response doesn't contain `non_field_errors`, where the application will instead continue on trying to update the token, even though the response does contain a token.

This PR adds more generalized handling of this class of errors, so that we cannot fall through with no raised exception:

https://github.com/unioslo/mreg-cli/blob/095f35ec66f1e636b3802719a3dd91ece97ea492/mreg_cli/utilities/api.py#L194-L205