### PR TITLE
Support last_login and token information about users.

### DIFF
--- a/mreg_cli/api/models.py
+++ b/mreg_cli/api/models.py
@@ -3695,7 +3695,7 @@ class TokenInfo(BaseModel):
     created: str
     expire: str
     last_used: str | None = None
-    lifespan_left: str
+    lifespan: str
 
 
 class UserInfo(BaseModel):
@@ -3764,7 +3764,7 @@ class UserInfo(BaseModel):
             outputmanager.add_line(f"  Created: {self.token.created}")
             outputmanager.add_line(f"  Expires: {self.token.expire}")
             outputmanager.add_line(f"  Last used: {self.token.last_used or 'Never'}")
-            outputmanager.add_line(f"  Lifespan left: {self.token.lifespan_left}")
+            outputmanager.add_line(f"  Lifespan: {self.token.lifespan}")
         else:
             outputmanager.add_line("Token: None")
 

--- a/mreg_cli/api/models.py
+++ b/mreg_cli/api/models.py
@@ -3688,10 +3688,22 @@ class ServerLibraries(BaseModel):
             manager.add_line(f"{' ' * indent}{lib.name}: {lib.version}")
 
 
+class TokenInfo(BaseModel):
+    """Model for token information."""
+
+    is_valid: bool
+    created: str
+    expire: str
+    last_used: str | None = None
+    lifespan_left: str
+
+
 class UserInfo(BaseModel):
     """Model for the user information."""
 
     username: str
+    last_login: str | None = None
+    token: TokenInfo | None = None
     django_status: UserDjangoStatus
     mreg_status: UserMregStatus
     groups: list[str]
@@ -3744,6 +3756,17 @@ class UserInfo(BaseModel):
         """Output the user information to the console."""
         outputmanager = OutputManager()
         outputmanager.add_line(f"Username: {self.username}")
+        outputmanager.add_line(f"Last login: {self.last_login or 'Never'}")
+
+        if self.token:
+            outputmanager.add_line("Token:")
+            outputmanager.add_line(f"  Valid: {self.token.is_valid}")
+            outputmanager.add_line(f"  Created: {self.token.created}")
+            outputmanager.add_line(f"  Expires: {self.token.expire}")
+            outputmanager.add_line(f"  Last used: {self.token.last_used or 'Never'}")
+            outputmanager.add_line(f"  Lifespan left: {self.token.lifespan_left}")
+        else:
+            outputmanager.add_line("Token: None")
 
         if django:
             outputmanager.add_line("Django roles:")


### PR DESCRIPTION
This requires https://github.com/unioslo/mreg/pull/579 to expose the data. For older servers both "Last login" and the token information will be None. 

Example output for someone that has logged in with an active session:

```
Username: user
Last login: 2025-05-13T10:05:17.553790+02:00
Token:
  Valid: True
  Created: 2025-05-13T10:05:17.526321+02:00
  Expires: 2025-05-13T18:05:17.526321+02:00
  Last used: 2025-05-13T10:40:56.790783+02:00
  Lifespan left: 7:24:20.704934
[...]
```

