### PR TITLE
Add `host add -force` for broadcast and network addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Allow `host add -force` option to use network or broadcast addresses as argument for `-ip` if the user has permission to do so.
 
 ## [1.3.0](https://github.com/unioslo/mreg-cli/releases/tag/1.3.0) - 2025-05-20
 

--- a/mreg_cli/commands/host_submodules/core.py
+++ b/mreg_cli/commands/host_submodules/core.py
@@ -141,13 +141,13 @@ def add(args: argparse.Namespace) -> None:
             try:
                 network = Network.get_by_ip(ipaddr)
                 if network:
-                    if ipaddr == network.network_address:
+                    if ipaddr == network.network_address and not force:
                         raise InvalidIPAddress(
-                            f"IP {ipaddr} is a network address, not a host address"
+                            f"IP {ipaddr} is a network address, not a host address, must force"
                         )
-                    elif ipaddr == network.broadcast_address:
+                    elif ipaddr == network.broadcast_address and not force:
                         raise InvalidIPAddress(
-                            f"IP {ipaddr} is a broadcast address, not a host address"
+                            f"IP {ipaddr} is a broadcast address, not a host address, must force"
                         )
             except (EntityNotFound, APINotOk) as e:
                 if not force:


### PR DESCRIPTION
Allows using network or broadcast address as `-ip` argument in `host add` if `-force` is used and the user has permission to do so (NYI on the server).