### PR TITLE
Add configurable HTTP timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Configurable HTTP request timeout. The timeout can be set with the `--timeout` option or with the `timeout` option in the config file.
+
 ### Fixed
 
 - `host info <ip>` command not working for IP addresses associated with multiple hosts.

--- a/data/mreg-cli.conf
+++ b/data/mreg-cli.conf
@@ -2,7 +2,8 @@
 # url=http://127.0.0.1:8000
 # user=test
 # domain=example.org
-# logfile=cli.log
+# timeout=20
 # prompt={user}@{host}
+# logfile=cli.log
 category_tags=cat1,cat2,cat3
 location_tags=loc1,loc2,loc3

--- a/mreg_cli/config.py
+++ b/mreg_cli/config.py
@@ -71,6 +71,8 @@ LOGGING_FORMAT = "%(asctime)s - %(levelname)-8s - %(name)s - %(message)s"
 
 DEFAULT_PROMPT = "{user}@{host}"
 
+DEFAULT_HTTP_TIMEOUT = 20  # seconds
+
 
 class MregCliConfig:
     """Configuration class for the mreg-cli.
@@ -259,17 +261,19 @@ class MregCliConfig:
             raise ValueError("No URL found in config, no defaults available!")
         return url
 
-    def get_http_timeout(self, default: int = 20) -> int:
+    def get_http_timeout(self) -> int:
         """Get the HTTP timeout from the application.
 
         :returns: HTTP timeout in seconds.
         """
-        timeout = self.get("timeout", default)
+        timeout = self.get("timeout", DEFAULT_HTTP_TIMEOUT)
         try:
             return int(timeout)
         except ValueError:
-            logger.warning("Invalid timeout value, using default %d seconds.", default)
-            return default
+            logger.warning(
+                "Invalid timeout value, using default %d seconds.", DEFAULT_HTTP_TIMEOUT
+            )
+            return DEFAULT_HTTP_TIMEOUT
 
     def _calculate_column_width(self, data: dict[str, Any], min_width: int = 8) -> int:
         """Calculate the maximum column width, ensuring a minimum width.

--- a/mreg_cli/config.py
+++ b/mreg_cli/config.py
@@ -259,6 +259,18 @@ class MregCliConfig:
             raise ValueError("No URL found in config, no defaults available!")
         return url
 
+    def get_http_timeout(self, default: int = 20) -> int:
+        """Get the HTTP timeout from the application.
+
+        :returns: HTTP timeout in seconds.
+        """
+        timeout = self.get("timeout", default)
+        try:
+            return int(timeout)
+        except ValueError:
+            logger.warning("Invalid timeout value, using default %d seconds.", default)
+            return default
+
     def _calculate_column_width(self, data: dict[str, Any], min_width: int = 8) -> int:
         """Calculate the maximum column width, ensuring a minimum width.
 

--- a/mreg_cli/main.py
+++ b/mreg_cli/main.py
@@ -51,6 +51,15 @@ def main():
         metavar="USER",
     )
 
+    connect_args.add_argument(
+        "-t",
+        "--timeout",
+        type=int,
+        default=config.get_http_timeout(),
+        help="HTTP request timeout in seconds (default: %(default)s)",
+        metavar="TIMEOUT",
+    )
+
     mreg_args = parser.add_argument_group("mreg settings")
     mreg_args.add_argument(
         "-d",

--- a/mreg_cli/utilities/api.py
+++ b/mreg_cli/utilities/api.py
@@ -40,7 +40,6 @@ session.headers.update({"User-Agent": f"mreg-cli-{__version__}"})
 
 logger = logging.getLogger(__name__)
 
-HTTP_TIMEOUT = 20
 
 T = TypeVar("T")
 
@@ -281,7 +280,7 @@ def _request_wrapper(
         url,
         params=params,
         json=data or None,
-        timeout=HTTP_TIMEOUT,
+        timeout=MregCliConfig().get_http_timeout(),
     )
 
     last_request_url.set(logurl)
@@ -304,7 +303,7 @@ def _request_wrapper(
         and params == {}
         and data
     ):
-        result = func(url, params={}, timeout=HTTP_TIMEOUT, data=data)
+        result = func(url, params={}, timeout=MregCliConfig().get_http_timeout(), data=data)
 
     OutputManager().recording_request(operation_type, url, params, data, result)
 


### PR DESCRIPTION
This PR adds configurable HTTP request timeout in the form of a `--timeout` CLI option as well as a `timeout` config file option.

---

Disclaimer: The motivation behind this PR was to make it easier to debug the server, as attaching a debugger to a request and stopping on a line would cause a timeout error on the client side unless `HTTP_TIMEOUT` was overridden directly in the code.