### PR TITLE
Handle IPs from Networks not managed by MREG

### DIFF
--- a/ci/testsuite-result.json
+++ b/ci/testsuite-result.json
@@ -23044,7 +23044,7 @@
     "command_issued": "dhcp assoc foo aa:bb:cc:dd:ee:ff # should fail, two IPs of same type",
     "ok": [],
     "warning": [
-      "Host foo.example.org has multiple IPs, cannot determine which one to use."
+      "Host foo.example.org has multiple IPs, cannot determine which one to use: 10.0.0.5, 10.0.0.6."
     ],
     "error": [],
     "output": [],
@@ -23070,15 +23070,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-06-19T13:09:08.251883+02:00",
-              "updated_at": "2025-06-19T13:09:08.251892+02:00",
+              "created_at": "2025-08-13T10:41:00.041467+02:00",
+              "updated_at": "2025-08-13T10:41:00.041474+02:00",
               "ipaddress": "10.0.0.5",
               "host": 18
             },
             {
               "macaddress": "",
-              "created_at": "2025-06-19T13:09:08.382145+02:00",
-              "updated_at": "2025-06-19T13:09:08.382151+02:00",
+              "created_at": "2025-08-13T10:41:00.185731+02:00",
+              "updated_at": "2025-08-13T10:41:00.185738+02:00",
               "ipaddress": "10.0.0.6",
               "host": 18
             }
@@ -23087,8 +23087,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-06-19T13:09:07.019259+02:00",
-              "updated_at": "2025-06-19T13:09:07.019265+02:00",
+              "created_at": "2025-08-13T10:40:58.935125+02:00",
+              "updated_at": "2025-08-13T10:40:58.935130+02:00",
               "txt": "v=spf1 -all",
               "host": 18
             }
@@ -23103,8 +23103,8 @@
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-06-19T13:09:07.017552+02:00",
-          "updated_at": "2025-06-19T13:09:07.017559+02:00",
+          "created_at": "2025-08-13T10:40:58.933270+02:00",
+          "updated_at": "2025-08-13T10:40:58.933280+02:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -23513,7 +23513,7 @@
     "command_issued": "dhcp assoc foo aa:bb:cc:dd:ee:ff # should fail, the host has two IPs of different types on different VLANs.",
     "ok": [],
     "warning": [
-      "Host foo.example.org has multiple IPs, cannot determine which one to use."
+      "Host foo.example.org has multiple IPs, cannot determine which one to use: 10.0.0.5, 2001:db9::5."
     ],
     "error": [],
     "output": [],
@@ -23539,15 +23539,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-06-19T13:09:08.251883+02:00",
-              "updated_at": "2025-06-19T13:09:08.251892+02:00",
+              "created_at": "2025-08-13T10:41:00.041467+02:00",
+              "updated_at": "2025-08-13T10:41:00.041474+02:00",
               "ipaddress": "10.0.0.5",
               "host": 18
             },
             {
               "macaddress": "",
-              "created_at": "2025-06-19T13:09:08.758513+02:00",
-              "updated_at": "2025-06-19T13:09:08.758520+02:00",
+              "created_at": "2025-08-13T10:41:00.786601+02:00",
+              "updated_at": "2025-08-13T10:41:00.786608+02:00",
               "ipaddress": "2001:db9::5",
               "host": 18
             }
@@ -23556,8 +23556,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-06-19T13:09:07.019259+02:00",
-              "updated_at": "2025-06-19T13:09:07.019265+02:00",
+              "created_at": "2025-08-13T10:40:58.935125+02:00",
+              "updated_at": "2025-08-13T10:40:58.935130+02:00",
               "txt": "v=spf1 -all",
               "host": 18
             }
@@ -23572,8 +23572,8 @@
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-06-19T13:09:07.017552+02:00",
-          "updated_at": "2025-06-19T13:09:07.017559+02:00",
+          "created_at": "2025-08-13T10:40:58.933270+02:00",
+          "updated_at": "2025-08-13T10:40:58.933280+02:00",
           "name": "foo.example.org",
           "contact": "",
           "ttl": null,
@@ -23590,8 +23590,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-06-19T13:09:06.902388+02:00",
-          "updated_at": "2025-06-19T13:09:06.902398+02:00",
+          "created_at": "2025-08-13T10:40:58.822374+02:00",
+          "updated_at": "2025-08-13T10:40:58.822385+02:00",
           "network": "10.0.0.0/24",
           "description": "foo",
           "vlan": 1234,
@@ -23611,8 +23611,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-06-19T13:09:08.663889+02:00",
-          "updated_at": "2025-06-19T13:09:08.663898+02:00",
+          "created_at": "2025-08-13T10:41:00.673383+02:00",
+          "updated_at": "2025-08-13T10:41:00.673397+02:00",
           "network": "2001:db9::/64",
           "description": "notfoo_ipv6",
           "vlan": 1235,

--- a/mreg_cli/api/models.py
+++ b/mreg_cli/api/models.py
@@ -3434,30 +3434,30 @@ class Host(FrozenModelWithTimestamps, WithTTL, WithHistory, APIMixin):
         if len(ipv4s) == 1 and len(ipv6s) == 1:
             ipv4_address = ipv4s[0]
             ipv6_address = ipv6s[0]
-            network4 = ipv4_address.network()
-            network6 = ipv6_address.network()
+            ipv4_network = ipv4_address.network()
+            ipv6_network = ipv6_address.network()
 
-            if network4 and network6:
-                if network4.vlan == network6.vlan:
-                    return ipv4s[0]
-            elif network4:  # only IPv4 is in mreg
+            if ipv4_network and ipv6_network:
+                if ipv4_network.vlan == ipv6_network.vlan:
+                    return ipv4_address
+            elif ipv4_network:  # only IPv4 is in mreg
                 logger.warning(
                     "Host '%s' has IPv6 address not in MREG: %s",
                     self.name,
                     str(ipv6_address.ipaddress),
                 )
                 return ipv4_address
-            elif network6:  # only IPv6 is in mreg
+            elif ipv6_network:  # only IPv6 is in mreg
                 logger.warning(
                     "Host '%s' has IPv4 address not in MREG: %s",
                     self.name,
                     str(ipv4_address.ipaddress),
                 )
                 return ipv6_address
-            # falls through to raise an error
 
+        ips = ", ".join(str(ip.ipaddress) for ip in self.ipaddresses)
         raise EntityOwnershipMismatch(
-            f"Host {self} has multiple IPs, cannot determine which one to use."
+            f"Host {self} has multiple IPs, cannot determine which one to use: {ips}."
         )
 
     def has_ptr_override(self, arg_ip: IP_AddressT) -> bool:

--- a/mreg_cli/api/models.py
+++ b/mreg_cli/api/models.py
@@ -1644,8 +1644,9 @@ class Network(FrozenModelWithTimestamps, APIMixin):
             reserved=0,
             policy=None,
             communities=[],
-            created_at=datetime.now(),
-            updated_at=datetime.now(),
+            # epoch time
+            created_at=datetime.fromtimestamp(0),
+            updated_at=datetime.fromtimestamp(0),
         )
 
     @classmethod

--- a/mreg_cli/commands/network.py
+++ b/mreg_cli/commands/network.py
@@ -1223,7 +1223,10 @@ def community_host_add(args: argparse.Namespace) -> None:
 
     h = Host.get_by_any_means_or_raise(host)
     ipaddr = _check_host_ip(h, ip)
-    net = ipaddr.network()
+
+    if not (net := ipaddr.network()):
+        raise EntityNotFound(f"{h.name!r} is not in a network controlled by MREG.")
+
     com = net.get_community_or_raise(community)
 
     com.add_host(h, ipaddress=ipaddr.ipaddress)

--- a/tests/api/test_models.py
+++ b/tests/api/test_models.py
@@ -6,7 +6,7 @@ from typing import Any, Callable
 
 import pytest
 
-from mreg_cli.api.models import IPNetMode, Network, NetworkOrIP
+from mreg_cli.api.models import IPAddress, IPNetMode, Network, NetworkOrIP
 from mreg_cli.exceptions import (
     InputFailure,
     InvalidIPAddress,
@@ -135,3 +135,44 @@ def test_network_ip_network(inp: str, expect: IP_NetworkT) -> None:
     assert network.ip_network == expect
     assert network.broadcast_address == expect.broadcast_address
     assert network.network_address == expect.network_address
+
+
+@pytest.mark.parametrize(
+    "inp",
+    [
+        "192.168.0.1",
+        "0.0.0.0",
+        "10.0.0.1",
+    ],
+)
+def test_network_dummy_network_from_ip_v4(inp: str) -> None:
+    """Test creating a dummy network from an IPv4 address."""
+    _test_network_dummy_network(IPv4Address(inp), expected_version=4)
+
+
+@pytest.mark.parametrize(
+    "inp",
+    [
+        "2001:db8::1",
+        "::1",
+        "fe80::1",
+    ],
+)
+def test_network_dummy_network_from_ip_v6(inp: str) -> None:
+    """Test creating a dummy network from an IPv6 address."""
+    _test_network_dummy_network(IPv6Address(inp), expected_version=6)
+
+
+def _test_network_dummy_network(inp: IPv4Address | IPv6Address, expected_version: int) -> None:
+    """Helper function to test creating a dummy network from an IP address."""  # noqa: D401
+    ip = IPAddress(
+        id=0,
+        host=0,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        ipaddress=inp,
+        # no mac
+    )
+    network = Network.dummy_network_from_ip(ip)
+    assert isinstance(network, Network)
+    assert network.ip_network.version == expected_version


### PR DESCRIPTION
Some IPs are "associated" with networks that are not managed by MREG. This PR fixes `IPAddress.network()` to account for that possibility.