### PR TITLE
Add simple disk-based caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Added
+
+- Configurable caching of API responses. Enabled by default.
+  - `cache` option to enable/disable caching.
+  - `cache_ttl` option to configure the cache time-to-live (TTL) in seconds.
 
 ## [1.4.2](https://github.com/unioslo/mreg-cli/releases/tag/1.4.2) - 2025-08-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Configurable caching of API responses. Enabled by default.
-  - `cache` option to enable/disable caching.
-  - `cache_ttl` option to configure the cache time-to-live (TTL) in seconds.
+  - Enable/disable caching (default: `true`)
+    - Config file: `cache=true|false`
+    - CLI: `--no-cache` (flag)
+  - Configure cache time-to-live (TTL) in seconds (default: `300`)
+    - Config file: `cache_ttl=<seconds>`
+    - CLI: `--cache-ttl <seconds>`
 
 ## [1.4.2](https://github.com/unioslo/mreg-cli/releases/tag/1.4.2) - 2025-08-15
 

--- a/ci/testsuite-result.json
+++ b/ci/testsuite-result.json
@@ -60,38 +60,6 @@
     "api_requests": [
       {
         "method": "GET",
-        "url": "/api/v1/hosts/ns1.example.org",
-        "data": {},
-        "status": 404,
-        "response": {
-          "type": "client_error",
-          "errors": [
-            {
-              "code": "not_found",
-              "detail": "Not found.",
-              "attr": null
-            }
-          ]
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/cnames/ns1.example.org",
-        "data": {},
-        "status": 404,
-        "response": {
-          "type": "client_error",
-          "errors": [
-            {
-              "code": "not_found",
-              "detail": "Not found.",
-              "attr": null
-            }
-          ]
-        }
-      },
-      {
-        "method": "GET",
         "url": "/api/v1/zones/forward/example.org",
         "data": {},
         "status": 404,
@@ -126,18 +94,18 @@
         "response": {
           "nameservers": [
             {
-              "created_at": "2025-05-19T10:27:38.255458+02:00",
-              "updated_at": "2025-05-19T10:27:38.255515+02:00",
+              "created_at": "2025-08-26T11:56:35.531281+02:00",
+              "updated_at": "2025-08-26T11:56:35.531321+02:00",
               "name": "ns1.example.org",
               "ttl": null
             }
           ],
-          "created_at": "2025-05-19T10:27:38.232774+02:00",
-          "updated_at": "2025-05-19T10:27:38.263493+02:00",
+          "created_at": "2025-08-26T11:56:35.478972+02:00",
+          "updated_at": "2025-08-26T11:56:35.541992+02:00",
           "updated": true,
           "primary_ns": "ns1.example.org",
           "email": "hostmaster@example.org",
-          "serialno_updated_at": "2025-05-19T10:27:38.232441+02:00",
+          "serialno_updated_at": "2025-08-26T11:56:35.477876+02:00",
           "refresh": 10800,
           "retry": 3600,
           "expire": 1814400,
@@ -267,34 +235,6 @@
     "api_requests": [
       {
         "method": "GET",
-        "url": "/api/v1/zones/forward/example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "nameservers": [
-            {
-              "created_at": "2025-05-19T10:27:38.255458+02:00",
-              "updated_at": "2025-05-19T10:27:38.255515+02:00",
-              "name": "ns1.example.org",
-              "ttl": null
-            }
-          ],
-          "created_at": "2025-05-19T10:27:38.232774+02:00",
-          "updated_at": "2025-05-19T10:27:38.263493+02:00",
-          "updated": true,
-          "primary_ns": "ns1.example.org",
-          "email": "hostmaster@example.org",
-          "serialno_updated_at": "2025-05-19T10:27:38.232441+02:00",
-          "refresh": 10800,
-          "retry": 3600,
-          "expire": 1814400,
-          "soa_ttl": 43200,
-          "default_ttl": 43200,
-          "name": "example.org"
-        }
-      },
-      {
-        "method": "GET",
         "url": "/api/v1/hosts/ns2.example.org",
         "data": {},
         "status": 404,
@@ -340,66 +280,6 @@
     "error": [],
     "output": [],
     "api_requests": [
-      {
-        "method": "GET",
-        "url": "/api/v1/zones/forward/example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "nameservers": [
-            {
-              "created_at": "2025-05-19T10:27:38.255458+02:00",
-              "updated_at": "2025-05-19T10:27:38.255515+02:00",
-              "name": "ns1.example.org",
-              "ttl": null
-            }
-          ],
-          "created_at": "2025-05-19T10:27:38.232774+02:00",
-          "updated_at": "2025-05-19T10:27:38.263493+02:00",
-          "updated": true,
-          "primary_ns": "ns1.example.org",
-          "email": "hostmaster@example.org",
-          "serialno_updated_at": "2025-05-19T10:27:38.232441+02:00",
-          "refresh": 10800,
-          "retry": 3600,
-          "expire": 1814400,
-          "soa_ttl": 43200,
-          "default_ttl": 43200,
-          "name": "example.org"
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hosts/ns2.example.org",
-        "data": {},
-        "status": 404,
-        "response": {
-          "type": "client_error",
-          "errors": [
-            {
-              "code": "not_found",
-              "detail": "Not found.",
-              "attr": null
-            }
-          ]
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/cnames/ns2.example.org",
-        "data": {},
-        "status": 404,
-        "response": {
-          "type": "client_error",
-          "errors": [
-            {
-              "code": "not_found",
-              "detail": "Not found.",
-              "attr": null
-            }
-          ]
-        }
-      },
       {
         "method": "PATCH",
         "url": "/api/v1/zones/forward/example.org/nameservers",
@@ -560,34 +440,6 @@
     "output": [],
     "api_requests": [
       {
-        "method": "GET",
-        "url": "/api/v1/zones/forward/example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "nameservers": [
-            {
-              "created_at": "2024-12-11T16:44:40.356452+01:00",
-              "updated_at": "2024-12-11T16:44:40.356481+01:00",
-              "name": "ns2.example.org",
-              "ttl": null
-            }
-          ],
-          "created_at": "2024-12-11T16:44:39.701254+01:00",
-          "updated_at": "2024-12-11T16:44:40.481572+01:00",
-          "updated": true,
-          "primary_ns": "ns2.example.org",
-          "email": "hostperson@example.org",
-          "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
-          "refresh": 360,
-          "retry": 1800,
-          "expire": 2400,
-          "soa_ttl": 1800,
-          "default_ttl": 43200,
-          "name": "example.org"
-        }
-      },
-      {
         "method": "PATCH",
         "url": "/api/v1/zones/forward/example.org",
         "data": {
@@ -608,18 +460,18 @@
             {
               "nameservers": [
                 {
-                  "created_at": "2024-12-11T16:44:40.356452+01:00",
-                  "updated_at": "2024-12-11T16:44:40.356481+01:00",
+                  "created_at": "2025-08-26T11:56:35.781651+02:00",
+                  "updated_at": "2025-08-26T11:56:35.781663+02:00",
                   "name": "ns2.example.org",
                   "ttl": null
                 }
               ],
-              "created_at": "2024-12-11T16:44:39.701254+01:00",
-              "updated_at": "2024-12-11T16:44:40.710848+01:00",
+              "created_at": "2025-08-26T11:56:35.478972+02:00",
+              "updated_at": "2025-08-26T11:56:36.225371+02:00",
               "updated": true,
               "primary_ns": "ns2.example.org",
               "email": "hostperson@example.org",
-              "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
+              "serialno_updated_at": "2025-08-26T11:56:36.090230+02:00",
               "refresh": 360,
               "retry": 1800,
               "expire": 2400,
@@ -765,27 +617,6 @@
     "api_requests": [
       {
         "method": "GET",
-        "url": "/api/v1/networks/10.0.2.0/28",
-        "data": {},
-        "status": 200,
-        "response": {
-          "excluded_ranges": [],
-          "policy": null,
-          "communities": [],
-          "created_at": "2025-03-19T10:10:42.905787+01:00",
-          "updated_at": "2025-03-19T10:10:42.905797+01:00",
-          "network": "10.0.2.0/28",
-          "description": "TinyNet",
-          "vlan": null,
-          "dns_delegated": false,
-          "category": "",
-          "location": "",
-          "frozen": false,
-          "reserved": 3
-        }
-      },
-      {
-        "method": "GET",
         "url": "/api/v1/networks/10.0.2.0/28/unused_list",
         "data": {},
         "status": 200,
@@ -819,27 +650,6 @@
     "output": [],
     "api_requests": [
       {
-        "method": "GET",
-        "url": "/api/v1/networks/10.0.2.0/28",
-        "data": {},
-        "status": 200,
-        "response": {
-          "excluded_ranges": [],
-          "policy": null,
-          "communities": [],
-          "created_at": "2025-03-19T10:10:42.905787+01:00",
-          "updated_at": "2025-03-19T10:10:42.905797+01:00",
-          "network": "10.0.2.0/28",
-          "description": "TinyNet",
-          "vlan": null,
-          "dns_delegated": false,
-          "category": "",
-          "location": "",
-          "frozen": false,
-          "reserved": 3
-        }
-      },
-      {
         "method": "PATCH",
         "url": "/api/v1/networks/10.0.2.0/28",
         "data": {
@@ -861,8 +671,8 @@
               "excluded_ranges": [],
               "policy": null,
               "communities": [],
-              "created_at": "2025-03-19T10:10:42.905787+01:00",
-              "updated_at": "2025-03-19T10:10:43.080147+01:00",
+              "created_at": "2025-08-26T11:56:36.423688+02:00",
+              "updated_at": "2025-08-26T11:56:36.676664+02:00",
               "network": "10.0.2.0/28",
               "description": "TinyNet",
               "vlan": null,
@@ -1131,27 +941,6 @@
       "10.0.2.14                "
     ],
     "api_requests": [
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/10.0.2.0/28",
-        "data": {},
-        "status": 200,
-        "response": {
-          "excluded_ranges": [],
-          "policy": null,
-          "communities": [],
-          "created_at": "2025-03-19T10:10:42.905787+01:00",
-          "updated_at": "2025-03-19T10:10:43.080147+01:00",
-          "network": "10.0.2.0/28",
-          "description": "TinyNet",
-          "vlan": null,
-          "dns_delegated": false,
-          "category": "",
-          "location": "",
-          "frozen": false,
-          "reserved": 8
-        }
-      },
       {
         "method": "GET",
         "url": "/api/v1/networks/10.0.2.0/28/unused_list",
@@ -5499,27 +5288,6 @@
     "api_requests": [
       {
         "method": "GET",
-        "url": "/api/v1/networks/2001%3Adb8%3A%3A/64",
-        "data": {},
-        "status": 200,
-        "response": {
-          "excluded_ranges": [],
-          "policy": null,
-          "communities": [],
-          "created_at": "2025-03-19T12:04:42.522693+01:00",
-          "updated_at": "2025-03-19T12:04:42.522709+01:00",
-          "network": "2001:db8::/64",
-          "description": "Lorem ipsum dolor sit amet",
-          "vlan": null,
-          "dns_delegated": false,
-          "category": "",
-          "location": "",
-          "frozen": false,
-          "reserved": 3
-        }
-      },
-      {
-        "method": "GET",
         "url": "/api/v1/networks/2001%3Adb8%3A%3A/64/unused_list",
         "data": {},
         "status": 200,
@@ -9638,27 +9406,6 @@
     "output": [],
     "api_requests": [
       {
-        "method": "GET",
-        "url": "/api/v1/networks/2001%3Adb8%3A%3A/64",
-        "data": {},
-        "status": 200,
-        "response": {
-          "excluded_ranges": [],
-          "policy": null,
-          "communities": [],
-          "created_at": "2025-03-19T10:10:43.865439+01:00",
-          "updated_at": "2025-03-19T10:10:43.865451+01:00",
-          "network": "2001:db8::/64",
-          "description": "Lorem ipsum dolor sit amet",
-          "vlan": null,
-          "dns_delegated": false,
-          "category": "",
-          "location": "",
-          "frozen": false,
-          "reserved": 3
-        }
-      },
-      {
         "method": "PATCH",
         "url": "/api/v1/networks/2001%3Adb8%3A%3A/64",
         "data": {
@@ -9680,8 +9427,8 @@
               "excluded_ranges": [],
               "policy": null,
               "communities": [],
-              "created_at": "2025-03-19T10:10:43.865439+01:00",
-              "updated_at": "2025-03-19T10:10:44.125057+01:00",
+              "created_at": "2025-08-26T11:56:37.637811+02:00",
+              "updated_at": "2025-08-26T11:56:37.857078+02:00",
               "network": "2001:db8::/64",
               "description": "Lorem ipsum dolor sit amet",
               "vlan": null,
@@ -9901,8 +9648,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-03-20T15:36:57.955525+01:00",
-              "updated_at": "2025-03-20T15:36:57.955532+01:00",
+              "created_at": "2025-08-26T11:56:38.120762+02:00",
+              "updated_at": "2025-08-26T11:56:38.120771+02:00",
               "ipaddress": "2001:db8::33",
               "host": 2
             }
@@ -9911,8 +9658,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-03-20T15:36:57.936502+01:00",
-              "updated_at": "2025-03-20T15:36:57.936509+01:00",
+              "created_at": "2025-08-26T11:56:38.094364+02:00",
+              "updated_at": "2025-08-26T11:56:38.094372+02:00",
               "txt": "v=spf1 -all",
               "host": 2
             }
@@ -9927,34 +9674,13 @@
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-03-20T15:36:57.934243+01:00",
-          "updated_at": "2025-03-20T15:36:57.934250+01:00",
+          "created_at": "2025-08-26T11:56:38.090913+02:00",
+          "updated_at": "2025-08-26T11:56:38.090922+02:00",
           "name": "tinyhost.example.org",
           "contact": "me@example.org",
           "ttl": null,
           "comment": "",
           "zone": 1
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/ip/2001%3Adb8%3A%3A33",
-        "data": {},
-        "status": 200,
-        "response": {
-          "excluded_ranges": [],
-          "policy": null,
-          "communities": [],
-          "created_at": "2025-03-20T15:36:57.535602+01:00",
-          "updated_at": "2025-03-20T15:36:57.772556+01:00",
-          "network": "2001:db8::/64",
-          "description": "Lorem ipsum dolor sit amet",
-          "vlan": null,
-          "dns_delegated": false,
-          "category": "",
-          "location": "",
-          "frozen": false,
-          "reserved": 50
         }
       }
     ],
@@ -9974,76 +9700,10 @@
       "              2001:db8::33   <not set>   ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Thu Mar 20 15:36:57 2025",
-      "Updated:      Thu Mar 20 15:36:57 2025"
+      "Created:      Tue Aug 26 11:56:38 2025",
+      "Updated:      Tue Aug 26 11:56:38 2025"
     ],
-    "api_requests": [
-      {
-        "method": "GET",
-        "url": "/api/v1/hosts/tinyhost.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "",
-              "created_at": "2025-03-20T15:36:57.955525+01:00",
-              "updated_at": "2025-03-20T15:36:57.955532+01:00",
-              "ipaddress": "2001:db8::33",
-              "host": 2
-            }
-          ],
-          "cnames": [],
-          "mxs": [],
-          "txts": [
-            {
-              "created_at": "2025-03-20T15:36:57.936502+01:00",
-              "updated_at": "2025-03-20T15:36:57.936509+01:00",
-              "txt": "v=spf1 -all",
-              "host": 2
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "created_at": "2025-03-20T15:36:57.934243+01:00",
-          "updated_at": "2025-03-20T15:36:57.934250+01:00",
-          "name": "tinyhost.example.org",
-          "contact": "me@example.org",
-          "ttl": null,
-          "comment": "",
-          "zone": 1
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/ip/2001%3Adb8%3A%3A33",
-        "data": {},
-        "status": 200,
-        "response": {
-          "excluded_ranges": [],
-          "policy": null,
-          "communities": [],
-          "created_at": "2025-03-20T15:36:57.535602+01:00",
-          "updated_at": "2025-03-20T15:36:57.772556+01:00",
-          "network": "2001:db8::/64",
-          "description": "Lorem ipsum dolor sit amet",
-          "vlan": null,
-          "dns_delegated": false,
-          "category": "",
-          "location": "",
-          "frozen": false,
-          "reserved": 50
-        }
-      }
-    ],
+    "api_requests": [],
     "time": null
   },
   {
@@ -10058,50 +9718,6 @@
     "error": [],
     "output": [],
     "api_requests": [
-      {
-        "method": "GET",
-        "url": "/api/v1/hosts/tinyhost.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "",
-              "created_at": "2025-03-20T15:36:57.955525+01:00",
-              "updated_at": "2025-03-20T15:36:57.955532+01:00",
-              "ipaddress": "2001:db8::33",
-              "host": 2
-            }
-          ],
-          "cnames": [],
-          "mxs": [],
-          "txts": [
-            {
-              "created_at": "2025-03-20T15:36:57.936502+01:00",
-              "updated_at": "2025-03-20T15:36:57.936509+01:00",
-              "txt": "v=spf1 -all",
-              "host": 2
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "created_at": "2025-03-20T15:36:57.934243+01:00",
-          "updated_at": "2025-03-20T15:36:57.934250+01:00",
-          "name": "tinyhost.example.org",
-          "contact": "me@example.org",
-          "ttl": null,
-          "comment": "",
-          "zone": 1
-        }
-      },
       {
         "method": "DELETE",
         "url": "/api/v1/hosts/tinyhost.example.org",
@@ -10401,27 +10017,6 @@
     "output": [],
     "api_requests": [
       {
-        "method": "GET",
-        "url": "/api/v1/networks/10.0.1.0/24",
-        "data": {},
-        "status": 200,
-        "response": {
-          "excluded_ranges": [],
-          "policy": null,
-          "communities": [],
-          "created_at": "2025-03-19T10:10:44.688196+01:00",
-          "updated_at": "2025-03-19T10:10:44.766999+01:00",
-          "network": "10.0.1.0/24",
-          "description": "Frozzzen",
-          "vlan": null,
-          "dns_delegated": false,
-          "category": "",
-          "location": "",
-          "frozen": true,
-          "reserved": 3
-        }
-      },
-      {
         "method": "POST",
         "url": "/api/v1/networks/10.0.1.0/24/excluded_ranges/",
         "data": {
@@ -10578,72 +10173,10 @@
       "              10.0.1.4   <not set>   ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Mon May 19 10:27:41 2025",
-      "Updated:      Mon May 19 10:27:41 2025"
+      "Created:      Tue Aug 26 11:56:38 2025",
+      "Updated:      Tue Aug 26 11:56:38 2025"
     ],
     "api_requests": [
-      {
-        "method": "GET",
-        "url": "/api/v1/hosts/somehost.example.org",
-        "data": {},
-        "status": 404,
-        "response": {
-          "type": "client_error",
-          "errors": [
-            {
-              "code": "not_found",
-              "detail": "Not found.",
-              "attr": null
-            }
-          ]
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/cnames/somehost.example.org",
-        "data": {},
-        "status": 404,
-        "response": {
-          "type": "client_error",
-          "errors": [
-            {
-              "code": "not_found",
-              "detail": "Not found.",
-              "attr": null
-            }
-          ]
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/zones/forward/hostname/somehost.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "zone": {
-            "nameservers": [
-              {
-                "created_at": "2025-05-19T10:27:38.778680+02:00",
-                "updated_at": "2025-05-19T10:27:38.778705+02:00",
-                "name": "ns2.example.org",
-                "ttl": null
-              }
-            ],
-            "created_at": "2025-05-19T10:27:38.232774+02:00",
-            "updated_at": "2025-05-19T10:27:41.326674+02:00",
-            "updated": true,
-            "primary_ns": "ns2.example.org",
-            "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-05-19T10:27:38.853040+02:00",
-            "refresh": 360,
-            "retry": 1800,
-            "expire": 2400,
-            "soa_ttl": 1800,
-            "default_ttl": 300,
-            "name": "example.org"
-          }
-        }
-      },
       {
         "method": "GET",
         "url": "/api/v1/networks/10.0.1.0/24",
@@ -10652,8 +10185,8 @@
         "response": {
           "excluded_ranges": [
             {
-              "created_at": "2025-05-19T10:27:41.676748+02:00",
-              "updated_at": "2025-05-19T10:27:41.676760+02:00",
+              "created_at": "2025-08-26T11:56:38.588823+02:00",
+              "updated_at": "2025-08-26T11:56:38.588836+02:00",
               "start_ip": "10.0.1.20",
               "end_ip": "10.0.1.30",
               "network": 3
@@ -10661,8 +10194,8 @@
           ],
           "policy": null,
           "communities": [],
-          "created_at": "2025-05-19T10:27:41.451087+02:00",
-          "updated_at": "2025-05-19T10:27:41.515781+02:00",
+          "created_at": "2025-08-26T11:56:38.384090+02:00",
+          "updated_at": "2025-08-26T11:56:38.446974+02:00",
           "network": "10.0.1.0/24",
           "description": "Frozzzen",
           "vlan": null,
@@ -10692,8 +10225,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-05-19T10:27:41.952174+02:00",
-              "updated_at": "2025-05-19T10:27:41.952184+02:00",
+              "created_at": "2025-08-26T11:56:38.799820+02:00",
+              "updated_at": "2025-08-26T11:56:38.799833+02:00",
               "ipaddress": "10.0.1.4",
               "host": 4
             }
@@ -10702,8 +10235,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-05-19T10:27:41.932232+02:00",
-              "updated_at": "2025-05-19T10:27:41.932237+02:00",
+              "created_at": "2025-08-26T11:56:38.772317+02:00",
+              "updated_at": "2025-08-26T11:56:38.772325+02:00",
               "txt": "v=spf1 -all",
               "host": 4
             }
@@ -10718,8 +10251,8 @@
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-05-19T10:27:41.930306+02:00",
-          "updated_at": "2025-05-19T10:27:41.930313+02:00",
+          "created_at": "2025-08-26T11:56:38.769930+02:00",
+          "updated_at": "2025-08-26T11:56:38.769945+02:00",
           "name": "somehost.example.org",
           "contact": "support@example.org",
           "ttl": null,
@@ -10735,8 +10268,8 @@
         "response": {
           "excluded_ranges": [
             {
-              "created_at": "2025-05-19T10:27:41.676748+02:00",
-              "updated_at": "2025-05-19T10:27:41.676760+02:00",
+              "created_at": "2025-08-26T11:56:38.588823+02:00",
+              "updated_at": "2025-08-26T11:56:38.588836+02:00",
               "start_ip": "10.0.1.20",
               "end_ip": "10.0.1.30",
               "network": 3
@@ -10744,8 +10277,8 @@
           ],
           "policy": null,
           "communities": [],
-          "created_at": "2025-05-19T10:27:41.451087+02:00",
-          "updated_at": "2025-05-19T10:27:41.515781+02:00",
+          "created_at": "2025-08-26T11:56:38.384090+02:00",
+          "updated_at": "2025-08-26T11:56:38.446974+02:00",
           "network": "10.0.1.0/24",
           "description": "Frozzzen",
           "vlan": null,
@@ -10834,35 +10367,6 @@
     "output": [],
     "api_requests": [
       {
-        "method": "GET",
-        "url": "/api/v1/networks/10.0.1.0/24",
-        "data": {},
-        "status": 200,
-        "response": {
-          "excluded_ranges": [
-            {
-              "created_at": "2025-03-19T10:10:44.935337+01:00",
-              "updated_at": "2025-03-19T10:10:44.935355+01:00",
-              "start_ip": "10.0.1.20",
-              "end_ip": "10.0.1.30",
-              "network": 3
-            }
-          ],
-          "policy": null,
-          "communities": [],
-          "created_at": "2025-03-19T10:10:44.688196+01:00",
-          "updated_at": "2025-03-19T10:10:44.766999+01:00",
-          "network": "10.0.1.0/24",
-          "description": "Frozzzen",
-          "vlan": null,
-          "dns_delegated": false,
-          "category": "",
-          "location": "",
-          "frozen": true,
-          "reserved": 3
-        }
-      },
-      {
         "method": "PATCH",
         "url": "/api/v1/networks/10.0.1.0/24",
         "data": {
@@ -10883,8 +10387,8 @@
             {
               "excluded_ranges": [
                 {
-                  "created_at": "2025-03-19T10:10:44.935337+01:00",
-                  "updated_at": "2025-03-19T10:10:44.935355+01:00",
+                  "created_at": "2025-08-26T11:56:38.588823+02:00",
+                  "updated_at": "2025-08-26T11:56:38.588836+02:00",
                   "start_ip": "10.0.1.20",
                   "end_ip": "10.0.1.30",
                   "network": 3
@@ -10892,8 +10396,8 @@
               ],
               "policy": null,
               "communities": [],
-              "created_at": "2025-03-19T10:10:44.688196+01:00",
-              "updated_at": "2025-03-19T10:10:45.413979+01:00",
+              "created_at": "2025-08-26T11:56:38.384090+02:00",
+              "updated_at": "2025-08-26T11:56:38.965659+02:00",
               "network": "10.0.1.0/24",
               "description": "Frozen but has one host",
               "vlan": null,
@@ -11657,86 +11161,6 @@
     "output": [],
     "api_requests": [
       {
-        "method": "GET",
-        "url": "/api/v1/hosts/somehost.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "",
-              "created_at": "2025-03-20T15:36:58.706620+01:00",
-              "updated_at": "2025-03-20T15:36:58.706626+01:00",
-              "ipaddress": "10.0.1.4",
-              "host": 4
-            }
-          ],
-          "cnames": [],
-          "mxs": [],
-          "txts": [
-            {
-              "created_at": "2025-03-20T15:36:58.692419+01:00",
-              "updated_at": "2025-03-20T15:36:58.692425+01:00",
-              "txt": "v=spf1 -all",
-              "host": 4
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "created_at": "2025-03-20T15:36:58.690682+01:00",
-          "updated_at": "2025-03-20T15:36:59.267728+01:00",
-          "name": "somehost.example.org",
-          "contact": "new-support@example.org",
-          "ttl": null,
-          "comment": "",
-          "zone": 1
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/10.0.1.0/24",
-        "data": {},
-        "status": 200,
-        "response": {
-          "excluded_ranges": [
-            {
-              "created_at": "2025-03-20T15:36:58.452833+01:00",
-              "updated_at": "2025-03-20T15:36:58.452841+01:00",
-              "start_ip": "10.0.1.20",
-              "end_ip": "10.0.1.30",
-              "network": 3
-            }
-          ],
-          "policy": null,
-          "communities": [],
-          "created_at": "2025-03-20T15:36:58.260675+01:00",
-          "updated_at": "2025-03-20T15:36:59.051810+01:00",
-          "network": "10.0.1.0/24",
-          "description": "Frozen but has one host",
-          "vlan": 1234,
-          "dns_delegated": false,
-          "category": "cat1",
-          "location": "loc1",
-          "frozen": true,
-          "reserved": 3
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/10.0.1.0/24/first_unused",
-        "data": {},
-        "status": 200,
-        "response": "10.0.1.5"
-      },
-      {
         "method": "POST",
         "url": "/api/v1/ipaddresses/",
         "data": {
@@ -11746,8 +11170,8 @@
         "status": 201,
         "response": {
           "macaddress": "",
-          "created_at": "2025-03-20T15:36:59.539135+01:00",
-          "updated_at": "2025-03-20T15:36:59.539141+01:00",
+          "created_at": "2025-08-26T11:56:39.688003+02:00",
+          "updated_at": "2025-08-26T11:56:39.688010+02:00",
           "ipaddress": "10.0.1.5",
           "host": 4
         }
@@ -11766,15 +11190,15 @@
               "ipaddresses": [
                 {
                   "macaddress": "",
-                  "created_at": "2025-03-20T15:36:58.706620+01:00",
-                  "updated_at": "2025-03-20T15:36:58.706626+01:00",
+                  "created_at": "2025-08-26T11:56:38.799820+02:00",
+                  "updated_at": "2025-08-26T11:56:38.799833+02:00",
                   "ipaddress": "10.0.1.4",
                   "host": 4
                 },
                 {
                   "macaddress": "",
-                  "created_at": "2025-03-20T15:36:59.539135+01:00",
-                  "updated_at": "2025-03-20T15:36:59.539141+01:00",
+                  "created_at": "2025-08-26T11:56:39.688003+02:00",
+                  "updated_at": "2025-08-26T11:56:39.688010+02:00",
                   "ipaddress": "10.0.1.5",
                   "host": 4
                 }
@@ -11783,8 +11207,8 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2025-03-20T15:36:58.692419+01:00",
-                  "updated_at": "2025-03-20T15:36:58.692425+01:00",
+                  "created_at": "2025-08-26T11:56:38.772317+02:00",
+                  "updated_at": "2025-08-26T11:56:38.772325+02:00",
                   "txt": "v=spf1 -all",
                   "host": 4
                 }
@@ -11799,8 +11223,8 @@
               "loc": null,
               "bacnetid": null,
               "communities": [],
-              "created_at": "2025-03-20T15:36:58.690682+01:00",
-              "updated_at": "2025-03-20T15:36:59.267728+01:00",
+              "created_at": "2025-08-26T11:56:38.769930+02:00",
+              "updated_at": "2025-08-26T11:56:39.434951+02:00",
               "name": "somehost.example.org",
               "contact": "new-support@example.org",
               "ttl": null,
@@ -11949,115 +11373,6 @@
     "error": [],
     "output": [],
     "api_requests": [
-      {
-        "method": "GET",
-        "url": "/api/v1/hosts/somehost.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "",
-              "created_at": "2025-03-20T15:36:58.706620+01:00",
-              "updated_at": "2025-03-20T15:36:58.706626+01:00",
-              "ipaddress": "10.0.1.4",
-              "host": 4
-            },
-            {
-              "macaddress": "",
-              "created_at": "2025-03-20T15:36:59.539135+01:00",
-              "updated_at": "2025-03-20T15:36:59.539141+01:00",
-              "ipaddress": "10.0.1.5",
-              "host": 4
-            }
-          ],
-          "cnames": [],
-          "mxs": [],
-          "txts": [
-            {
-              "created_at": "2025-03-20T15:36:58.692419+01:00",
-              "updated_at": "2025-03-20T15:36:58.692425+01:00",
-              "txt": "v=spf1 -all",
-              "host": 4
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "created_at": "2025-03-20T15:36:58.690682+01:00",
-          "updated_at": "2025-03-20T15:36:59.267728+01:00",
-          "name": "somehost.example.org",
-          "contact": "new-support@example.org",
-          "ttl": null,
-          "comment": "",
-          "zone": 1
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/ip/10.0.1.4",
-        "data": {},
-        "status": 200,
-        "response": {
-          "excluded_ranges": [
-            {
-              "created_at": "2025-03-20T15:36:58.452833+01:00",
-              "updated_at": "2025-03-20T15:36:58.452841+01:00",
-              "start_ip": "10.0.1.20",
-              "end_ip": "10.0.1.30",
-              "network": 3
-            }
-          ],
-          "policy": null,
-          "communities": [],
-          "created_at": "2025-03-20T15:36:58.260675+01:00",
-          "updated_at": "2025-03-20T15:36:59.051810+01:00",
-          "network": "10.0.1.0/24",
-          "description": "Frozen but has one host",
-          "vlan": 1234,
-          "dns_delegated": false,
-          "category": "cat1",
-          "location": "loc1",
-          "frozen": true,
-          "reserved": 3
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/ip/10.0.1.5",
-        "data": {},
-        "status": 200,
-        "response": {
-          "excluded_ranges": [
-            {
-              "created_at": "2025-03-20T15:36:58.452833+01:00",
-              "updated_at": "2025-03-20T15:36:58.452841+01:00",
-              "start_ip": "10.0.1.20",
-              "end_ip": "10.0.1.30",
-              "network": 3
-            }
-          ],
-          "policy": null,
-          "communities": [],
-          "created_at": "2025-03-20T15:36:58.260675+01:00",
-          "updated_at": "2025-03-20T15:36:59.051810+01:00",
-          "network": "10.0.1.0/24",
-          "description": "Frozen but has one host",
-          "vlan": 1234,
-          "dns_delegated": false,
-          "category": "cat1",
-          "location": "loc1",
-          "frozen": true,
-          "reserved": 3
-        }
-      },
       {
         "method": "DELETE",
         "url": "/api/v1/hosts/somehost.example.org",
@@ -12836,27 +12151,6 @@
     "output": [],
     "api_requests": [
       {
-        "method": "GET",
-        "url": "/api/v1/networks/2001%3Adb8%3A%3A/64",
-        "data": {},
-        "status": 200,
-        "response": {
-          "excluded_ranges": [],
-          "policy": null,
-          "communities": [],
-          "created_at": "2025-06-19T11:56:58.276297+02:00",
-          "updated_at": "2025-06-19T11:56:58.331422+02:00",
-          "network": "2001:db8::/64",
-          "description": "Lorem ipsum dolor sit amet",
-          "vlan": null,
-          "dns_delegated": false,
-          "category": "",
-          "location": "",
-          "frozen": true,
-          "reserved": 3
-        }
-      },
-      {
         "method": "POST",
         "url": "/api/v1/networks/2001%3Adb8%3A%3A/64/excluded_ranges/",
         "data": {
@@ -13013,72 +12307,10 @@
       "              2001:db8::4   <not set>   ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Thu Jun 19 11:56:58 2025",
-      "Updated:      Thu Jun 19 11:56:58 2025"
+      "Created:      Tue Aug 26 11:56:41 2025",
+      "Updated:      Tue Aug 26 11:56:41 2025"
     ],
     "api_requests": [
-      {
-        "method": "GET",
-        "url": "/api/v1/hosts/somehost.example.org",
-        "data": {},
-        "status": 404,
-        "response": {
-          "type": "client_error",
-          "errors": [
-            {
-              "code": "not_found",
-              "detail": "Not found.",
-              "attr": null
-            }
-          ]
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/cnames/somehost.example.org",
-        "data": {},
-        "status": 404,
-        "response": {
-          "type": "client_error",
-          "errors": [
-            {
-              "code": "not_found",
-              "detail": "Not found.",
-              "attr": null
-            }
-          ]
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/zones/forward/hostname/somehost.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "zone": {
-            "nameservers": [
-              {
-                "created_at": "2025-06-19T11:56:54.325815+02:00",
-                "updated_at": "2025-06-19T11:56:54.325829+02:00",
-                "name": "ns2.example.org",
-                "ttl": null
-              }
-            ],
-            "created_at": "2025-06-19T11:56:53.844130+02:00",
-            "updated_at": "2025-06-19T11:56:58.229983+02:00",
-            "updated": true,
-            "primary_ns": "ns2.example.org",
-            "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-06-19T11:56:54.386439+02:00",
-            "refresh": 360,
-            "retry": 1800,
-            "expire": 2400,
-            "soa_ttl": 1800,
-            "default_ttl": 300,
-            "name": "example.org"
-          }
-        }
-      },
       {
         "method": "GET",
         "url": "/api/v1/networks/2001%3Adb8%3A%3A/64",
@@ -13087,8 +12319,8 @@
         "response": {
           "excluded_ranges": [
             {
-              "created_at": "2025-06-19T11:56:58.463832+02:00",
-              "updated_at": "2025-06-19T11:56:58.463842+02:00",
+              "created_at": "2025-08-26T11:56:40.989836+02:00",
+              "updated_at": "2025-08-26T11:56:40.989850+02:00",
               "start_ip": "2001:db8::20",
               "end_ip": "2001:db8::30",
               "network": 4
@@ -13096,8 +12328,8 @@
           ],
           "policy": null,
           "communities": [],
-          "created_at": "2025-06-19T11:56:58.276297+02:00",
-          "updated_at": "2025-06-19T11:56:58.331422+02:00",
+          "created_at": "2025-08-26T11:56:40.636727+02:00",
+          "updated_at": "2025-08-26T11:56:40.699144+02:00",
           "network": "2001:db8::/64",
           "description": "Lorem ipsum dolor sit amet",
           "vlan": null,
@@ -13127,8 +12359,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-06-19T11:56:58.690703+02:00",
-              "updated_at": "2025-06-19T11:56:58.690711+02:00",
+              "created_at": "2025-08-26T11:56:41.212812+02:00",
+              "updated_at": "2025-08-26T11:56:41.212818+02:00",
               "ipaddress": "2001:db8::4",
               "host": 8
             }
@@ -13137,8 +12369,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-06-19T11:56:58.676157+02:00",
-              "updated_at": "2025-06-19T11:56:58.676163+02:00",
+              "created_at": "2025-08-26T11:56:41.197863+02:00",
+              "updated_at": "2025-08-26T11:56:41.197869+02:00",
               "txt": "v=spf1 -all",
               "host": 8
             }
@@ -13153,8 +12385,8 @@
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-06-19T11:56:58.674253+02:00",
-          "updated_at": "2025-06-19T11:56:58.674261+02:00",
+          "created_at": "2025-08-26T11:56:41.196169+02:00",
+          "updated_at": "2025-08-26T11:56:41.196176+02:00",
           "name": "somehost.example.org",
           "contact": "support@example.org",
           "ttl": null,
@@ -13170,8 +12402,8 @@
         "response": {
           "excluded_ranges": [
             {
-              "created_at": "2025-06-19T11:56:58.463832+02:00",
-              "updated_at": "2025-06-19T11:56:58.463842+02:00",
+              "created_at": "2025-08-26T11:56:40.989836+02:00",
+              "updated_at": "2025-08-26T11:56:40.989850+02:00",
               "start_ip": "2001:db8::20",
               "end_ip": "2001:db8::30",
               "network": 4
@@ -13179,8 +12411,8 @@
           ],
           "policy": null,
           "communities": [],
-          "created_at": "2025-06-19T11:56:58.276297+02:00",
-          "updated_at": "2025-06-19T11:56:58.331422+02:00",
+          "created_at": "2025-08-26T11:56:40.636727+02:00",
+          "updated_at": "2025-08-26T11:56:40.699144+02:00",
           "network": "2001:db8::/64",
           "description": "Lorem ipsum dolor sit amet",
           "vlan": null,
@@ -13392,8 +12624,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-06-19T11:56:58.690703+02:00",
-              "updated_at": "2025-06-19T11:56:58.690711+02:00",
+              "created_at": "2025-08-26T11:56:41.212812+02:00",
+              "updated_at": "2025-08-26T11:56:41.212818+02:00",
               "ipaddress": "2001:db8::4",
               "host": 8
             }
@@ -13402,8 +12634,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-06-19T11:56:58.676157+02:00",
-              "updated_at": "2025-06-19T11:56:58.676163+02:00",
+              "created_at": "2025-08-26T11:56:41.197863+02:00",
+              "updated_at": "2025-08-26T11:56:41.197869+02:00",
               "txt": "v=spf1 -all",
               "host": 8
             }
@@ -13418,42 +12650,13 @@
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-06-19T11:56:58.674253+02:00",
-          "updated_at": "2025-06-19T11:56:58.674261+02:00",
+          "created_at": "2025-08-26T11:56:41.196169+02:00",
+          "updated_at": "2025-08-26T11:56:41.196176+02:00",
           "name": "somehost.example.org",
           "contact": "support@example.org",
           "ttl": null,
           "comment": "",
           "zone": 1
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/2001%3Adb8%3A%3A/64",
-        "data": {},
-        "status": 200,
-        "response": {
-          "excluded_ranges": [
-            {
-              "created_at": "2025-06-19T11:56:58.463832+02:00",
-              "updated_at": "2025-06-19T11:56:58.463842+02:00",
-              "start_ip": "2001:db8::20",
-              "end_ip": "2001:db8::30",
-              "network": 4
-            }
-          ],
-          "policy": null,
-          "communities": [],
-          "created_at": "2025-06-19T11:56:58.276297+02:00",
-          "updated_at": "2025-06-19T11:56:58.779271+02:00",
-          "network": "2001:db8::/64",
-          "description": "Frozen but has one host",
-          "vlan": null,
-          "dns_delegated": false,
-          "category": "",
-          "location": "",
-          "frozen": true,
-          "reserved": 3
         }
       },
       {
@@ -13479,86 +12682,6 @@
     "output": [],
     "api_requests": [
       {
-        "method": "GET",
-        "url": "/api/v1/hosts/somehost.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "",
-              "created_at": "2025-06-19T11:56:58.690703+02:00",
-              "updated_at": "2025-06-19T11:56:58.690711+02:00",
-              "ipaddress": "2001:db8::4",
-              "host": 8
-            }
-          ],
-          "cnames": [],
-          "mxs": [],
-          "txts": [
-            {
-              "created_at": "2025-06-19T11:56:58.676157+02:00",
-              "updated_at": "2025-06-19T11:56:58.676163+02:00",
-              "txt": "v=spf1 -all",
-              "host": 8
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "created_at": "2025-06-19T11:56:58.674253+02:00",
-          "updated_at": "2025-06-19T11:56:58.674261+02:00",
-          "name": "somehost.example.org",
-          "contact": "support@example.org",
-          "ttl": null,
-          "comment": "",
-          "zone": 1
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/2001%3Adb8%3A%3A/64",
-        "data": {},
-        "status": 200,
-        "response": {
-          "excluded_ranges": [
-            {
-              "created_at": "2025-06-19T11:56:58.463832+02:00",
-              "updated_at": "2025-06-19T11:56:58.463842+02:00",
-              "start_ip": "2001:db8::20",
-              "end_ip": "2001:db8::30",
-              "network": 4
-            }
-          ],
-          "policy": null,
-          "communities": [],
-          "created_at": "2025-06-19T11:56:58.276297+02:00",
-          "updated_at": "2025-06-19T11:56:58.779271+02:00",
-          "network": "2001:db8::/64",
-          "description": "Frozen but has one host",
-          "vlan": null,
-          "dns_delegated": false,
-          "category": "",
-          "location": "",
-          "frozen": true,
-          "reserved": 3
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/2001%3Adb8%3A%3A/64/first_unused",
-        "data": {},
-        "status": 200,
-        "response": "2001:db8::5"
-      },
-      {
         "method": "POST",
         "url": "/api/v1/ipaddresses/",
         "data": {
@@ -13568,8 +12691,8 @@
         "status": 201,
         "response": {
           "macaddress": "",
-          "created_at": "2025-06-19T11:56:59.025456+02:00",
-          "updated_at": "2025-06-19T11:56:59.025461+02:00",
+          "created_at": "2025-08-26T11:56:41.500616+02:00",
+          "updated_at": "2025-08-26T11:56:41.500623+02:00",
           "ipaddress": "2001:db8::5",
           "host": 8
         }
@@ -13588,15 +12711,15 @@
               "ipaddresses": [
                 {
                   "macaddress": "",
-                  "created_at": "2025-06-19T11:56:58.690703+02:00",
-                  "updated_at": "2025-06-19T11:56:58.690711+02:00",
+                  "created_at": "2025-08-26T11:56:41.212812+02:00",
+                  "updated_at": "2025-08-26T11:56:41.212818+02:00",
                   "ipaddress": "2001:db8::4",
                   "host": 8
                 },
                 {
                   "macaddress": "",
-                  "created_at": "2025-06-19T11:56:59.025456+02:00",
-                  "updated_at": "2025-06-19T11:56:59.025461+02:00",
+                  "created_at": "2025-08-26T11:56:41.500616+02:00",
+                  "updated_at": "2025-08-26T11:56:41.500623+02:00",
                   "ipaddress": "2001:db8::5",
                   "host": 8
                 }
@@ -13605,8 +12728,8 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2025-06-19T11:56:58.676157+02:00",
-                  "updated_at": "2025-06-19T11:56:58.676163+02:00",
+                  "created_at": "2025-08-26T11:56:41.197863+02:00",
+                  "updated_at": "2025-08-26T11:56:41.197869+02:00",
                   "txt": "v=spf1 -all",
                   "host": 8
                 }
@@ -13621,8 +12744,8 @@
               "loc": null,
               "bacnetid": null,
               "communities": [],
-              "created_at": "2025-06-19T11:56:58.674253+02:00",
-              "updated_at": "2025-06-19T11:56:58.674261+02:00",
+              "created_at": "2025-08-26T11:56:41.196169+02:00",
+              "updated_at": "2025-08-26T11:56:41.196176+02:00",
               "name": "somehost.example.org",
               "contact": "support@example.org",
               "ttl": null,
@@ -14067,63 +13190,6 @@
     "output": [],
     "api_requests": [
       {
-        "method": "GET",
-        "url": "/api/v1/hosts/somehost.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [],
-          "cnames": [],
-          "mxs": [],
-          "txts": [
-            {
-              "created_at": "2025-06-19T11:56:59.536346+02:00",
-              "updated_at": "2025-06-19T11:56:59.536355+02:00",
-              "txt": "v=spf1 -all",
-              "host": 9
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "created_at": "2025-06-19T11:56:59.534175+02:00",
-          "updated_at": "2025-06-19T11:56:59.534182+02:00",
-          "name": "somehost.example.org",
-          "contact": "support@example.org",
-          "ttl": null,
-          "comment": "",
-          "zone": 1
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/ip/10.0.1.0",
-        "data": {},
-        "status": 200,
-        "response": {
-          "excluded_ranges": [],
-          "policy": null,
-          "communities": [],
-          "created_at": "2025-06-19T11:56:56.238306+02:00",
-          "updated_at": "2025-06-19T11:56:57.831469+02:00",
-          "network": "10.0.1.0/24",
-          "description": "Frozen but has one host",
-          "vlan": 1234,
-          "dns_delegated": false,
-          "category": "cat1",
-          "location": "loc1",
-          "frozen": false,
-          "reserved": 3
-        }
-      },
-      {
         "method": "POST",
         "url": "/api/v1/ipaddresses/",
         "data": {
@@ -14133,8 +13199,8 @@
         "status": 201,
         "response": {
           "macaddress": "",
-          "created_at": "2025-06-19T11:56:59.691204+02:00",
-          "updated_at": "2025-06-19T11:56:59.691210+02:00",
+          "created_at": "2025-08-26T11:56:41.993992+02:00",
+          "updated_at": "2025-08-26T11:56:41.993997+02:00",
           "ipaddress": "10.0.1.0",
           "host": 9
         }
@@ -14153,8 +13219,8 @@
               "ipaddresses": [
                 {
                   "macaddress": "",
-                  "created_at": "2025-06-19T11:56:59.691204+02:00",
-                  "updated_at": "2025-06-19T11:56:59.691210+02:00",
+                  "created_at": "2025-08-26T11:56:41.993992+02:00",
+                  "updated_at": "2025-08-26T11:56:41.993997+02:00",
                   "ipaddress": "10.0.1.0",
                   "host": 9
                 }
@@ -14163,8 +13229,8 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2025-06-19T11:56:59.536346+02:00",
-                  "updated_at": "2025-06-19T11:56:59.536355+02:00",
+                  "created_at": "2025-08-26T11:56:41.884045+02:00",
+                  "updated_at": "2025-08-26T11:56:41.884052+02:00",
                   "txt": "v=spf1 -all",
                   "host": 9
                 }
@@ -14179,8 +13245,8 @@
               "loc": null,
               "bacnetid": null,
               "communities": [],
-              "created_at": "2025-06-19T11:56:59.534175+02:00",
-              "updated_at": "2025-06-19T11:56:59.534182+02:00",
+              "created_at": "2025-08-26T11:56:41.882174+02:00",
+              "updated_at": "2025-08-26T11:56:41.882182+02:00",
               "name": "somehost.example.org",
               "contact": "support@example.org",
               "ttl": null,
@@ -14343,63 +13409,6 @@
     "output": [],
     "api_requests": [
       {
-        "method": "GET",
-        "url": "/api/v1/hosts/somehost.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [],
-          "cnames": [],
-          "mxs": [],
-          "txts": [
-            {
-              "created_at": "2025-06-19T11:56:59.536346+02:00",
-              "updated_at": "2025-06-19T11:56:59.536355+02:00",
-              "txt": "v=spf1 -all",
-              "host": 9
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "created_at": "2025-06-19T11:56:59.534175+02:00",
-          "updated_at": "2025-06-19T11:56:59.534182+02:00",
-          "name": "somehost.example.org",
-          "contact": "support@example.org",
-          "ttl": null,
-          "comment": "",
-          "zone": 1
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/ip/10.0.1.255",
-        "data": {},
-        "status": 200,
-        "response": {
-          "excluded_ranges": [],
-          "policy": null,
-          "communities": [],
-          "created_at": "2025-06-19T11:56:56.238306+02:00",
-          "updated_at": "2025-06-19T11:56:57.831469+02:00",
-          "network": "10.0.1.0/24",
-          "description": "Frozen but has one host",
-          "vlan": 1234,
-          "dns_delegated": false,
-          "category": "cat1",
-          "location": "loc1",
-          "frozen": false,
-          "reserved": 3
-        }
-      },
-      {
         "method": "POST",
         "url": "/api/v1/ipaddresses/",
         "data": {
@@ -14409,8 +13418,8 @@
         "status": 201,
         "response": {
           "macaddress": "",
-          "created_at": "2025-06-19T11:56:59.904596+02:00",
-          "updated_at": "2025-06-19T11:56:59.904601+02:00",
+          "created_at": "2025-08-26T11:56:42.223919+02:00",
+          "updated_at": "2025-08-26T11:56:42.223938+02:00",
           "ipaddress": "10.0.1.255",
           "host": 9
         }
@@ -14429,8 +13438,8 @@
               "ipaddresses": [
                 {
                   "macaddress": "",
-                  "created_at": "2025-06-19T11:56:59.904596+02:00",
-                  "updated_at": "2025-06-19T11:56:59.904601+02:00",
+                  "created_at": "2025-08-26T11:56:42.223919+02:00",
+                  "updated_at": "2025-08-26T11:56:42.223938+02:00",
                   "ipaddress": "10.0.1.255",
                   "host": 9
                 }
@@ -14439,8 +13448,8 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2025-06-19T11:56:59.536346+02:00",
-                  "updated_at": "2025-06-19T11:56:59.536355+02:00",
+                  "created_at": "2025-08-26T11:56:41.884045+02:00",
+                  "updated_at": "2025-08-26T11:56:41.884052+02:00",
                   "txt": "v=spf1 -all",
                   "host": 9
                 }
@@ -14455,8 +13464,8 @@
               "loc": null,
               "bacnetid": null,
               "communities": [],
-              "created_at": "2025-06-19T11:56:59.534175+02:00",
-              "updated_at": "2025-06-19T11:56:59.534182+02:00",
+              "created_at": "2025-08-26T11:56:41.882174+02:00",
+              "updated_at": "2025-08-26T11:56:41.882182+02:00",
               "name": "somehost.example.org",
               "contact": "support@example.org",
               "ttl": null,
@@ -14562,71 +13571,6 @@
     "output": [],
     "api_requests": [
       {
-        "method": "GET",
-        "url": "/api/v1/networks/ip/10.0.1.0",
-        "data": {},
-        "status": 200,
-        "response": {
-          "excluded_ranges": [],
-          "policy": null,
-          "communities": [],
-          "created_at": "2025-06-20T11:43:10.897148+02:00",
-          "updated_at": "2025-06-20T11:43:12.833706+02:00",
-          "network": "10.0.1.0/24",
-          "description": "Frozen but has one host",
-          "vlan": 1234,
-          "dns_delegated": false,
-          "category": "cat1",
-          "location": "loc1",
-          "frozen": false,
-          "reserved": 3
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hosts/somehost.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "",
-              "created_at": "2025-06-20T11:43:15.678831+02:00",
-              "updated_at": "2025-06-20T11:43:15.678840+02:00",
-              "ipaddress": "10.0.1.255",
-              "host": 9
-            }
-          ],
-          "cnames": [],
-          "mxs": [],
-          "txts": [
-            {
-              "created_at": "2025-06-20T11:43:14.707352+02:00",
-              "updated_at": "2025-06-20T11:43:14.707360+02:00",
-              "txt": "v=spf1 -all",
-              "host": 9
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "created_at": "2025-06-20T11:43:14.704872+02:00",
-          "updated_at": "2025-06-20T11:43:14.704882+02:00",
-          "name": "somehost.example.org",
-          "contact": "support@example.org",
-          "ttl": null,
-          "comment": "",
-          "zone": 1
-        }
-      },
-      {
         "method": "PATCH",
         "url": "/api/v1/ipaddresses/9",
         "data": {
@@ -14641,8 +13585,8 @@
         "status": 200,
         "response": {
           "macaddress": "",
-          "created_at": "2025-06-20T11:43:15.678831+02:00",
-          "updated_at": "2025-06-20T11:43:16.065860+02:00",
+          "created_at": "2025-08-26T11:56:42.223919+02:00",
+          "updated_at": "2025-08-26T11:56:42.368461+02:00",
           "ipaddress": "10.0.1.0",
           "host": 9
         }
@@ -14831,72 +13775,10 @@
       "              10.0.1.1   <not set>   ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Thu Jun 19 12:49:24 2025",
-      "Updated:      Thu Jun 19 12:49:24 2025"
+      "Created:      Tue Aug 26 11:56:42 2025",
+      "Updated:      Tue Aug 26 11:56:42 2025"
     ],
     "api_requests": [
-      {
-        "method": "GET",
-        "url": "/api/v1/hosts/somehost.example.org",
-        "data": {},
-        "status": 404,
-        "response": {
-          "type": "client_error",
-          "errors": [
-            {
-              "code": "not_found",
-              "detail": "Not found.",
-              "attr": null
-            }
-          ]
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/cnames/somehost.example.org",
-        "data": {},
-        "status": 404,
-        "response": {
-          "type": "client_error",
-          "errors": [
-            {
-              "code": "not_found",
-              "detail": "Not found.",
-              "attr": null
-            }
-          ]
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/zones/forward/hostname/somehost.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "zone": {
-            "nameservers": [
-              {
-                "created_at": "2025-06-19T12:49:17.978940+02:00",
-                "updated_at": "2025-06-19T12:49:17.978953+02:00",
-                "name": "ns2.example.org",
-                "ttl": null
-              }
-            ],
-            "created_at": "2025-06-19T12:49:17.403500+02:00",
-            "updated_at": "2025-06-19T12:49:24.244041+02:00",
-            "updated": true,
-            "primary_ns": "ns2.example.org",
-            "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-06-19T12:49:18.049890+02:00",
-            "refresh": 360,
-            "retry": 1800,
-            "expire": 2400,
-            "soa_ttl": 1800,
-            "default_ttl": 300,
-            "name": "example.org"
-          }
-        }
-      },
       {
         "method": "GET",
         "url": "/api/v1/networks/ip/10.0.1.1",
@@ -14906,8 +13788,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-06-19T12:49:20.307109+02:00",
-          "updated_at": "2025-06-19T12:49:21.946774+02:00",
+          "created_at": "2025-08-26T11:56:38.384090+02:00",
+          "updated_at": "2025-08-26T11:56:40.079937+02:00",
           "network": "10.0.1.0/24",
           "description": "Frozen but has one host",
           "vlan": 1234,
@@ -14936,8 +13818,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-06-19T12:49:24.428104+02:00",
-              "updated_at": "2025-06-19T12:49:24.428109+02:00",
+              "created_at": "2025-08-26T11:56:42.628635+02:00",
+              "updated_at": "2025-08-26T11:56:42.628641+02:00",
               "ipaddress": "10.0.1.1",
               "host": 10
             }
@@ -14946,8 +13828,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-06-19T12:49:24.413311+02:00",
-              "updated_at": "2025-06-19T12:49:24.413316+02:00",
+              "created_at": "2025-08-26T11:56:42.613402+02:00",
+              "updated_at": "2025-08-26T11:56:42.613407+02:00",
               "txt": "v=spf1 -all",
               "host": 10
             }
@@ -14962,8 +13844,8 @@
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-06-19T12:49:24.411364+02:00",
-          "updated_at": "2025-06-19T12:49:24.411372+02:00",
+          "created_at": "2025-08-26T11:56:42.611708+02:00",
+          "updated_at": "2025-08-26T11:56:42.611715+02:00",
           "name": "somehost.example.org",
           "contact": "",
           "ttl": null,
@@ -14980,8 +13862,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-06-19T12:49:20.307109+02:00",
-          "updated_at": "2025-06-19T12:49:21.946774+02:00",
+          "created_at": "2025-08-26T11:56:38.384090+02:00",
+          "updated_at": "2025-08-26T11:56:40.079937+02:00",
           "network": "10.0.1.0/24",
           "description": "Frozen but has one host",
           "vlan": 1234,
@@ -15176,93 +14058,10 @@
       "              10.0.1.255   <not set>   ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Thu Jun 19 13:04:10 2025",
-      "Updated:      Thu Jun 19 13:04:10 2025"
+      "Created:      Tue Aug 26 11:56:42 2025",
+      "Updated:      Tue Aug 26 11:56:42 2025"
     ],
     "api_requests": [
-      {
-        "method": "GET",
-        "url": "/api/v1/hosts/somehost.example.org",
-        "data": {},
-        "status": 404,
-        "response": {
-          "type": "client_error",
-          "errors": [
-            {
-              "code": "not_found",
-              "detail": "Not found.",
-              "attr": null
-            }
-          ]
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/cnames/somehost.example.org",
-        "data": {},
-        "status": 404,
-        "response": {
-          "type": "client_error",
-          "errors": [
-            {
-              "code": "not_found",
-              "detail": "Not found.",
-              "attr": null
-            }
-          ]
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/zones/forward/hostname/somehost.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "zone": {
-            "nameservers": [
-              {
-                "created_at": "2025-06-19T13:04:03.806300+02:00",
-                "updated_at": "2025-06-19T13:04:03.806309+02:00",
-                "name": "ns2.example.org",
-                "ttl": null
-              }
-            ],
-            "created_at": "2025-06-19T13:04:03.507442+02:00",
-            "updated_at": "2025-06-19T13:04:10.613583+02:00",
-            "updated": true,
-            "primary_ns": "ns2.example.org",
-            "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-06-19T13:04:03.847616+02:00",
-            "refresh": 360,
-            "retry": 1800,
-            "expire": 2400,
-            "soa_ttl": 1800,
-            "default_ttl": 300,
-            "name": "example.org"
-          }
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/ip/10.0.1.255",
-        "data": {},
-        "status": 200,
-        "response": {
-          "excluded_ranges": [],
-          "policy": null,
-          "communities": [],
-          "created_at": "2025-06-19T13:04:05.973393+02:00",
-          "updated_at": "2025-06-19T13:04:07.988169+02:00",
-          "network": "10.0.1.0/24",
-          "description": "Frozen but has one host",
-          "vlan": 1234,
-          "dns_delegated": false,
-          "category": "cat1",
-          "location": "loc1",
-          "frozen": false,
-          "reserved": 3
-        }
-      },
       {
         "method": "POST",
         "url": "/api/v1/hosts/",
@@ -15281,8 +14080,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-06-19T13:04:10.789777+02:00",
-              "updated_at": "2025-06-19T13:04:10.789782+02:00",
+              "created_at": "2025-08-26T11:56:42.881768+02:00",
+              "updated_at": "2025-08-26T11:56:42.881777+02:00",
               "ipaddress": "10.0.1.255",
               "host": 11
             }
@@ -15291,8 +14090,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-06-19T13:04:10.775997+02:00",
-              "updated_at": "2025-06-19T13:04:10.776003+02:00",
+              "created_at": "2025-08-26T11:56:42.862300+02:00",
+              "updated_at": "2025-08-26T11:56:42.862307+02:00",
               "txt": "v=spf1 -all",
               "host": 11
             }
@@ -15307,8 +14106,8 @@
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-06-19T13:04:10.774404+02:00",
-          "updated_at": "2025-06-19T13:04:10.774412+02:00",
+          "created_at": "2025-08-26T11:56:42.859916+02:00",
+          "updated_at": "2025-08-26T11:56:42.859925+02:00",
           "name": "somehost.example.org",
           "contact": "",
           "ttl": null,
@@ -15325,8 +14124,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-06-19T13:04:05.973393+02:00",
-          "updated_at": "2025-06-19T13:04:07.988169+02:00",
+          "created_at": "2025-08-26T11:56:38.384090+02:00",
+          "updated_at": "2025-08-26T11:56:40.079937+02:00",
           "network": "10.0.1.0/24",
           "description": "Frozen but has one host",
           "vlan": 1234,
@@ -15498,71 +14297,6 @@
     "output": [],
     "api_requests": [
       {
-        "method": "GET",
-        "url": "/api/v1/hosts/somehost.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [],
-          "cnames": [],
-          "mxs": [],
-          "txts": [
-            {
-              "created_at": "2025-06-19T13:42:10.106647+02:00",
-              "updated_at": "2025-06-19T13:42:10.106653+02:00",
-              "txt": "v=spf1 -all",
-              "host": 11
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "created_at": "2025-06-19T13:42:10.104606+02:00",
-          "updated_at": "2025-06-19T13:42:10.104613+02:00",
-          "name": "somehost.example.org",
-          "contact": "",
-          "ttl": null,
-          "comment": "",
-          "zone": 1
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/ip/2001%3Adb8%3A%3A",
-        "data": {},
-        "status": 200,
-        "response": {
-          "excluded_ranges": [
-            {
-              "created_at": "2025-06-19T13:42:08.147979+02:00",
-              "updated_at": "2025-06-19T13:42:08.147988+02:00",
-              "start_ip": "2001:db8::20",
-              "end_ip": "2001:db8::30",
-              "network": 4
-            }
-          ],
-          "policy": null,
-          "communities": [],
-          "created_at": "2025-06-19T13:42:07.836969+02:00",
-          "updated_at": "2025-06-19T13:42:08.906149+02:00",
-          "network": "2001:db8::/64",
-          "description": "Frozen but has one host",
-          "vlan": null,
-          "dns_delegated": false,
-          "category": "",
-          "location": "",
-          "frozen": false,
-          "reserved": 3
-        }
-      },
-      {
         "method": "POST",
         "url": "/api/v1/ipaddresses/",
         "data": {
@@ -15572,8 +14306,8 @@
         "status": 201,
         "response": {
           "macaddress": "",
-          "created_at": "2025-06-19T13:42:10.331837+02:00",
-          "updated_at": "2025-06-19T13:42:10.331843+02:00",
+          "created_at": "2025-08-26T11:56:43.088591+02:00",
+          "updated_at": "2025-08-26T11:56:43.088600+02:00",
           "ipaddress": "2001:db8::",
           "host": 11
         }
@@ -15592,8 +14326,8 @@
               "ipaddresses": [
                 {
                   "macaddress": "",
-                  "created_at": "2025-06-19T13:42:10.331837+02:00",
-                  "updated_at": "2025-06-19T13:42:10.331843+02:00",
+                  "created_at": "2025-08-26T11:56:43.088591+02:00",
+                  "updated_at": "2025-08-26T11:56:43.088600+02:00",
                   "ipaddress": "2001:db8::",
                   "host": 11
                 }
@@ -15602,8 +14336,8 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2025-06-19T13:42:10.106647+02:00",
-                  "updated_at": "2025-06-19T13:42:10.106653+02:00",
+                  "created_at": "2025-08-26T11:56:42.862300+02:00",
+                  "updated_at": "2025-08-26T11:56:42.862307+02:00",
                   "txt": "v=spf1 -all",
                   "host": 11
                 }
@@ -15618,8 +14352,8 @@
               "loc": null,
               "bacnetid": null,
               "communities": [],
-              "created_at": "2025-06-19T13:42:10.104606+02:00",
-              "updated_at": "2025-06-19T13:42:10.104613+02:00",
+              "created_at": "2025-08-26T11:56:42.859916+02:00",
+              "updated_at": "2025-08-26T11:56:42.859925+02:00",
               "name": "somehost.example.org",
               "contact": "",
               "ttl": null,
@@ -15790,71 +14524,6 @@
     "output": [],
     "api_requests": [
       {
-        "method": "GET",
-        "url": "/api/v1/hosts/somehost.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [],
-          "cnames": [],
-          "mxs": [],
-          "txts": [
-            {
-              "created_at": "2025-06-19T13:42:10.106647+02:00",
-              "updated_at": "2025-06-19T13:42:10.106653+02:00",
-              "txt": "v=spf1 -all",
-              "host": 11
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "created_at": "2025-06-19T13:42:10.104606+02:00",
-          "updated_at": "2025-06-19T13:42:10.104613+02:00",
-          "name": "somehost.example.org",
-          "contact": "",
-          "ttl": null,
-          "comment": "",
-          "zone": 1
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/ip/2001%3Adb8%3A%3Affff%3Affff%3Affff%3Affff",
-        "data": {},
-        "status": 200,
-        "response": {
-          "excluded_ranges": [
-            {
-              "created_at": "2025-06-19T13:42:08.147979+02:00",
-              "updated_at": "2025-06-19T13:42:08.147988+02:00",
-              "start_ip": "2001:db8::20",
-              "end_ip": "2001:db8::30",
-              "network": 4
-            }
-          ],
-          "policy": null,
-          "communities": [],
-          "created_at": "2025-06-19T13:42:07.836969+02:00",
-          "updated_at": "2025-06-19T13:42:08.906149+02:00",
-          "network": "2001:db8::/64",
-          "description": "Frozen but has one host",
-          "vlan": null,
-          "dns_delegated": false,
-          "category": "",
-          "location": "",
-          "frozen": false,
-          "reserved": 3
-        }
-      },
-      {
         "method": "POST",
         "url": "/api/v1/ipaddresses/",
         "data": {
@@ -15864,8 +14533,8 @@
         "status": 201,
         "response": {
           "macaddress": "",
-          "created_at": "2025-06-19T13:42:10.549776+02:00",
-          "updated_at": "2025-06-19T13:42:10.549783+02:00",
+          "created_at": "2025-08-26T11:56:43.293421+02:00",
+          "updated_at": "2025-08-26T11:56:43.293428+02:00",
           "ipaddress": "2001:db8::ffff:ffff:ffff:ffff",
           "host": 11
         }
@@ -15884,8 +14553,8 @@
               "ipaddresses": [
                 {
                   "macaddress": "",
-                  "created_at": "2025-06-19T13:42:10.549776+02:00",
-                  "updated_at": "2025-06-19T13:42:10.549783+02:00",
+                  "created_at": "2025-08-26T11:56:43.293421+02:00",
+                  "updated_at": "2025-08-26T11:56:43.293428+02:00",
                   "ipaddress": "2001:db8::ffff:ffff:ffff:ffff",
                   "host": 11
                 }
@@ -15894,8 +14563,8 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2025-06-19T13:42:10.106647+02:00",
-                  "updated_at": "2025-06-19T13:42:10.106653+02:00",
+                  "created_at": "2025-08-26T11:56:42.862300+02:00",
+                  "updated_at": "2025-08-26T11:56:42.862307+02:00",
                   "txt": "v=spf1 -all",
                   "host": 11
                 }
@@ -15910,8 +14579,8 @@
               "loc": null,
               "bacnetid": null,
               "communities": [],
-              "created_at": "2025-06-19T13:42:10.104606+02:00",
-              "updated_at": "2025-06-19T13:42:10.104613+02:00",
+              "created_at": "2025-08-26T11:56:42.859916+02:00",
+              "updated_at": "2025-08-26T11:56:42.859925+02:00",
               "name": "somehost.example.org",
               "contact": "",
               "ttl": null,
@@ -16025,79 +14694,6 @@
     "output": [],
     "api_requests": [
       {
-        "method": "GET",
-        "url": "/api/v1/networks/ip/2001%3Adb8%3A%3A",
-        "data": {},
-        "status": 200,
-        "response": {
-          "excluded_ranges": [
-            {
-              "created_at": "2025-06-20T11:43:13.637366+02:00",
-              "updated_at": "2025-06-20T11:43:13.637380+02:00",
-              "start_ip": "2001:db8::20",
-              "end_ip": "2001:db8::30",
-              "network": 4
-            }
-          ],
-          "policy": null,
-          "communities": [],
-          "created_at": "2025-06-20T11:43:13.395028+02:00",
-          "updated_at": "2025-06-20T11:43:14.560692+02:00",
-          "network": "2001:db8::/64",
-          "description": "Frozen but has one host",
-          "vlan": null,
-          "dns_delegated": false,
-          "category": "",
-          "location": "",
-          "frozen": false,
-          "reserved": 3
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hosts/somehost.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "",
-              "created_at": "2025-06-20T11:43:17.529248+02:00",
-              "updated_at": "2025-06-20T11:43:17.529255+02:00",
-              "ipaddress": "2001:db8::ffff:ffff:ffff:ffff",
-              "host": 11
-            }
-          ],
-          "cnames": [],
-          "mxs": [],
-          "txts": [
-            {
-              "created_at": "2025-06-20T11:43:16.941149+02:00",
-              "updated_at": "2025-06-20T11:43:16.941159+02:00",
-              "txt": "v=spf1 -all",
-              "host": 11
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "created_at": "2025-06-20T11:43:16.931464+02:00",
-          "updated_at": "2025-06-20T11:43:16.931486+02:00",
-          "name": "somehost.example.org",
-          "contact": "",
-          "ttl": null,
-          "comment": "",
-          "zone": 1
-        }
-      },
-      {
         "method": "PATCH",
         "url": "/api/v1/ipaddresses/13",
         "data": {
@@ -16112,8 +14708,8 @@
         "status": 200,
         "response": {
           "macaddress": "",
-          "created_at": "2025-06-20T11:43:17.529248+02:00",
-          "updated_at": "2025-06-20T11:43:17.743446+02:00",
+          "created_at": "2025-08-26T11:56:43.293421+02:00",
+          "updated_at": "2025-08-26T11:56:43.429354+02:00",
           "ipaddress": "2001:db8::",
           "host": 11
         }
@@ -16192,50 +14788,6 @@
     "error": [],
     "output": [],
     "api_requests": [
-      {
-        "method": "GET",
-        "url": "/api/v1/hosts/somehost.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "",
-              "created_at": "2025-06-19T13:42:10.549776+02:00",
-              "updated_at": "2025-06-19T13:42:10.967604+02:00",
-              "ipaddress": "2001:db8::",
-              "host": 11
-            }
-          ],
-          "cnames": [],
-          "mxs": [],
-          "txts": [
-            {
-              "created_at": "2025-06-19T13:42:10.106647+02:00",
-              "updated_at": "2025-06-19T13:42:10.106653+02:00",
-              "txt": "v=spf1 -all",
-              "host": 11
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "created_at": "2025-06-19T13:42:10.104606+02:00",
-          "updated_at": "2025-06-19T13:42:10.104613+02:00",
-          "name": "somehost.example.org",
-          "contact": "",
-          "ttl": null,
-          "comment": "",
-          "zone": 1
-        }
-      },
       {
         "method": "DELETE",
         "url": "/api/v1/hosts/somehost.example.org",
@@ -16361,72 +14913,10 @@
       "              10.0.1.1   <not set>   ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Thu Jun 19 13:04:11 2025",
-      "Updated:      Thu Jun 19 13:04:11 2025"
+      "Created:      Tue Aug 26 11:56:43 2025",
+      "Updated:      Tue Aug 26 11:56:43 2025"
     ],
     "api_requests": [
-      {
-        "method": "GET",
-        "url": "/api/v1/hosts/somehost.example.org",
-        "data": {},
-        "status": 404,
-        "response": {
-          "type": "client_error",
-          "errors": [
-            {
-              "code": "not_found",
-              "detail": "Not found.",
-              "attr": null
-            }
-          ]
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/cnames/somehost.example.org",
-        "data": {},
-        "status": 404,
-        "response": {
-          "type": "client_error",
-          "errors": [
-            {
-              "code": "not_found",
-              "detail": "Not found.",
-              "attr": null
-            }
-          ]
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/zones/forward/hostname/somehost.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "zone": {
-            "nameservers": [
-              {
-                "created_at": "2025-06-19T13:04:03.806300+02:00",
-                "updated_at": "2025-06-19T13:04:03.806309+02:00",
-                "name": "ns2.example.org",
-                "ttl": null
-              }
-            ],
-            "created_at": "2025-06-19T13:04:03.507442+02:00",
-            "updated_at": "2025-06-19T13:04:11.532322+02:00",
-            "updated": true,
-            "primary_ns": "ns2.example.org",
-            "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-06-19T13:04:03.847616+02:00",
-            "refresh": 360,
-            "retry": 1800,
-            "expire": 2400,
-            "soa_ttl": 1800,
-            "default_ttl": 300,
-            "name": "example.org"
-          }
-        }
-      },
       {
         "method": "GET",
         "url": "/api/v1/networks/ip/10.0.1.1",
@@ -16436,8 +14926,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-06-19T13:04:05.973393+02:00",
-          "updated_at": "2025-06-19T13:04:07.988169+02:00",
+          "created_at": "2025-08-26T11:56:38.384090+02:00",
+          "updated_at": "2025-08-26T11:56:40.079937+02:00",
           "network": "10.0.1.0/24",
           "description": "Frozen but has one host",
           "vlan": 1234,
@@ -16466,8 +14956,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-06-19T13:04:11.710063+02:00",
-              "updated_at": "2025-06-19T13:04:11.710069+02:00",
+              "created_at": "2025-08-26T11:56:43.663246+02:00",
+              "updated_at": "2025-08-26T11:56:43.663255+02:00",
               "ipaddress": "10.0.1.1",
               "host": 12
             }
@@ -16476,8 +14966,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-06-19T13:04:11.696356+02:00",
-              "updated_at": "2025-06-19T13:04:11.696362+02:00",
+              "created_at": "2025-08-26T11:56:43.648168+02:00",
+              "updated_at": "2025-08-26T11:56:43.648174+02:00",
               "txt": "v=spf1 -all",
               "host": 12
             }
@@ -16492,8 +14982,8 @@
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-06-19T13:04:11.694840+02:00",
-          "updated_at": "2025-06-19T13:04:11.694847+02:00",
+          "created_at": "2025-08-26T11:56:43.646373+02:00",
+          "updated_at": "2025-08-26T11:56:43.646380+02:00",
           "name": "somehost.example.org",
           "contact": "",
           "ttl": null,
@@ -16510,8 +15000,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-06-19T13:04:05.973393+02:00",
-          "updated_at": "2025-06-19T13:04:07.988169+02:00",
+          "created_at": "2025-08-26T11:56:38.384090+02:00",
+          "updated_at": "2025-08-26T11:56:40.079937+02:00",
           "network": "10.0.1.0/24",
           "description": "Frozen but has one host",
           "vlan": 1234,
@@ -16706,93 +15196,10 @@
       "              10.0.1.255   <not set>   ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Thu Jun 19 13:09:01 2025",
-      "Updated:      Thu Jun 19 13:09:01 2025"
+      "Created:      Tue Aug 26 11:56:43 2025",
+      "Updated:      Tue Aug 26 11:56:43 2025"
     ],
     "api_requests": [
-      {
-        "method": "GET",
-        "url": "/api/v1/hosts/somehost.example.org",
-        "data": {},
-        "status": 404,
-        "response": {
-          "type": "client_error",
-          "errors": [
-            {
-              "code": "not_found",
-              "detail": "Not found.",
-              "attr": null
-            }
-          ]
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/cnames/somehost.example.org",
-        "data": {},
-        "status": 404,
-        "response": {
-          "type": "client_error",
-          "errors": [
-            {
-              "code": "not_found",
-              "detail": "Not found.",
-              "attr": null
-            }
-          ]
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/zones/forward/hostname/somehost.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "zone": {
-            "nameservers": [
-              {
-                "created_at": "2025-06-19T13:08:49.394396+02:00",
-                "updated_at": "2025-06-19T13:08:49.394408+02:00",
-                "name": "ns2.example.org",
-                "ttl": null
-              }
-            ],
-            "created_at": "2025-06-19T13:08:48.992266+02:00",
-            "updated_at": "2025-06-19T13:09:01.355366+02:00",
-            "updated": true,
-            "primary_ns": "ns2.example.org",
-            "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-06-19T13:08:49.869830+02:00",
-            "refresh": 360,
-            "retry": 1800,
-            "expire": 2400,
-            "soa_ttl": 1800,
-            "default_ttl": 300,
-            "name": "example.org"
-          }
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/ip/10.0.1.255",
-        "data": {},
-        "status": 200,
-        "response": {
-          "excluded_ranges": [],
-          "policy": null,
-          "communities": [],
-          "created_at": "2025-06-19T13:08:53.578354+02:00",
-          "updated_at": "2025-06-19T13:08:56.071248+02:00",
-          "network": "10.0.1.0/24",
-          "description": "Frozen but has one host",
-          "vlan": 1234,
-          "dns_delegated": false,
-          "category": "cat1",
-          "location": "loc1",
-          "frozen": false,
-          "reserved": 3
-        }
-      },
       {
         "method": "POST",
         "url": "/api/v1/hosts/",
@@ -16811,8 +15218,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-06-19T13:09:01.562059+02:00",
-              "updated_at": "2025-06-19T13:09:01.562065+02:00",
+              "created_at": "2025-08-26T11:56:43.939550+02:00",
+              "updated_at": "2025-08-26T11:56:43.939556+02:00",
               "ipaddress": "10.0.1.255",
               "host": 13
             }
@@ -16821,8 +15228,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-06-19T13:09:01.545751+02:00",
-              "updated_at": "2025-06-19T13:09:01.545757+02:00",
+              "created_at": "2025-08-26T11:56:43.924102+02:00",
+              "updated_at": "2025-08-26T11:56:43.924109+02:00",
               "txt": "v=spf1 -all",
               "host": 13
             }
@@ -16837,8 +15244,8 @@
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-06-19T13:09:01.543440+02:00",
-          "updated_at": "2025-06-19T13:09:01.543448+02:00",
+          "created_at": "2025-08-26T11:56:43.921940+02:00",
+          "updated_at": "2025-08-26T11:56:43.921946+02:00",
           "name": "somehost.example.org",
           "contact": "",
           "ttl": null,
@@ -16855,8 +15262,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-06-19T13:08:53.578354+02:00",
-          "updated_at": "2025-06-19T13:08:56.071248+02:00",
+          "created_at": "2025-08-26T11:56:38.384090+02:00",
+          "updated_at": "2025-08-26T11:56:40.079937+02:00",
           "network": "10.0.1.0/24",
           "description": "Frozen but has one host",
           "vlan": 1234,
@@ -18205,34 +16612,6 @@
     "output": [],
     "api_requests": [
       {
-        "method": "GET",
-        "url": "/api/v1/hostgroups/mygroup",
-        "data": {},
-        "status": 200,
-        "response": {
-          "parent": [],
-          "groups": [
-            {
-              "name": "yourgroup"
-            }
-          ],
-          "hosts": [
-            {
-              "name": "testhost1.example.org"
-            }
-          ],
-          "owners": [
-            {
-              "name": "myself"
-            }
-          ],
-          "created_at": "2024-12-11T16:44:54.078203+01:00",
-          "updated_at": "2024-12-11T16:44:56.640484+01:00",
-          "name": "mygroup",
-          "description": "This describes the group"
-        }
-      },
-      {
         "method": "DELETE",
         "url": "/api/v1/hostgroups/mygroup/groups/yourgroup",
         "data": {},
@@ -18261,8 +16640,8 @@
                   "name": "myself"
                 }
               ],
-              "created_at": "2024-12-11T16:44:54.078203+01:00",
-              "updated_at": "2024-12-11T16:44:56.864542+01:00",
+              "created_at": "2025-08-26T11:56:44.457550+02:00",
+              "updated_at": "2025-08-26T11:56:45.501550+02:00",
               "name": "mygroup",
               "description": "This describes the group"
             }
@@ -18773,30 +17152,6 @@
     "output": [],
     "api_requests": [
       {
-        "method": "GET",
-        "url": "/api/v1/hostgroups/mygroup",
-        "data": {},
-        "status": 200,
-        "response": {
-          "parent": [],
-          "groups": [],
-          "hosts": [
-            {
-              "name": "testhost1.example.org"
-            }
-          ],
-          "owners": [
-            {
-              "name": "anotherowner"
-            }
-          ],
-          "created_at": "2024-12-11T16:44:54.078203+01:00",
-          "updated_at": "2024-12-11T16:44:56.864542+01:00",
-          "name": "mygroup",
-          "description": "This describes the group"
-        }
-      },
-      {
         "method": "DELETE",
         "url": "/api/v1/hostgroups/mygroup",
         "data": {},
@@ -19099,45 +17454,24 @@
         "response": {
           "nameservers": [
             {
-              "created_at": "2024-12-11T16:44:40.356452+01:00",
-              "updated_at": "2024-12-11T16:44:40.356481+01:00",
+              "created_at": "2025-08-26T11:56:35.781651+02:00",
+              "updated_at": "2025-08-26T11:56:35.781663+02:00",
               "name": "ns2.example.org",
               "ttl": null
             }
           ],
-          "created_at": "2024-12-11T16:44:39.701254+01:00",
-          "updated_at": "2024-12-11T16:44:58.600163+01:00",
+          "created_at": "2025-08-26T11:56:35.478972+02:00",
+          "updated_at": "2025-08-26T11:56:46.169656+02:00",
           "updated": true,
           "primary_ns": "ns2.example.org",
           "email": "hostperson@example.org",
-          "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
+          "serialno_updated_at": "2025-08-26T11:56:36.090230+02:00",
           "refresh": 360,
           "retry": 1800,
           "expire": 2400,
           "soa_ttl": 1800,
           "default_ttl": 300,
           "name": "example.org"
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/zones/forward/example.org/delegations/wut.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "nameservers": [
-            {
-              "created_at": "2024-12-11T16:44:40.356452+01:00",
-              "updated_at": "2024-12-11T16:44:40.356481+01:00",
-              "name": "ns2.example.org",
-              "ttl": null
-            }
-          ],
-          "created_at": "2024-12-11T16:44:58.566491+01:00",
-          "updated_at": "2024-12-11T16:44:58.588744+01:00",
-          "name": "wut.example.org",
-          "comment": "",
-          "zone": 1
         }
       },
       {
@@ -19310,65 +17644,10 @@
       "Name:         testhost.wut.example.org",
       "Contact:      ",
       "TTL:          (Default)",
-      "Created:      Mon May 19 10:27:47 2025",
-      "Updated:      Mon May 19 10:27:47 2025"
+      "Created:      Tue Aug 26 11:56:46 2025",
+      "Updated:      Tue Aug 26 11:56:46 2025"
     ],
     "api_requests": [
-      {
-        "method": "GET",
-        "url": "/api/v1/hosts/testhost.wut.example.org",
-        "data": {},
-        "status": 404,
-        "response": {
-          "type": "client_error",
-          "errors": [
-            {
-              "code": "not_found",
-              "detail": "Not found.",
-              "attr": null
-            }
-          ]
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/cnames/testhost.wut.example.org",
-        "data": {},
-        "status": 404,
-        "response": {
-          "type": "client_error",
-          "errors": [
-            {
-              "code": "not_found",
-              "detail": "Not found.",
-              "attr": null
-            }
-          ]
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/zones/forward/hostname/testhost.wut.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "delegation": {
-            "nameservers": [
-              {
-                "created_at": "2025-05-19T10:27:38.778680+02:00",
-                "updated_at": "2025-05-19T10:27:38.778705+02:00",
-                "name": "ns2.example.org",
-                "ttl": null
-              }
-            ],
-            "created_at": "2025-05-19T10:27:47.606669+02:00",
-            "updated_at": "2025-05-19T10:27:47.702410+02:00",
-            "name": "wut.example.org",
-            "comment": "This is a comment",
-            "zone": 1
-          }
-        }
-      },
       {
         "method": "POST",
         "url": "/api/v1/hosts/",
@@ -19397,8 +17676,8 @@
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-05-19T10:27:47.898751+02:00",
-          "updated_at": "2025-05-19T10:27:47.898765+02:00",
+          "created_at": "2025-08-26T11:56:46.360926+02:00",
+          "updated_at": "2025-08-26T11:56:46.360935+02:00",
           "name": "testhost.wut.example.org",
           "contact": "",
           "ttl": null,
@@ -20119,29 +18398,7 @@
       " apple",
       " orange"
     ],
-    "api_requests": [
-      {
-        "method": "GET",
-        "url": "/api/v1/hostpolicy/roles/fruit",
-        "data": {},
-        "status": 200,
-        "response": {
-          "hosts": [],
-          "atoms": [
-            {
-              "name": "apple"
-            },
-            {
-              "name": "orange"
-            }
-          ],
-          "updated_at": "2024-12-11T16:45:01.258316+01:00",
-          "description": "5 a day",
-          "name": "fruit",
-          "labels": []
-        }
-      }
-    ],
+    "api_requests": [],
     "time": null
   },
   {
@@ -20303,27 +18560,6 @@
     "error": [],
     "output": [],
     "api_requests": [
-      {
-        "method": "GET",
-        "url": "/api/v1/hostpolicy/roles/fruit",
-        "data": {},
-        "status": 200,
-        "response": {
-          "hosts": [],
-          "atoms": [
-            {
-              "name": "apple"
-            },
-            {
-              "name": "orange"
-            }
-          ],
-          "updated_at": "2024-12-11T16:45:01.258316+01:00",
-          "description": "5 a day",
-          "name": "fruit",
-          "labels": []
-        }
-      },
       {
         "method": "DELETE",
         "url": "/api/v1/hostpolicy/roles/fruit/atoms/apple",
@@ -20875,46 +19111,10 @@
               "name": "tangerine"
             }
           ],
-          "updated_at": "2025-06-19T13:09:05.787299+02:00",
+          "updated_at": "2025-08-26T11:56:47.676513+02:00",
           "description": "5 a day",
           "name": "fruit",
           "labels": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hosts/foo.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [],
-          "cnames": [],
-          "mxs": [],
-          "txts": [
-            {
-              "created_at": "2025-06-19T13:09:05.909776+02:00",
-              "updated_at": "2025-06-19T13:09:05.909782+02:00",
-              "txt": "v=spf1 -all",
-              "host": 17
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "created_at": "2025-06-19T13:09:05.907474+02:00",
-          "updated_at": "2025-06-19T13:09:05.907487+02:00",
-          "name": "foo.example.org",
-          "contact": "",
-          "ttl": null,
-          "comment": "",
-          "zone": 1
         }
       },
       {
@@ -21034,49 +19234,10 @@
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
       "Roles:        fruit",
-      "Created:      Thu Jun 19 13:09:05 2025",
-      "Updated:      Thu Jun 19 13:09:05 2025"
+      "Created:      Tue Aug 26 11:56:47 2025",
+      "Updated:      Tue Aug 26 11:56:47 2025"
     ],
-    "api_requests": [
-      {
-        "method": "GET",
-        "url": "/api/v1/hosts/foo.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [],
-          "cnames": [],
-          "mxs": [],
-          "txts": [
-            {
-              "created_at": "2025-06-19T13:09:05.909776+02:00",
-              "updated_at": "2025-06-19T13:09:05.909782+02:00",
-              "txt": "v=spf1 -all",
-              "host": 17
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [
-            "fruit"
-          ],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "created_at": "2025-06-19T13:09:05.907474+02:00",
-          "updated_at": "2025-06-19T13:09:05.907487+02:00",
-          "name": "foo.example.org",
-          "contact": "",
-          "ttl": null,
-          "comment": "",
-          "zone": 1
-        }
-      }
-    ],
+    "api_requests": [],
     "time": null
   },
   {
@@ -21091,66 +19252,6 @@
     "error": [],
     "output": [],
     "api_requests": [
-      {
-        "method": "GET",
-        "url": "/api/v1/hostpolicy/roles/fruit",
-        "data": {},
-        "status": 200,
-        "response": {
-          "hosts": [
-            {
-              "name": "foo.example.org"
-            }
-          ],
-          "atoms": [
-            {
-              "name": "tangerine"
-            }
-          ],
-          "updated_at": "2025-06-19T13:09:06.080868+02:00",
-          "description": "5 a day",
-          "name": "fruit",
-          "labels": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hosts/foo.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [],
-          "cnames": [],
-          "mxs": [],
-          "txts": [
-            {
-              "created_at": "2025-06-19T13:09:05.909776+02:00",
-              "updated_at": "2025-06-19T13:09:05.909782+02:00",
-              "txt": "v=spf1 -all",
-              "host": 17
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [
-            "fruit"
-          ],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "created_at": "2025-06-19T13:09:05.907474+02:00",
-          "updated_at": "2025-06-19T13:09:05.907487+02:00",
-          "name": "foo.example.org",
-          "contact": "",
-          "ttl": null,
-          "comment": "",
-          "zone": 1
-        }
-      },
       {
         "method": "DELETE",
         "url": "/api/v1/hostpolicy/roles/fruit/hosts/foo.example.org",
@@ -21205,24 +19306,6 @@
     "error": [],
     "output": [],
     "api_requests": [
-      {
-        "method": "GET",
-        "url": "/api/v1/hostpolicy/roles/fruit",
-        "data": {},
-        "status": 200,
-        "response": {
-          "hosts": [],
-          "atoms": [
-            {
-              "name": "tangerine"
-            }
-          ],
-          "updated_at": "2024-12-11T16:45:04.346261+01:00",
-          "description": "5 a day",
-          "name": "fruit",
-          "labels": []
-        }
-      },
       {
         "method": "DELETE",
         "url": "/api/v1/hostpolicy/roles/fruit/atoms/tangerine",
@@ -22189,18 +20272,6 @@
     "api_requests": [
       {
         "method": "GET",
-        "url": "/api/v1/ipaddresses/?macaddress=aa%3Abb%3Acc%3Add%3Aee%3Aff",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
-        }
-      },
-      {
-        "method": "GET",
         "url": "/api/v1/ipaddresses/?ipaddress=10.0.0.5",
         "data": {},
         "status": 200,
@@ -22211,8 +20282,8 @@
           "results": [
             {
               "macaddress": "",
-              "created_at": "2025-06-19T13:09:07.202179+02:00",
-              "updated_at": "2025-06-19T13:09:07.202186+02:00",
+              "created_at": "2025-08-26T11:56:49.288257+02:00",
+              "updated_at": "2025-08-26T11:56:49.288280+02:00",
               "ipaddress": "10.0.0.5",
               "host": 18
             }
@@ -22234,8 +20305,8 @@
         "status": 200,
         "response": {
           "macaddress": "aa:bb:cc:dd:ee:ff",
-          "created_at": "2025-06-19T13:09:07.202179+02:00",
-          "updated_at": "2025-06-19T13:09:07.552574+02:00",
+          "created_at": "2025-08-26T11:56:49.288257+02:00",
+          "updated_at": "2025-08-26T11:56:49.602146+02:00",
           "ipaddress": "10.0.0.5",
           "host": 18
         }
@@ -22746,42 +20817,6 @@
     "api_requests": [
       {
         "method": "GET",
-        "url": "/api/v1/hosts/foo.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [],
-          "cnames": [],
-          "mxs": [],
-          "txts": [
-            {
-              "created_at": "2025-06-19T13:09:07.019259+02:00",
-              "updated_at": "2025-06-19T13:09:07.019265+02:00",
-              "txt": "v=spf1 -all",
-              "host": 18
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "created_at": "2025-06-19T13:09:07.017552+02:00",
-          "updated_at": "2025-06-19T13:09:07.017559+02:00",
-          "name": "foo.example.org",
-          "contact": "",
-          "ttl": null,
-          "comment": "",
-          "zone": 1
-        }
-      },
-      {
-        "method": "GET",
         "url": "/api/v1/networks/ip/10.0.0.5",
         "data": {},
         "status": 200,
@@ -22789,8 +20824,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-06-19T13:09:06.902388+02:00",
-          "updated_at": "2025-06-19T13:09:06.902398+02:00",
+          "created_at": "2025-08-26T11:56:48.961289+02:00",
+          "updated_at": "2025-08-26T11:56:48.961300+02:00",
           "network": "10.0.0.0/24",
           "description": "foo",
           "vlan": 1234,
@@ -22823,8 +20858,8 @@
         "status": 201,
         "response": {
           "macaddress": "",
-          "created_at": "2025-06-19T13:09:08.251883+02:00",
-          "updated_at": "2025-06-19T13:09:08.251892+02:00",
+          "created_at": "2025-08-26T11:56:50.510378+02:00",
+          "updated_at": "2025-08-26T11:56:50.510386+02:00",
           "ipaddress": "10.0.0.5",
           "host": 18
         }
@@ -22843,8 +20878,8 @@
               "ipaddresses": [
                 {
                   "macaddress": "",
-                  "created_at": "2025-06-19T13:09:08.251883+02:00",
-                  "updated_at": "2025-06-19T13:09:08.251892+02:00",
+                  "created_at": "2025-08-26T11:56:50.510378+02:00",
+                  "updated_at": "2025-08-26T11:56:50.510386+02:00",
                   "ipaddress": "10.0.0.5",
                   "host": 18
                 }
@@ -22853,8 +20888,8 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2025-06-19T13:09:07.019259+02:00",
-                  "updated_at": "2025-06-19T13:09:07.019265+02:00",
+                  "created_at": "2025-08-26T11:56:49.094847+02:00",
+                  "updated_at": "2025-08-26T11:56:49.094856+02:00",
                   "txt": "v=spf1 -all",
                   "host": 18
                 }
@@ -22869,8 +20904,8 @@
               "loc": null,
               "bacnetid": null,
               "communities": [],
-              "created_at": "2025-06-19T13:09:07.017552+02:00",
-              "updated_at": "2025-06-19T13:09:07.017559+02:00",
+              "created_at": "2025-08-26T11:56:49.090929+02:00",
+              "updated_at": "2025-08-26T11:56:49.090940+02:00",
               "name": "foo.example.org",
               "contact": "",
               "ttl": null,
@@ -23127,57 +21162,6 @@
     "error": [],
     "output": [],
     "api_requests": [
-      {
-        "method": "GET",
-        "url": "/api/v1/hosts/foo.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "",
-              "created_at": "2025-06-19T13:09:08.251883+02:00",
-              "updated_at": "2025-06-19T13:09:08.251892+02:00",
-              "ipaddress": "10.0.0.5",
-              "host": 18
-            },
-            {
-              "macaddress": "",
-              "created_at": "2025-06-19T13:09:08.382145+02:00",
-              "updated_at": "2025-06-19T13:09:08.382151+02:00",
-              "ipaddress": "10.0.0.6",
-              "host": 18
-            }
-          ],
-          "cnames": [],
-          "mxs": [],
-          "txts": [
-            {
-              "created_at": "2025-06-19T13:09:07.019259+02:00",
-              "updated_at": "2025-06-19T13:09:07.019265+02:00",
-              "txt": "v=spf1 -all",
-              "host": 18
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "created_at": "2025-06-19T13:09:07.017552+02:00",
-          "updated_at": "2025-06-19T13:09:07.017559+02:00",
-          "name": "foo.example.org",
-          "contact": "",
-          "ttl": null,
-          "comment": "",
-          "zone": 1
-        }
-      },
       {
         "method": "DELETE",
         "url": "/api/v1/ipaddresses/18",
@@ -23639,57 +21623,6 @@
     "output": [],
     "api_requests": [
       {
-        "method": "GET",
-        "url": "/api/v1/hosts/foo.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "",
-              "created_at": "2025-06-19T13:09:08.251883+02:00",
-              "updated_at": "2025-06-19T13:09:08.251892+02:00",
-              "ipaddress": "10.0.0.5",
-              "host": 18
-            },
-            {
-              "macaddress": "",
-              "created_at": "2025-06-19T13:09:08.758513+02:00",
-              "updated_at": "2025-06-19T13:09:08.758520+02:00",
-              "ipaddress": "2001:db9::5",
-              "host": 18
-            }
-          ],
-          "cnames": [],
-          "mxs": [],
-          "txts": [
-            {
-              "created_at": "2025-06-19T13:09:07.019259+02:00",
-              "updated_at": "2025-06-19T13:09:07.019265+02:00",
-              "txt": "v=spf1 -all",
-              "host": 18
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "created_at": "2025-06-19T13:09:07.017552+02:00",
-          "updated_at": "2025-06-19T13:09:07.017559+02:00",
-          "name": "foo.example.org",
-          "contact": "",
-          "ttl": null,
-          "comment": "",
-          "zone": 1
-        }
-      },
-      {
         "method": "DELETE",
         "url": "/api/v1/ipaddresses/19",
         "data": {},
@@ -24124,99 +22057,6 @@
     "error": [],
     "output": [],
     "api_requests": [
-      {
-        "method": "GET",
-        "url": "/api/v1/hosts/foo.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "aa:bb:cc:dd:ee:ff",
-              "created_at": "2025-06-19T13:09:08.251883+02:00",
-              "updated_at": "2025-06-19T13:09:09.214112+02:00",
-              "ipaddress": "10.0.0.5",
-              "host": 18
-            },
-            {
-              "macaddress": "",
-              "created_at": "2025-06-19T13:09:09.025963+02:00",
-              "updated_at": "2025-06-19T13:09:09.025970+02:00",
-              "ipaddress": "2001:db8::5",
-              "host": 18
-            }
-          ],
-          "cnames": [],
-          "mxs": [],
-          "txts": [
-            {
-              "created_at": "2025-06-19T13:09:07.019259+02:00",
-              "updated_at": "2025-06-19T13:09:07.019265+02:00",
-              "txt": "v=spf1 -all",
-              "host": 18
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "created_at": "2025-06-19T13:09:07.017552+02:00",
-          "updated_at": "2025-06-19T13:09:07.017559+02:00",
-          "name": "foo.example.org",
-          "contact": "",
-          "ttl": null,
-          "comment": "",
-          "zone": 1
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/ip/10.0.0.5",
-        "data": {},
-        "status": 200,
-        "response": {
-          "excluded_ranges": [],
-          "policy": null,
-          "communities": [],
-          "created_at": "2025-06-19T13:09:06.902388+02:00",
-          "updated_at": "2025-06-19T13:09:06.902398+02:00",
-          "network": "10.0.0.0/24",
-          "description": "foo",
-          "vlan": 1234,
-          "dns_delegated": false,
-          "category": "",
-          "location": "",
-          "frozen": false,
-          "reserved": 3
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/ip/2001%3Adb8%3A%3A5",
-        "data": {},
-        "status": 200,
-        "response": {
-          "excluded_ranges": [],
-          "policy": null,
-          "communities": [],
-          "created_at": "2025-06-19T13:09:08.595654+02:00",
-          "updated_at": "2025-06-19T13:09:08.595664+02:00",
-          "network": "2001:db8::/64",
-          "description": "foo_ipv6",
-          "vlan": 1234,
-          "dns_delegated": false,
-          "category": "",
-          "location": "",
-          "frozen": false,
-          "reserved": 3
-        }
-      },
       {
         "method": "DELETE",
         "url": "/api/v1/hosts/foo.example.org",
@@ -24803,8 +22643,8 @@
       "              10.0.0.10   11:22:33:aa:bb:cc   ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Thu Jun 19 13:09:09 2025",
-      "Updated:      Thu Jun 19 13:09:09 2025"
+      "Created:      Tue Aug 26 11:56:52 2025",
+      "Updated:      Tue Aug 26 11:56:52 2025"
     ],
     "api_requests": [
       {
@@ -24816,8 +22656,8 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2025-06-19T13:09:09.968166+02:00",
-              "updated_at": "2025-06-19T13:09:10.068876+02:00",
+              "created_at": "2025-08-26T11:56:52.681144+02:00",
+              "updated_at": "2025-08-26T11:56:52.826848+02:00",
               "ipaddress": "10.0.0.10",
               "host": 19
             }
@@ -24826,8 +22666,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-06-19T13:09:09.945029+02:00",
-              "updated_at": "2025-06-19T13:09:09.945036+02:00",
+              "created_at": "2025-08-26T11:56:52.619543+02:00",
+              "updated_at": "2025-08-26T11:56:52.619576+02:00",
               "txt": "v=spf1 -all",
               "host": 19
             }
@@ -24842,34 +22682,13 @@
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-06-19T13:09:09.942915+02:00",
-          "updated_at": "2025-06-19T13:09:09.942923+02:00",
+          "created_at": "2025-08-26T11:56:52.606852+02:00",
+          "updated_at": "2025-08-26T11:56:52.606863+02:00",
           "name": "foo.example.org",
           "contact": "hi@ho.com",
           "ttl": null,
           "comment": "meh",
           "zone": 1
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/ip/10.0.0.10",
-        "data": {},
-        "status": 200,
-        "response": {
-          "excluded_ranges": [],
-          "policy": null,
-          "communities": [],
-          "created_at": "2025-06-19T13:09:09.671414+02:00",
-          "updated_at": "2025-06-19T13:09:09.671430+02:00",
-          "network": "10.0.0.0/24",
-          "description": "lorem ipsum",
-          "vlan": null,
-          "dns_delegated": false,
-          "category": "",
-          "location": "",
-          "frozen": false,
-          "reserved": 3
         }
       }
     ],
@@ -25157,50 +22976,6 @@
     "api_requests": [
       {
         "method": "GET",
-        "url": "/api/v1/hosts/foo.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2025-06-19T13:09:09.968166+02:00",
-              "updated_at": "2025-06-19T13:09:10.068876+02:00",
-              "ipaddress": "10.0.0.10",
-              "host": 19
-            }
-          ],
-          "cnames": [],
-          "mxs": [],
-          "txts": [
-            {
-              "created_at": "2025-06-19T13:09:09.945029+02:00",
-              "updated_at": "2025-06-19T13:09:09.945036+02:00",
-              "txt": "v=spf1 -all",
-              "host": 19
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "created_at": "2025-06-19T13:09:09.942915+02:00",
-          "updated_at": "2025-06-19T13:09:09.942923+02:00",
-          "name": "foo.example.org",
-          "contact": "hi@ho.com",
-          "ttl": null,
-          "comment": "meh",
-          "zone": 1
-        }
-      },
-      {
-        "method": "GET",
         "url": "/api/v1/hosts/bar.example.org",
         "data": {},
         "status": 404,
@@ -25240,18 +23015,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2025-06-19T13:08:49.394396+02:00",
-                "updated_at": "2025-06-19T13:08:49.394408+02:00",
+                "created_at": "2025-08-26T11:56:35.781651+02:00",
+                "updated_at": "2025-08-26T11:56:35.781663+02:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-06-19T13:08:48.992266+02:00",
-            "updated_at": "2025-06-19T13:09:10.067988+02:00",
+            "created_at": "2025-08-26T11:56:35.478972+02:00",
+            "updated_at": "2025-08-26T11:56:52.826172+02:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-06-19T13:08:49.869830+02:00",
+            "serialno_updated_at": "2025-08-26T11:56:36.090230+02:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -25283,8 +23058,8 @@
               "ipaddresses": [
                 {
                   "macaddress": "11:22:33:aa:bb:cc",
-                  "created_at": "2025-06-19T13:09:09.968166+02:00",
-                  "updated_at": "2025-06-19T13:09:10.068876+02:00",
+                  "created_at": "2025-08-26T11:56:52.681144+02:00",
+                  "updated_at": "2025-08-26T11:56:52.826848+02:00",
                   "ipaddress": "10.0.0.10",
                   "host": 19
                 }
@@ -25293,8 +23068,8 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2025-06-19T13:09:09.945029+02:00",
-                  "updated_at": "2025-06-19T13:09:09.945036+02:00",
+                  "created_at": "2025-08-26T11:56:52.619543+02:00",
+                  "updated_at": "2025-08-26T11:56:52.619576+02:00",
                   "txt": "v=spf1 -all",
                   "host": 19
                 }
@@ -25309,8 +23084,8 @@
               "loc": null,
               "bacnetid": null,
               "communities": [],
-              "created_at": "2025-06-19T13:09:09.942915+02:00",
-              "updated_at": "2025-06-19T13:09:10.609509+02:00",
+              "created_at": "2025-08-26T11:56:52.606852+02:00",
+              "updated_at": "2025-08-26T11:56:53.429621+02:00",
               "name": "bar.example.org",
               "contact": "hi@ho.com",
               "ttl": null,
@@ -25531,50 +23306,6 @@
     "output": [],
     "api_requests": [
       {
-        "method": "GET",
-        "url": "/api/v1/hosts/bar.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2025-06-19T13:09:09.968166+02:00",
-              "updated_at": "2025-06-19T13:09:10.068876+02:00",
-              "ipaddress": "10.0.0.10",
-              "host": 19
-            }
-          ],
-          "cnames": [],
-          "mxs": [],
-          "txts": [
-            {
-              "created_at": "2025-06-19T13:09:09.945029+02:00",
-              "updated_at": "2025-06-19T13:09:09.945036+02:00",
-              "txt": "v=spf1 -all",
-              "host": 19
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "created_at": "2025-06-19T13:09:09.942915+02:00",
-          "updated_at": "2025-06-19T13:09:10.799518+02:00",
-          "name": "bar.example.org",
-          "contact": "hi@ho.com",
-          "ttl": null,
-          "comment": "This is the comment",
-          "zone": 1
-        }
-      },
-      {
         "method": "PATCH",
         "url": "/api/v1/hosts/bar.example.org",
         "data": {
@@ -25596,8 +23327,8 @@
               "ipaddresses": [
                 {
                   "macaddress": "11:22:33:aa:bb:cc",
-                  "created_at": "2025-06-19T13:09:09.968166+02:00",
-                  "updated_at": "2025-06-19T13:09:10.068876+02:00",
+                  "created_at": "2025-08-26T11:56:52.681144+02:00",
+                  "updated_at": "2025-08-26T11:56:52.826848+02:00",
                   "ipaddress": "10.0.0.10",
                   "host": 19
                 }
@@ -25606,8 +23337,8 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2025-06-19T13:09:09.945029+02:00",
-                  "updated_at": "2025-06-19T13:09:09.945036+02:00",
+                  "created_at": "2025-08-26T11:56:52.619543+02:00",
+                  "updated_at": "2025-08-26T11:56:52.619576+02:00",
                   "txt": "v=spf1 -all",
                   "host": 19
                 }
@@ -25622,8 +23353,8 @@
               "loc": null,
               "bacnetid": null,
               "communities": [],
-              "created_at": "2025-06-19T13:09:09.942915+02:00",
-              "updated_at": "2025-06-19T13:09:11.270412+02:00",
+              "created_at": "2025-08-26T11:56:52.606852+02:00",
+              "updated_at": "2025-08-26T11:56:54.198507+02:00",
               "name": "bar.example.org",
               "contact": "me@example.org",
               "ttl": null,
@@ -25729,71 +23460,6 @@
     "output": [],
     "api_requests": [
       {
-        "method": "GET",
-        "url": "/api/v1/hosts/bar.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2025-06-19T13:09:09.968166+02:00",
-              "updated_at": "2025-06-19T13:09:10.068876+02:00",
-              "ipaddress": "10.0.0.10",
-              "host": 19
-            }
-          ],
-          "cnames": [],
-          "mxs": [],
-          "txts": [
-            {
-              "created_at": "2025-06-19T13:09:09.945029+02:00",
-              "updated_at": "2025-06-19T13:09:09.945036+02:00",
-              "txt": "v=spf1 -all",
-              "host": 19
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "created_at": "2025-06-19T13:09:09.942915+02:00",
-          "updated_at": "2025-06-19T13:09:11.270412+02:00",
-          "name": "bar.example.org",
-          "contact": "me@example.org",
-          "ttl": null,
-          "comment": "This is the comment",
-          "zone": 1
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/ip/10.0.0.12",
-        "data": {},
-        "status": 200,
-        "response": {
-          "excluded_ranges": [],
-          "policy": null,
-          "communities": [],
-          "created_at": "2025-06-19T13:09:09.671414+02:00",
-          "updated_at": "2025-06-19T13:09:09.671430+02:00",
-          "network": "10.0.0.0/24",
-          "description": "lorem ipsum",
-          "vlan": null,
-          "dns_delegated": false,
-          "category": "",
-          "location": "",
-          "frozen": false,
-          "reserved": 3
-        }
-      },
-      {
         "method": "POST",
         "url": "/api/v1/ipaddresses/",
         "data": {
@@ -25803,8 +23469,8 @@
         "status": 201,
         "response": {
           "macaddress": "",
-          "created_at": "2025-06-19T13:09:11.489496+02:00",
-          "updated_at": "2025-06-19T13:09:11.489536+02:00",
+          "created_at": "2025-08-26T11:56:54.782509+02:00",
+          "updated_at": "2025-08-26T11:56:54.782520+02:00",
           "ipaddress": "10.0.0.12",
           "host": 19
         }
@@ -25823,15 +23489,15 @@
               "ipaddresses": [
                 {
                   "macaddress": "11:22:33:aa:bb:cc",
-                  "created_at": "2025-06-19T13:09:09.968166+02:00",
-                  "updated_at": "2025-06-19T13:09:10.068876+02:00",
+                  "created_at": "2025-08-26T11:56:52.681144+02:00",
+                  "updated_at": "2025-08-26T11:56:52.826848+02:00",
                   "ipaddress": "10.0.0.10",
                   "host": 19
                 },
                 {
                   "macaddress": "",
-                  "created_at": "2025-06-19T13:09:11.489496+02:00",
-                  "updated_at": "2025-06-19T13:09:11.489536+02:00",
+                  "created_at": "2025-08-26T11:56:54.782509+02:00",
+                  "updated_at": "2025-08-26T11:56:54.782520+02:00",
                   "ipaddress": "10.0.0.12",
                   "host": 19
                 }
@@ -25840,8 +23506,8 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2025-06-19T13:09:09.945029+02:00",
-                  "updated_at": "2025-06-19T13:09:09.945036+02:00",
+                  "created_at": "2025-08-26T11:56:52.619543+02:00",
+                  "updated_at": "2025-08-26T11:56:52.619576+02:00",
                   "txt": "v=spf1 -all",
                   "host": 19
                 }
@@ -25856,8 +23522,8 @@
               "loc": null,
               "bacnetid": null,
               "communities": [],
-              "created_at": "2025-06-19T13:09:09.942915+02:00",
-              "updated_at": "2025-06-19T13:09:11.270412+02:00",
+              "created_at": "2025-08-26T11:56:52.606852+02:00",
+              "updated_at": "2025-08-26T11:56:54.198507+02:00",
               "name": "bar.example.org",
               "contact": "me@example.org",
               "ttl": null,
@@ -26792,57 +24458,6 @@
     "api_requests": [
       {
         "method": "GET",
-        "url": "/api/v1/hosts/bar.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "",
-              "created_at": "2025-06-19T13:09:11.489496+02:00",
-              "updated_at": "2025-06-19T13:09:11.845269+02:00",
-              "ipaddress": "10.0.0.14",
-              "host": 19
-            },
-            {
-              "macaddress": "11:22:33:44:55:66",
-              "created_at": "2025-06-19T13:09:11.658060+02:00",
-              "updated_at": "2025-06-19T13:09:12.012542+02:00",
-              "ipaddress": "10.0.0.15",
-              "host": 19
-            }
-          ],
-          "cnames": [],
-          "mxs": [],
-          "txts": [
-            {
-              "created_at": "2025-06-19T13:09:09.945029+02:00",
-              "updated_at": "2025-06-19T13:09:09.945036+02:00",
-              "txt": "v=spf1 -all",
-              "host": 19
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "created_at": "2025-06-19T13:09:09.942915+02:00",
-          "updated_at": "2025-06-19T13:09:11.270412+02:00",
-          "name": "bar.example.org",
-          "contact": "me@example.org",
-          "ttl": null,
-          "comment": "This is the comment",
-          "zone": 1
-        }
-      },
-      {
-        "method": "GET",
         "url": "/api/v1/networks/ip/2001%3Adb8%3A%3A11",
         "data": {},
         "status": 200,
@@ -26850,8 +24465,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-06-19T13:09:09.737206+02:00",
-          "updated_at": "2025-06-19T13:09:09.737214+02:00",
+          "created_at": "2025-08-26T11:56:52.409989+02:00",
+          "updated_at": "2025-08-26T11:56:52.410004+02:00",
           "network": "2001:db8::/64",
           "description": "dolor sit amet",
           "vlan": null,
@@ -26872,8 +24487,8 @@
         "status": 201,
         "response": {
           "macaddress": "",
-          "created_at": "2025-06-19T13:09:12.500812+02:00",
-          "updated_at": "2025-06-19T13:09:12.500818+02:00",
+          "created_at": "2025-08-26T11:56:56.531110+02:00",
+          "updated_at": "2025-08-26T11:56:56.531124+02:00",
           "ipaddress": "2001:db8::11",
           "host": 19
         }
@@ -26892,22 +24507,22 @@
               "ipaddresses": [
                 {
                   "macaddress": "",
-                  "created_at": "2025-06-19T13:09:11.489496+02:00",
-                  "updated_at": "2025-06-19T13:09:11.845269+02:00",
+                  "created_at": "2025-08-26T11:56:54.782509+02:00",
+                  "updated_at": "2025-08-26T11:56:55.340478+02:00",
                   "ipaddress": "10.0.0.14",
                   "host": 19
                 },
                 {
                   "macaddress": "11:22:33:44:55:66",
-                  "created_at": "2025-06-19T13:09:11.658060+02:00",
-                  "updated_at": "2025-06-19T13:09:12.012542+02:00",
+                  "created_at": "2025-08-26T11:56:55.103884+02:00",
+                  "updated_at": "2025-08-26T11:56:55.613257+02:00",
                   "ipaddress": "10.0.0.15",
                   "host": 19
                 },
                 {
                   "macaddress": "",
-                  "created_at": "2025-06-19T13:09:12.500812+02:00",
-                  "updated_at": "2025-06-19T13:09:12.500818+02:00",
+                  "created_at": "2025-08-26T11:56:56.531110+02:00",
+                  "updated_at": "2025-08-26T11:56:56.531124+02:00",
                   "ipaddress": "2001:db8::11",
                   "host": 19
                 }
@@ -26916,8 +24531,8 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2025-06-19T13:09:09.945029+02:00",
-                  "updated_at": "2025-06-19T13:09:09.945036+02:00",
+                  "created_at": "2025-08-26T11:56:52.619543+02:00",
+                  "updated_at": "2025-08-26T11:56:52.619576+02:00",
                   "txt": "v=spf1 -all",
                   "host": 19
                 }
@@ -26932,8 +24547,8 @@
               "loc": null,
               "bacnetid": null,
               "communities": [],
-              "created_at": "2025-06-19T13:09:09.942915+02:00",
-              "updated_at": "2025-06-19T13:09:11.270412+02:00",
+              "created_at": "2025-08-26T11:56:52.606852+02:00",
+              "updated_at": "2025-08-26T11:56:54.198507+02:00",
               "name": "bar.example.org",
               "contact": "me@example.org",
               "ttl": null,
@@ -27306,73 +24921,7 @@
       "              2001:db8::11  <not set>",
       "              2001:db8::12  11:22:33:44:55:67"
     ],
-    "api_requests": [
-      {
-        "method": "GET",
-        "url": "/api/v1/hosts/bar.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "",
-              "created_at": "2025-06-19T13:09:11.489496+02:00",
-              "updated_at": "2025-06-19T13:09:11.845269+02:00",
-              "ipaddress": "10.0.0.14",
-              "host": 19
-            },
-            {
-              "macaddress": "11:22:33:44:55:66",
-              "created_at": "2025-06-19T13:09:11.658060+02:00",
-              "updated_at": "2025-06-19T13:09:12.012542+02:00",
-              "ipaddress": "10.0.0.15",
-              "host": 19
-            },
-            {
-              "macaddress": "",
-              "created_at": "2025-06-19T13:09:12.500812+02:00",
-              "updated_at": "2025-06-19T13:09:12.500818+02:00",
-              "ipaddress": "2001:db8::11",
-              "host": 19
-            },
-            {
-              "macaddress": "11:22:33:44:55:67",
-              "created_at": "2025-06-19T13:09:12.648868+02:00",
-              "updated_at": "2025-06-19T13:09:12.648877+02:00",
-              "ipaddress": "2001:db8::12",
-              "host": 19
-            }
-          ],
-          "cnames": [],
-          "mxs": [],
-          "txts": [
-            {
-              "created_at": "2025-06-19T13:09:09.945029+02:00",
-              "updated_at": "2025-06-19T13:09:09.945036+02:00",
-              "txt": "v=spf1 -all",
-              "host": 19
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "created_at": "2025-06-19T13:09:09.942915+02:00",
-          "updated_at": "2025-06-19T13:09:11.270412+02:00",
-          "name": "bar.example.org",
-          "contact": "me@example.org",
-          "ttl": null,
-          "comment": "This is the comment",
-          "zone": 1
-        }
-      }
-    ],
+    "api_requests": [],
     "time": null
   },
   {
@@ -27396,8 +24945,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-06-20T11:43:28.247683+02:00",
-          "updated_at": "2025-06-20T11:43:28.247699+02:00",
+          "created_at": "2025-08-26T11:56:52.409989+02:00",
+          "updated_at": "2025-08-26T11:56:52.410004+02:00",
           "network": "2001:db8::/64",
           "description": "dolor sit amet",
           "vlan": null,
@@ -27406,71 +24955,6 @@
           "location": "",
           "frozen": false,
           "reserved": 3
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hosts/bar.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "",
-              "created_at": "2025-06-20T11:43:29.619291+02:00",
-              "updated_at": "2025-06-20T11:43:29.973056+02:00",
-              "ipaddress": "10.0.0.14",
-              "host": 19
-            },
-            {
-              "macaddress": "11:22:33:44:55:66",
-              "created_at": "2025-06-20T11:43:29.750216+02:00",
-              "updated_at": "2025-06-20T11:43:30.160959+02:00",
-              "ipaddress": "10.0.0.15",
-              "host": 19
-            },
-            {
-              "macaddress": "",
-              "created_at": "2025-06-20T11:43:31.228509+02:00",
-              "updated_at": "2025-06-20T11:43:31.228517+02:00",
-              "ipaddress": "2001:db8::11",
-              "host": 19
-            },
-            {
-              "macaddress": "11:22:33:44:55:67",
-              "created_at": "2025-06-20T11:43:31.368764+02:00",
-              "updated_at": "2025-06-20T11:43:31.368770+02:00",
-              "ipaddress": "2001:db8::12",
-              "host": 19
-            }
-          ],
-          "cnames": [],
-          "mxs": [],
-          "txts": [
-            {
-              "created_at": "2025-06-20T11:43:28.396092+02:00",
-              "updated_at": "2025-06-20T11:43:28.396098+02:00",
-              "txt": "v=spf1 -all",
-              "host": 19
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "created_at": "2025-06-20T11:43:28.393781+02:00",
-          "updated_at": "2025-06-20T11:43:29.367767+02:00",
-          "name": "bar.example.org",
-          "contact": "me@example.org",
-          "ttl": null,
-          "comment": "This is the comment",
-          "zone": 1
         }
       },
       {
@@ -27500,8 +24984,8 @@
         "status": 200,
         "response": {
           "macaddress": "",
-          "created_at": "2025-06-20T11:43:31.228509+02:00",
-          "updated_at": "2025-06-20T11:43:32.086423+02:00",
+          "created_at": "2025-08-26T11:56:56.531110+02:00",
+          "updated_at": "2025-08-26T11:56:57.688141+02:00",
           "ipaddress": "2001:db8::13",
           "host": 19
         }
@@ -28174,66 +25658,6 @@
     "api_requests": [
       {
         "method": "GET",
-        "url": "/api/v1/hosts/bar.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "",
-              "created_at": "2025-06-19T13:09:11.489496+02:00",
-              "updated_at": "2025-06-19T13:09:11.845269+02:00",
-              "ipaddress": "10.0.0.14",
-              "host": 19
-            },
-            {
-              "macaddress": "11:22:33:44:55:66",
-              "created_at": "2025-06-19T13:09:11.658060+02:00",
-              "updated_at": "2025-06-19T13:09:12.012542+02:00",
-              "ipaddress": "10.0.0.15",
-              "host": 19
-            }
-          ],
-          "cnames": [
-            {
-              "created_at": "2025-06-19T13:09:13.466436+02:00",
-              "updated_at": "2025-06-19T13:09:13.466444+02:00",
-              "name": "fubar.example.org",
-              "ttl": null,
-              "zone": 1,
-              "host": 19
-            }
-          ],
-          "mxs": [],
-          "txts": [
-            {
-              "created_at": "2025-06-19T13:09:09.945029+02:00",
-              "updated_at": "2025-06-19T13:09:09.945036+02:00",
-              "txt": "v=spf1 -all",
-              "host": 19
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "created_at": "2025-06-19T13:09:09.942915+02:00",
-          "updated_at": "2025-06-19T13:09:11.270412+02:00",
-          "name": "bar.example.org",
-          "contact": "me@example.org",
-          "ttl": null,
-          "comment": "This is the comment",
-          "zone": 1
-        }
-      },
-      {
-        "method": "GET",
         "url": "/api/v1/networks/ip/10.0.0.14",
         "data": {},
         "status": 200,
@@ -28241,8 +25665,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-06-19T13:09:09.671414+02:00",
-          "updated_at": "2025-06-19T13:09:09.671430+02:00",
+          "created_at": "2025-08-26T11:56:52.269985+02:00",
+          "updated_at": "2025-08-26T11:56:52.270000+02:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -28262,8 +25686,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-06-19T13:09:09.671414+02:00",
-          "updated_at": "2025-06-19T13:09:09.671430+02:00",
+          "created_at": "2025-08-26T11:56:52.269985+02:00",
+          "updated_at": "2025-08-26T11:56:52.270000+02:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -28288,68 +25712,7 @@
     "output": [
       "Cname:        fubar.example.org -> bar.example.org"
     ],
-    "api_requests": [
-      {
-        "method": "GET",
-        "url": "/api/v1/hosts/bar.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "",
-              "created_at": "2025-06-19T13:09:11.489496+02:00",
-              "updated_at": "2025-06-19T13:09:11.845269+02:00",
-              "ipaddress": "10.0.0.14",
-              "host": 19
-            },
-            {
-              "macaddress": "11:22:33:44:55:66",
-              "created_at": "2025-06-19T13:09:11.658060+02:00",
-              "updated_at": "2025-06-19T13:09:12.012542+02:00",
-              "ipaddress": "10.0.0.15",
-              "host": 19
-            }
-          ],
-          "cnames": [
-            {
-              "created_at": "2025-06-19T13:09:13.466436+02:00",
-              "updated_at": "2025-06-19T13:09:13.466444+02:00",
-              "name": "fubar.example.org",
-              "ttl": null,
-              "zone": 1,
-              "host": 19
-            }
-          ],
-          "mxs": [],
-          "txts": [
-            {
-              "created_at": "2025-06-19T13:09:09.945029+02:00",
-              "updated_at": "2025-06-19T13:09:09.945036+02:00",
-              "txt": "v=spf1 -all",
-              "host": 19
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "created_at": "2025-06-19T13:09:09.942915+02:00",
-          "updated_at": "2025-06-19T13:09:11.270412+02:00",
-          "name": "bar.example.org",
-          "contact": "me@example.org",
-          "ttl": null,
-          "comment": "This is the comment",
-          "zone": 1
-        }
-      }
-    ],
+    "api_requests": [],
     "time": null
   },
   {
@@ -28364,66 +25727,6 @@
       "Removed CNAME fubar.example.org for bar.example.org."
     ],
     "api_requests": [
-      {
-        "method": "GET",
-        "url": "/api/v1/hosts/bar.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "",
-              "created_at": "2025-06-19T13:09:11.489496+02:00",
-              "updated_at": "2025-06-19T13:09:11.845269+02:00",
-              "ipaddress": "10.0.0.14",
-              "host": 19
-            },
-            {
-              "macaddress": "11:22:33:44:55:66",
-              "created_at": "2025-06-19T13:09:11.658060+02:00",
-              "updated_at": "2025-06-19T13:09:12.012542+02:00",
-              "ipaddress": "10.0.0.15",
-              "host": 19
-            }
-          ],
-          "cnames": [
-            {
-              "created_at": "2025-06-19T13:09:13.466436+02:00",
-              "updated_at": "2025-06-19T13:09:13.466444+02:00",
-              "name": "fubar.example.org",
-              "ttl": null,
-              "zone": 1,
-              "host": 19
-            }
-          ],
-          "mxs": [],
-          "txts": [
-            {
-              "created_at": "2025-06-19T13:09:09.945029+02:00",
-              "updated_at": "2025-06-19T13:09:09.945036+02:00",
-              "txt": "v=spf1 -all",
-              "host": 19
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "created_at": "2025-06-19T13:09:09.942915+02:00",
-          "updated_at": "2025-06-19T13:09:11.270412+02:00",
-          "name": "bar.example.org",
-          "contact": "me@example.org",
-          "ttl": null,
-          "comment": "This is the comment",
-          "zone": 1
-        }
-      },
       {
         "method": "GET",
         "url": "/api/v1/hosts/fubar.example.org",
@@ -28446,8 +25749,8 @@
         "data": {},
         "status": 200,
         "response": {
-          "created_at": "2025-06-19T13:09:13.466436+02:00",
-          "updated_at": "2025-06-19T13:09:13.466444+02:00",
+          "created_at": "2025-08-26T11:56:58.707306+02:00",
+          "updated_at": "2025-08-26T11:56:58.707335+02:00",
           "name": "fubar.example.org",
           "ttl": null,
           "zone": 1,
@@ -28708,76 +26011,6 @@
     "output": [],
     "api_requests": [
       {
-        "method": "GET",
-        "url": "/api/v1/hosts/baz.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2025-06-19T13:09:09.968166+02:00",
-              "updated_at": "2025-06-19T13:09:12.300460+02:00",
-              "ipaddress": "10.0.0.10",
-              "host": 20
-            },
-            {
-              "macaddress": "11:22:33:44:55:67",
-              "created_at": "2025-06-19T13:09:12.648868+02:00",
-              "updated_at": "2025-06-19T13:09:13.288692+02:00",
-              "ipaddress": "2001:db8::14",
-              "host": 20
-            }
-          ],
-          "cnames": [],
-          "mxs": [],
-          "txts": [
-            {
-              "created_at": "2025-06-19T13:09:12.150069+02:00",
-              "updated_at": "2025-06-19T13:09:12.150078+02:00",
-              "txt": "v=spf1 -all",
-              "host": 20
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": {
-            "host": 20,
-            "created_at": "2025-06-19T13:09:13.901605+02:00",
-            "updated_at": "2025-06-19T13:09:13.901611+02:00",
-            "cpu": "x86",
-            "os": "Win"
-          },
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "created_at": "2025-06-19T13:09:12.147666+02:00",
-          "updated_at": "2025-06-19T13:09:12.147677+02:00",
-          "name": "baz.example.org",
-          "contact": "",
-          "ttl": null,
-          "comment": "",
-          "zone": 1
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hinfos/20",
-        "data": {},
-        "status": 200,
-        "response": {
-          "host": 20,
-          "created_at": "2025-06-19T13:09:13.901605+02:00",
-          "updated_at": "2025-06-19T13:09:13.901611+02:00",
-          "cpu": "x86",
-          "os": "Win"
-        }
-      },
-      {
         "method": "DELETE",
         "url": "/api/v1/hinfos/20",
         "data": {},
@@ -29014,62 +26247,6 @@
     "output": [],
     "api_requests": [
       {
-        "method": "GET",
-        "url": "/api/v1/hosts/baz.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2025-06-19T13:09:09.968166+02:00",
-              "updated_at": "2025-06-19T13:09:12.300460+02:00",
-              "ipaddress": "10.0.0.10",
-              "host": 20
-            },
-            {
-              "macaddress": "11:22:33:44:55:67",
-              "created_at": "2025-06-19T13:09:12.648868+02:00",
-              "updated_at": "2025-06-19T13:09:13.288692+02:00",
-              "ipaddress": "2001:db8::14",
-              "host": 20
-            }
-          ],
-          "cnames": [],
-          "mxs": [],
-          "txts": [
-            {
-              "created_at": "2025-06-19T13:09:12.150069+02:00",
-              "updated_at": "2025-06-19T13:09:12.150078+02:00",
-              "txt": "v=spf1 -all",
-              "host": 20
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": {
-            "host": 20,
-            "created_at": "2025-06-19T13:09:14.141935+02:00",
-            "updated_at": "2025-06-19T13:09:14.141941+02:00",
-            "loc": "52 22 23.000 N 4 53 32.000 E -2.00m 0.00m 10000m 10m"
-          },
-          "bacnetid": null,
-          "communities": [],
-          "created_at": "2025-06-19T13:09:12.147666+02:00",
-          "updated_at": "2025-06-19T13:09:12.147677+02:00",
-          "name": "baz.example.org",
-          "contact": "",
-          "ttl": null,
-          "comment": "",
-          "zone": 1
-        }
-      },
-      {
         "method": "DELETE",
         "url": "/api/v1/locs/20",
         "data": {},
@@ -29250,65 +26427,6 @@
     "api_requests": [
       {
         "method": "GET",
-        "url": "/api/v1/hosts/baz.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2025-06-19T13:09:09.968166+02:00",
-              "updated_at": "2025-06-19T13:09:12.300460+02:00",
-              "ipaddress": "10.0.0.10",
-              "host": 20
-            },
-            {
-              "macaddress": "11:22:33:44:55:67",
-              "created_at": "2025-06-19T13:09:12.648868+02:00",
-              "updated_at": "2025-06-19T13:09:13.288692+02:00",
-              "ipaddress": "2001:db8::14",
-              "host": 20
-            }
-          ],
-          "cnames": [],
-          "mxs": [
-            {
-              "created_at": "2025-06-19T13:09:14.322891+02:00",
-              "updated_at": "2025-06-19T13:09:14.322898+02:00",
-              "priority": 10,
-              "mx": "mail.example.org",
-              "host": 20
-            }
-          ],
-          "txts": [
-            {
-              "created_at": "2025-06-19T13:09:12.150069+02:00",
-              "updated_at": "2025-06-19T13:09:12.150078+02:00",
-              "txt": "v=spf1 -all",
-              "host": 20
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "created_at": "2025-06-19T13:09:12.147666+02:00",
-          "updated_at": "2025-06-19T13:09:12.147677+02:00",
-          "name": "baz.example.org",
-          "contact": "",
-          "ttl": null,
-          "comment": "",
-          "zone": 1
-        }
-      },
-      {
-        "method": "GET",
         "url": "/api/v1/networks/ip/10.0.0.10",
         "data": {},
         "status": 200,
@@ -29316,8 +26434,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-06-19T13:09:09.671414+02:00",
-          "updated_at": "2025-06-19T13:09:09.671430+02:00",
+          "created_at": "2025-08-26T11:56:52.269985+02:00",
+          "updated_at": "2025-08-26T11:56:52.270000+02:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -29337,8 +26455,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-06-19T13:09:09.737206+02:00",
-          "updated_at": "2025-06-19T13:09:09.737214+02:00",
+          "created_at": "2025-08-26T11:56:52.409989+02:00",
+          "updated_at": "2025-08-26T11:56:52.410004+02:00",
           "network": "2001:db8::/64",
           "description": "dolor sit amet",
           "vlan": null,
@@ -29366,65 +26484,6 @@
     "api_requests": [
       {
         "method": "GET",
-        "url": "/api/v1/hosts/baz.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2025-06-19T13:09:09.968166+02:00",
-              "updated_at": "2025-06-19T13:09:12.300460+02:00",
-              "ipaddress": "10.0.0.10",
-              "host": 20
-            },
-            {
-              "macaddress": "11:22:33:44:55:67",
-              "created_at": "2025-06-19T13:09:12.648868+02:00",
-              "updated_at": "2025-06-19T13:09:13.288692+02:00",
-              "ipaddress": "2001:db8::14",
-              "host": 20
-            }
-          ],
-          "cnames": [],
-          "mxs": [
-            {
-              "created_at": "2025-06-19T13:09:14.322891+02:00",
-              "updated_at": "2025-06-19T13:09:14.322898+02:00",
-              "priority": 10,
-              "mx": "mail.example.org",
-              "host": 20
-            }
-          ],
-          "txts": [
-            {
-              "created_at": "2025-06-19T13:09:12.150069+02:00",
-              "updated_at": "2025-06-19T13:09:12.150078+02:00",
-              "txt": "v=spf1 -all",
-              "host": 20
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "created_at": "2025-06-19T13:09:12.147666+02:00",
-          "updated_at": "2025-06-19T13:09:12.147677+02:00",
-          "name": "baz.example.org",
-          "contact": "",
-          "ttl": null,
-          "comment": "",
-          "zone": 1
-        }
-      },
-      {
-        "method": "GET",
         "url": "/api/v1/mxs/?host=20&mx=mail.example.org&priority=10",
         "data": {},
         "status": 200,
@@ -29434,8 +26493,8 @@
           "previous": null,
           "results": [
             {
-              "created_at": "2025-06-19T13:09:14.322891+02:00",
-              "updated_at": "2025-06-19T13:09:14.322898+02:00",
+              "created_at": "2025-08-26T11:56:59.513810+02:00",
+              "updated_at": "2025-08-26T11:56:59.513816+02:00",
               "priority": 10,
               "mx": "mail.example.org",
               "host": 20
@@ -29646,69 +26705,6 @@
     "error": [],
     "output": [],
     "api_requests": [
-      {
-        "method": "GET",
-        "url": "/api/v1/hosts/baz.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2025-06-19T13:09:09.968166+02:00",
-              "updated_at": "2025-06-19T13:09:12.300460+02:00",
-              "ipaddress": "10.0.0.10",
-              "host": 20
-            },
-            {
-              "macaddress": "11:22:33:44:55:67",
-              "created_at": "2025-06-19T13:09:12.648868+02:00",
-              "updated_at": "2025-06-19T13:09:13.288692+02:00",
-              "ipaddress": "2001:db8::14",
-              "host": 20
-            }
-          ],
-          "cnames": [],
-          "mxs": [],
-          "txts": [
-            {
-              "created_at": "2025-06-19T13:09:12.150069+02:00",
-              "updated_at": "2025-06-19T13:09:12.150078+02:00",
-              "txt": "v=spf1 -all",
-              "host": 20
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [
-            {
-              "created_at": "2025-06-19T13:09:14.606131+02:00",
-              "updated_at": "2025-06-19T13:09:14.606137+02:00",
-              "preference": 16384,
-              "order": 3,
-              "flag": "u",
-              "service": "sip",
-              "regex": "[abc]+",
-              "replacement": "wonk",
-              "host": 20
-            }
-          ],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "created_at": "2025-06-19T13:09:12.147666+02:00",
-          "updated_at": "2025-06-19T13:09:12.147677+02:00",
-          "name": "baz.example.org",
-          "contact": "",
-          "ttl": null,
-          "comment": "",
-          "zone": 1
-        }
-      },
       {
         "method": "DELETE",
         "url": "/api/v1/naptrs/1",
@@ -30509,57 +27505,6 @@
     "api_requests": [
       {
         "method": "GET",
-        "url": "/api/v1/hosts/baz.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2025-06-19T13:09:09.968166+02:00",
-              "updated_at": "2025-06-19T13:09:12.300460+02:00",
-              "ipaddress": "10.0.0.10",
-              "host": 20
-            },
-            {
-              "macaddress": "11:22:33:44:55:67",
-              "created_at": "2025-06-19T13:09:12.648868+02:00",
-              "updated_at": "2025-06-19T13:09:13.288692+02:00",
-              "ipaddress": "2001:db8::14",
-              "host": 20
-            }
-          ],
-          "cnames": [],
-          "mxs": [],
-          "txts": [
-            {
-              "created_at": "2025-06-19T13:09:12.150069+02:00",
-              "updated_at": "2025-06-19T13:09:12.150078+02:00",
-              "txt": "v=spf1 -all",
-              "host": 20
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "created_at": "2025-06-19T13:09:12.147666+02:00",
-          "updated_at": "2025-06-19T13:09:12.147677+02:00",
-          "name": "baz.example.org",
-          "contact": "",
-          "ttl": null,
-          "comment": "",
-          "zone": 1
-        }
-      },
-      {
-        "method": "GET",
         "url": "/api/v1/zones/forward/hostname/_sip._tcp.example.org",
         "data": {},
         "status": 200,
@@ -30567,48 +27512,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2025-06-19T13:08:49.394396+02:00",
-                "updated_at": "2025-06-19T13:08:49.394408+02:00",
+                "created_at": "2025-08-26T11:56:35.781651+02:00",
+                "updated_at": "2025-08-26T11:56:35.781663+02:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-06-19T13:08:48.992266+02:00",
-            "updated_at": "2025-06-19T13:09:15.460033+02:00",
+            "created_at": "2025-08-26T11:56:35.478972+02:00",
+            "updated_at": "2025-08-26T11:57:00.621893+02:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-06-19T13:08:49.869830+02:00",
-            "refresh": 360,
-            "retry": 1800,
-            "expire": 2400,
-            "soa_ttl": 1800,
-            "default_ttl": 300,
-            "name": "example.org"
-          }
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/zones/forward/hostname/baz.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "zone": {
-            "nameservers": [
-              {
-                "created_at": "2025-06-19T13:08:49.394396+02:00",
-                "updated_at": "2025-06-19T13:08:49.394408+02:00",
-                "name": "ns2.example.org",
-                "ttl": null
-              }
-            ],
-            "created_at": "2025-06-19T13:08:48.992266+02:00",
-            "updated_at": "2025-06-19T13:09:15.460033+02:00",
-            "updated": true,
-            "primary_ns": "ns2.example.org",
-            "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-06-19T13:08:49.869830+02:00",
+            "serialno_updated_at": "2025-08-26T11:56:36.090230+02:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -30642,8 +27557,8 @@
         },
         "status": 201,
         "response": {
-          "created_at": "2025-06-19T13:09:15.741486+02:00",
-          "updated_at": "2025-06-19T13:09:15.741494+02:00",
+          "created_at": "2025-08-26T11:57:00.848637+02:00",
+          "updated_at": "2025-08-26T11:57:00.848645+02:00",
           "name": "_sip._tcp.example.org",
           "priority": 10,
           "weight": 5,
@@ -31062,67 +27977,6 @@
     "api_requests": [
       {
         "method": "GET",
-        "url": "/api/v1/hosts/bar.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "",
-              "created_at": "2025-06-19T13:09:11.489496+02:00",
-              "updated_at": "2025-06-19T13:09:11.845269+02:00",
-              "ipaddress": "10.0.0.14",
-              "host": 19
-            },
-            {
-              "macaddress": "11:22:33:44:55:66",
-              "created_at": "2025-06-19T13:09:11.658060+02:00",
-              "updated_at": "2025-06-19T13:09:12.012542+02:00",
-              "ipaddress": "10.0.0.15",
-              "host": 19
-            }
-          ],
-          "cnames": [],
-          "mxs": [],
-          "txts": [
-            {
-              "created_at": "2025-06-19T13:09:09.945029+02:00",
-              "updated_at": "2025-06-19T13:09:09.945036+02:00",
-              "txt": "v=spf1 -all",
-              "host": 19
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [],
-          "sshfps": [
-            {
-              "created_at": "2025-06-19T13:09:15.967843+02:00",
-              "updated_at": "2025-06-19T13:09:15.967849+02:00",
-              "ttl": null,
-              "algorithm": 1,
-              "hash_type": 1,
-              "fingerprint": "12345678abcde",
-              "host": 19
-            }
-          ],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "created_at": "2025-06-19T13:09:09.942915+02:00",
-          "updated_at": "2025-06-19T13:09:11.270412+02:00",
-          "name": "bar.example.org",
-          "contact": "me@example.org",
-          "ttl": null,
-          "comment": "This is the comment",
-          "zone": 1
-        }
-      },
-      {
-        "method": "GET",
         "url": "/api/v1/sshfps/?fingerprint=394875985&host=19",
         "data": {},
         "status": 200,
@@ -31148,67 +28002,6 @@
     "error": [],
     "output": [],
     "api_requests": [
-      {
-        "method": "GET",
-        "url": "/api/v1/hosts/bar.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "",
-              "created_at": "2025-06-19T13:09:11.489496+02:00",
-              "updated_at": "2025-06-19T13:09:11.845269+02:00",
-              "ipaddress": "10.0.0.14",
-              "host": 19
-            },
-            {
-              "macaddress": "11:22:33:44:55:66",
-              "created_at": "2025-06-19T13:09:11.658060+02:00",
-              "updated_at": "2025-06-19T13:09:12.012542+02:00",
-              "ipaddress": "10.0.0.15",
-              "host": 19
-            }
-          ],
-          "cnames": [],
-          "mxs": [],
-          "txts": [
-            {
-              "created_at": "2025-06-19T13:09:09.945029+02:00",
-              "updated_at": "2025-06-19T13:09:09.945036+02:00",
-              "txt": "v=spf1 -all",
-              "host": 19
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [],
-          "sshfps": [
-            {
-              "created_at": "2025-06-19T13:09:15.967843+02:00",
-              "updated_at": "2025-06-19T13:09:15.967849+02:00",
-              "ttl": null,
-              "algorithm": 1,
-              "hash_type": 1,
-              "fingerprint": "12345678abcde",
-              "host": 19
-            }
-          ],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "created_at": "2025-06-19T13:09:09.942915+02:00",
-          "updated_at": "2025-06-19T13:09:11.270412+02:00",
-          "name": "bar.example.org",
-          "contact": "me@example.org",
-          "ttl": null,
-          "comment": "This is the comment",
-          "zone": 1
-        }
-      },
       {
         "method": "DELETE",
         "url": "/api/v1/sshfps/1",
@@ -31429,57 +28222,6 @@
     "output": [],
     "api_requests": [
       {
-        "method": "GET",
-        "url": "/api/v1/hosts/bar.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "",
-              "created_at": "2025-06-19T13:09:11.489496+02:00",
-              "updated_at": "2025-06-19T13:09:11.845269+02:00",
-              "ipaddress": "10.0.0.14",
-              "host": 19
-            },
-            {
-              "macaddress": "11:22:33:44:55:66",
-              "created_at": "2025-06-19T13:09:11.658060+02:00",
-              "updated_at": "2025-06-19T13:09:12.012542+02:00",
-              "ipaddress": "10.0.0.15",
-              "host": 19
-            }
-          ],
-          "cnames": [],
-          "mxs": [],
-          "txts": [
-            {
-              "created_at": "2025-06-19T13:09:09.945029+02:00",
-              "updated_at": "2025-06-19T13:09:09.945036+02:00",
-              "txt": "v=spf1 -all",
-              "host": 19
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "created_at": "2025-06-19T13:09:09.942915+02:00",
-          "updated_at": "2025-06-19T13:09:16.207212+02:00",
-          "name": "bar.example.org",
-          "contact": "me@example.org",
-          "ttl": 3600,
-          "comment": "This is the comment",
-          "zone": 1
-        }
-      },
-      {
         "method": "PATCH",
         "url": "/api/v1/hosts/bar.example.org",
         "data": {
@@ -31501,15 +28243,15 @@
               "ipaddresses": [
                 {
                   "macaddress": "",
-                  "created_at": "2025-06-19T13:09:11.489496+02:00",
-                  "updated_at": "2025-06-19T13:09:11.845269+02:00",
+                  "created_at": "2025-08-26T11:56:54.782509+02:00",
+                  "updated_at": "2025-08-26T11:56:55.340478+02:00",
                   "ipaddress": "10.0.0.14",
                   "host": 19
                 },
                 {
                   "macaddress": "11:22:33:44:55:66",
-                  "created_at": "2025-06-19T13:09:11.658060+02:00",
-                  "updated_at": "2025-06-19T13:09:12.012542+02:00",
+                  "created_at": "2025-08-26T11:56:55.103884+02:00",
+                  "updated_at": "2025-08-26T11:56:55.613257+02:00",
                   "ipaddress": "10.0.0.15",
                   "host": 19
                 }
@@ -31518,8 +28260,8 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2025-06-19T13:09:09.945029+02:00",
-                  "updated_at": "2025-06-19T13:09:09.945036+02:00",
+                  "created_at": "2025-08-26T11:56:52.619543+02:00",
+                  "updated_at": "2025-08-26T11:56:52.619576+02:00",
                   "txt": "v=spf1 -all",
                   "host": 19
                 }
@@ -31534,8 +28276,8 @@
               "loc": null,
               "bacnetid": null,
               "communities": [],
-              "created_at": "2025-06-19T13:09:09.942915+02:00",
-              "updated_at": "2025-06-19T13:09:16.379596+02:00",
+              "created_at": "2025-08-26T11:56:52.606852+02:00",
+              "updated_at": "2025-08-26T11:57:01.618739+02:00",
               "name": "bar.example.org",
               "contact": "me@example.org",
               "ttl": null,
@@ -31716,63 +28458,6 @@
     "api_requests": [
       {
         "method": "GET",
-        "url": "/api/v1/hosts/bar.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "",
-              "created_at": "2025-06-19T13:09:11.489496+02:00",
-              "updated_at": "2025-06-19T13:09:11.845269+02:00",
-              "ipaddress": "10.0.0.14",
-              "host": 19
-            },
-            {
-              "macaddress": "11:22:33:44:55:66",
-              "created_at": "2025-06-19T13:09:11.658060+02:00",
-              "updated_at": "2025-06-19T13:09:12.012542+02:00",
-              "ipaddress": "10.0.0.15",
-              "host": 19
-            }
-          ],
-          "cnames": [],
-          "mxs": [],
-          "txts": [
-            {
-              "created_at": "2025-06-19T13:09:09.945029+02:00",
-              "updated_at": "2025-06-19T13:09:09.945036+02:00",
-              "txt": "v=spf1 -all",
-              "host": 19
-            },
-            {
-              "created_at": "2025-06-19T13:09:16.496986+02:00",
-              "updated_at": "2025-06-19T13:09:16.496993+02:00",
-              "txt": "Lorem ipsum dolor sit amet",
-              "host": 19
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "created_at": "2025-06-19T13:09:09.942915+02:00",
-          "updated_at": "2025-06-19T13:09:16.379596+02:00",
-          "name": "bar.example.org",
-          "contact": "me@example.org",
-          "ttl": null,
-          "comment": "This is the comment",
-          "zone": 1
-        }
-      },
-      {
-        "method": "GET",
         "url": "/api/v1/txts/?host=19&txt=Whatever",
         "data": {},
         "status": 200,
@@ -31800,63 +28485,6 @@
     "api_requests": [
       {
         "method": "GET",
-        "url": "/api/v1/hosts/bar.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "",
-              "created_at": "2025-06-19T13:09:11.489496+02:00",
-              "updated_at": "2025-06-19T13:09:11.845269+02:00",
-              "ipaddress": "10.0.0.14",
-              "host": 19
-            },
-            {
-              "macaddress": "11:22:33:44:55:66",
-              "created_at": "2025-06-19T13:09:11.658060+02:00",
-              "updated_at": "2025-06-19T13:09:12.012542+02:00",
-              "ipaddress": "10.0.0.15",
-              "host": 19
-            }
-          ],
-          "cnames": [],
-          "mxs": [],
-          "txts": [
-            {
-              "created_at": "2025-06-19T13:09:09.945029+02:00",
-              "updated_at": "2025-06-19T13:09:09.945036+02:00",
-              "txt": "v=spf1 -all",
-              "host": 19
-            },
-            {
-              "created_at": "2025-06-19T13:09:16.496986+02:00",
-              "updated_at": "2025-06-19T13:09:16.496993+02:00",
-              "txt": "Lorem ipsum dolor sit amet",
-              "host": 19
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "created_at": "2025-06-19T13:09:09.942915+02:00",
-          "updated_at": "2025-06-19T13:09:16.379596+02:00",
-          "name": "bar.example.org",
-          "contact": "me@example.org",
-          "ttl": null,
-          "comment": "This is the comment",
-          "zone": 1
-        }
-      },
-      {
-        "method": "GET",
         "url": "/api/v1/txts/?host=19&txt=Lorem+ipsum+dolor+sit+amet",
         "data": {},
         "status": 200,
@@ -31866,8 +28494,8 @@
           "previous": null,
           "results": [
             {
-              "created_at": "2025-06-19T13:09:16.496986+02:00",
-              "updated_at": "2025-06-19T13:09:16.496993+02:00",
+              "created_at": "2025-08-26T11:57:01.730234+02:00",
+              "updated_at": "2025-08-26T11:57:01.730241+02:00",
               "txt": "Lorem ipsum dolor sit amet",
               "host": 19
             }
@@ -33070,58 +29698,6 @@
     "output": [],
     "api_requests": [
       {
-        "method": "GET",
-        "url": "/api/v1/hosts/foo.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "",
-              "created_at": "2025-06-19T13:09:18.752804+02:00",
-              "updated_at": "2025-06-19T13:09:18.752813+02:00",
-              "ipaddress": "10.0.0.10",
-              "host": 24
-            }
-          ],
-          "cnames": [],
-          "mxs": [
-            {
-              "created_at": "2025-06-19T13:09:18.884373+02:00",
-              "updated_at": "2025-06-19T13:09:18.884384+02:00",
-              "priority": 10,
-              "mx": "mail.example.org",
-              "host": 24
-            }
-          ],
-          "txts": [
-            {
-              "created_at": "2025-06-19T13:09:18.714858+02:00",
-              "updated_at": "2025-06-19T13:09:18.714865+02:00",
-              "txt": "v=spf1 -all",
-              "host": 24
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "created_at": "2025-06-19T13:09:18.711816+02:00",
-          "updated_at": "2025-06-19T13:09:18.711843+02:00",
-          "name": "foo.example.org",
-          "contact": "foo@example.org",
-          "ttl": null,
-          "comment": "",
-          "zone": 1
-        }
-      },
-      {
         "method": "DELETE",
         "url": "/api/v1/hosts/foo.example.org",
         "data": {},
@@ -33513,57 +30089,6 @@
     "output": [],
     "api_requests": [
       {
-        "method": "GET",
-        "url": "/api/v1/hosts/foo.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "",
-              "created_at": "2025-06-19T13:09:19.182163+02:00",
-              "updated_at": "2025-06-19T13:09:19.182175+02:00",
-              "ipaddress": "10.0.0.10",
-              "host": 25
-            }
-          ],
-          "cnames": [],
-          "mxs": [],
-          "txts": [
-            {
-              "created_at": "2025-06-19T13:09:19.124521+02:00",
-              "updated_at": "2025-06-19T13:09:19.124527+02:00",
-              "txt": "v=spf1 -all",
-              "host": 25
-            }
-          ],
-          "ptr_overrides": [
-            {
-              "created_at": "2025-06-19T13:09:19.598259+02:00",
-              "updated_at": "2025-06-19T13:09:19.598267+02:00",
-              "ipaddress": "10.0.0.11",
-              "host": 25
-            }
-          ],
-          "srvs": [],
-          "naptrs": [],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "created_at": "2025-06-19T13:09:19.122473+02:00",
-          "updated_at": "2025-06-19T13:09:19.122481+02:00",
-          "name": "foo.example.org",
-          "contact": "foo@example.org",
-          "ttl": null,
-          "comment": "",
-          "zone": 1
-        }
-      },
-      {
         "method": "DELETE",
         "url": "/api/v1/hosts/foo.example.org",
         "data": {},
@@ -33935,62 +30460,6 @@
     "error": [],
     "output": [],
     "api_requests": [
-      {
-        "method": "GET",
-        "url": "/api/v1/hosts/foo.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "",
-              "created_at": "2025-06-19T13:09:19.904349+02:00",
-              "updated_at": "2025-06-19T13:09:19.904368+02:00",
-              "ipaddress": "10.0.0.10",
-              "host": 26
-            }
-          ],
-          "cnames": [],
-          "mxs": [],
-          "txts": [
-            {
-              "created_at": "2025-06-19T13:09:19.880837+02:00",
-              "updated_at": "2025-06-19T13:09:19.880845+02:00",
-              "txt": "v=spf1 -all",
-              "host": 26
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [
-            {
-              "created_at": "2025-06-19T13:09:20.143803+02:00",
-              "updated_at": "2025-06-19T13:09:20.143814+02:00",
-              "preference": 16384,
-              "order": 3,
-              "flag": "u",
-              "service": "sip",
-              "regex": "[abc]+",
-              "replacement": "wonk",
-              "host": 26
-            }
-          ],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "created_at": "2025-06-19T13:09:19.878789+02:00",
-          "updated_at": "2025-06-19T13:09:19.878799+02:00",
-          "name": "foo.example.org",
-          "contact": "foo@example.org",
-          "ttl": null,
-          "comment": "",
-          "zone": 1
-        }
-      },
       {
         "method": "DELETE",
         "url": "/api/v1/hosts/foo.example.org",
@@ -34422,62 +30891,6 @@
     "output": [],
     "api_requests": [
       {
-        "method": "GET",
-        "url": "/api/v1/hosts/foo.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "",
-              "created_at": "2025-06-19T13:09:20.455468+02:00",
-              "updated_at": "2025-06-19T13:09:20.455475+02:00",
-              "ipaddress": "10.0.0.10",
-              "host": 27
-            }
-          ],
-          "cnames": [],
-          "mxs": [],
-          "txts": [
-            {
-              "created_at": "2025-06-19T13:09:20.437537+02:00",
-              "updated_at": "2025-06-19T13:09:20.437544+02:00",
-              "txt": "v=spf1 -all",
-              "host": 27
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [
-            {
-              "created_at": "2025-06-19T13:09:20.637233+02:00",
-              "updated_at": "2025-06-19T13:09:20.637240+02:00",
-              "name": "_sip._tcp.example.org",
-              "priority": 10,
-              "weight": 5,
-              "port": 3456,
-              "ttl": null,
-              "zone": 1,
-              "host": 27
-            }
-          ],
-          "naptrs": [],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "created_at": "2025-06-19T13:09:20.435581+02:00",
-          "updated_at": "2025-06-19T13:09:20.435588+02:00",
-          "name": "foo.example.org",
-          "contact": "foo@example.org",
-          "ttl": null,
-          "comment": "",
-          "zone": 1
-        }
-      },
-      {
         "method": "DELETE",
         "url": "/api/v1/hosts/foo.example.org",
         "data": {},
@@ -34892,61 +31305,7 @@
     ],
     "error": [],
     "output": [],
-    "api_requests": [
-      {
-        "method": "GET",
-        "url": "/api/v1/hosts/foo.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "",
-              "created_at": "2025-06-19T13:09:20.871148+02:00",
-              "updated_at": "2025-06-19T13:09:20.871156+02:00",
-              "ipaddress": "10.0.0.10",
-              "host": 28
-            }
-          ],
-          "cnames": [
-            {
-              "created_at": "2025-06-19T13:09:21.039050+02:00",
-              "updated_at": "2025-06-19T13:09:21.039058+02:00",
-              "name": "fubar.example.org",
-              "ttl": null,
-              "zone": 1,
-              "host": 28
-            }
-          ],
-          "mxs": [],
-          "txts": [
-            {
-              "created_at": "2025-06-19T13:09:20.855535+02:00",
-              "updated_at": "2025-06-19T13:09:20.855540+02:00",
-              "txt": "v=spf1 -all",
-              "host": 28
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "created_at": "2025-06-19T13:09:20.853583+02:00",
-          "updated_at": "2025-06-19T13:09:20.853593+02:00",
-          "name": "foo.example.org",
-          "contact": "foo@example.org",
-          "ttl": null,
-          "comment": "",
-          "zone": 1
-        }
-      }
-    ],
+    "api_requests": [],
     "time": null
   },
   {
@@ -34961,59 +31320,6 @@
     "error": [],
     "output": [],
     "api_requests": [
-      {
-        "method": "GET",
-        "url": "/api/v1/hosts/foo.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "",
-              "created_at": "2025-06-19T13:09:20.871148+02:00",
-              "updated_at": "2025-06-19T13:09:20.871156+02:00",
-              "ipaddress": "10.0.0.10",
-              "host": 28
-            }
-          ],
-          "cnames": [
-            {
-              "created_at": "2025-06-19T13:09:21.039050+02:00",
-              "updated_at": "2025-06-19T13:09:21.039058+02:00",
-              "name": "fubar.example.org",
-              "ttl": null,
-              "zone": 1,
-              "host": 28
-            }
-          ],
-          "mxs": [],
-          "txts": [
-            {
-              "created_at": "2025-06-19T13:09:20.855535+02:00",
-              "updated_at": "2025-06-19T13:09:20.855540+02:00",
-              "txt": "v=spf1 -all",
-              "host": 28
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "created_at": "2025-06-19T13:09:20.853583+02:00",
-          "updated_at": "2025-06-19T13:09:20.853593+02:00",
-          "name": "foo.example.org",
-          "contact": "foo@example.org",
-          "ttl": null,
-          "comment": "",
-          "zone": 1
-        }
-      },
       {
         "method": "DELETE",
         "url": "/api/v1/hosts/foo.example.org",
@@ -36003,100 +32309,7 @@
     ],
     "error": [],
     "output": [],
-    "api_requests": [
-      {
-        "method": "GET",
-        "url": "/api/v1/hosts/foo.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "",
-              "created_at": "2025-06-19T13:09:21.423104+02:00",
-              "updated_at": "2025-06-19T13:09:21.423114+02:00",
-              "ipaddress": "10.0.0.10",
-              "host": 29
-            }
-          ],
-          "cnames": [
-            {
-              "created_at": "2025-06-19T13:09:22.259207+02:00",
-              "updated_at": "2025-06-19T13:09:22.259214+02:00",
-              "name": "fubar.example.org",
-              "ttl": null,
-              "zone": 1,
-              "host": 29
-            }
-          ],
-          "mxs": [
-            {
-              "created_at": "2025-06-19T13:09:21.529516+02:00",
-              "updated_at": "2025-06-19T13:09:21.529525+02:00",
-              "priority": 10,
-              "mx": "mail.example.org",
-              "host": 29
-            }
-          ],
-          "txts": [
-            {
-              "created_at": "2025-06-19T13:09:21.402387+02:00",
-              "updated_at": "2025-06-19T13:09:21.402394+02:00",
-              "txt": "v=spf1 -all",
-              "host": 29
-            }
-          ],
-          "ptr_overrides": [
-            {
-              "created_at": "2025-06-19T13:09:21.681379+02:00",
-              "updated_at": "2025-06-19T13:09:21.681387+02:00",
-              "ipaddress": "10.0.0.11",
-              "host": 29
-            }
-          ],
-          "srvs": [
-            {
-              "created_at": "2025-06-19T13:09:22.144577+02:00",
-              "updated_at": "2025-06-19T13:09:22.144585+02:00",
-              "name": "_sip._tcp.example.org",
-              "priority": 10,
-              "weight": 5,
-              "port": 3456,
-              "ttl": null,
-              "zone": 1,
-              "host": 29
-            }
-          ],
-          "naptrs": [
-            {
-              "created_at": "2025-06-19T13:09:21.991643+02:00",
-              "updated_at": "2025-06-19T13:09:21.991651+02:00",
-              "preference": 16384,
-              "order": 3,
-              "flag": "u",
-              "service": "sip",
-              "regex": "[abc]+",
-              "replacement": "wonk",
-              "host": 29
-            }
-          ],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "created_at": "2025-06-19T13:09:21.400433+02:00",
-          "updated_at": "2025-06-19T13:09:21.400440+02:00",
-          "name": "foo.example.org",
-          "contact": "foo@example.org",
-          "ttl": null,
-          "comment": "",
-          "zone": 1
-        }
-      }
-    ],
+    "api_requests": [],
     "time": null
   },
   {
@@ -36114,98 +32327,6 @@
     "error": [],
     "output": [],
     "api_requests": [
-      {
-        "method": "GET",
-        "url": "/api/v1/hosts/foo.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "",
-              "created_at": "2025-06-19T13:09:21.423104+02:00",
-              "updated_at": "2025-06-19T13:09:21.423114+02:00",
-              "ipaddress": "10.0.0.10",
-              "host": 29
-            }
-          ],
-          "cnames": [
-            {
-              "created_at": "2025-06-19T13:09:22.259207+02:00",
-              "updated_at": "2025-06-19T13:09:22.259214+02:00",
-              "name": "fubar.example.org",
-              "ttl": null,
-              "zone": 1,
-              "host": 29
-            }
-          ],
-          "mxs": [
-            {
-              "created_at": "2025-06-19T13:09:21.529516+02:00",
-              "updated_at": "2025-06-19T13:09:21.529525+02:00",
-              "priority": 10,
-              "mx": "mail.example.org",
-              "host": 29
-            }
-          ],
-          "txts": [
-            {
-              "created_at": "2025-06-19T13:09:21.402387+02:00",
-              "updated_at": "2025-06-19T13:09:21.402394+02:00",
-              "txt": "v=spf1 -all",
-              "host": 29
-            }
-          ],
-          "ptr_overrides": [
-            {
-              "created_at": "2025-06-19T13:09:21.681379+02:00",
-              "updated_at": "2025-06-19T13:09:21.681387+02:00",
-              "ipaddress": "10.0.0.11",
-              "host": 29
-            }
-          ],
-          "srvs": [
-            {
-              "created_at": "2025-06-19T13:09:22.144577+02:00",
-              "updated_at": "2025-06-19T13:09:22.144585+02:00",
-              "name": "_sip._tcp.example.org",
-              "priority": 10,
-              "weight": 5,
-              "port": 3456,
-              "ttl": null,
-              "zone": 1,
-              "host": 29
-            }
-          ],
-          "naptrs": [
-            {
-              "created_at": "2025-06-19T13:09:21.991643+02:00",
-              "updated_at": "2025-06-19T13:09:21.991651+02:00",
-              "preference": 16384,
-              "order": 3,
-              "flag": "u",
-              "service": "sip",
-              "regex": "[abc]+",
-              "replacement": "wonk",
-              "host": 29
-            }
-          ],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "created_at": "2025-06-19T13:09:21.400433+02:00",
-          "updated_at": "2025-06-19T13:09:21.400440+02:00",
-          "name": "foo.example.org",
-          "contact": "foo@example.org",
-          "ttl": null,
-          "comment": "",
-          "zone": 1
-        }
-      },
       {
         "method": "DELETE",
         "url": "/api/v1/hosts/foo.example.org",
@@ -36448,25 +32569,6 @@
     "output": [],
     "api_requests": [
       {
-        "method": "GET",
-        "url": "/api/v1/labels/?name=postit",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
-            {
-              "created_at": "2024-12-11T16:45:38.097351+01:00",
-              "updated_at": "2024-12-11T16:45:38.097369+01:00",
-              "name": "postit",
-              "description": "This is a label"
-            }
-          ]
-        }
-      },
-      {
         "method": "PATCH",
         "url": "/api/v1/labels/1",
         "data": {
@@ -36480,8 +32582,8 @@
         "data": {},
         "status": 200,
         "response": {
-          "created_at": "2024-12-11T16:45:38.097351+01:00",
-          "updated_at": "2024-12-11T16:45:38.353381+01:00",
+          "created_at": "2025-08-26T11:57:08.510558+02:00",
+          "updated_at": "2025-08-26T11:57:08.656676+02:00",
           "name": "mylabel",
           "description": "This is a label"
         }
@@ -36803,8 +32905,8 @@
     "error": [],
     "output": [
       "Name:         myrole",
-      "Created:      Mon May 19 00:00:00 2025",
-      "Updated:      Mon May 19 10:28:07 2025",
+      "Created:      Tue Aug 26 00:00:00 2025",
+      "Updated:      Tue Aug 26 11:57:09 2025",
       "Description:  This is the description",
       "Atom members:",
       "Labels:",
@@ -36835,24 +32937,12 @@
         "response": {
           "hosts": [],
           "atoms": [],
-          "updated_at": "2025-05-19T10:28:07.516979+02:00",
+          "updated_at": "2025-08-26T11:57:09.273647+02:00",
           "description": "This is the description",
           "name": "myrole",
           "labels": [
             2
           ]
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/labels/2",
-        "data": {},
-        "status": 200,
-        "response": {
-          "created_at": "2025-05-19T10:28:07.346862+02:00",
-          "updated_at": "2025-05-19T10:28:07.346876+02:00",
-          "name": "postit",
-          "description": "A label again"
         }
       }
     ],
@@ -36945,41 +33035,6 @@
     "output": [],
     "api_requests": [
       {
-        "method": "GET",
-        "url": "/api/v1/hostpolicy/roles/myrole",
-        "data": {},
-        "status": 200,
-        "response": {
-          "hosts": [],
-          "atoms": [],
-          "updated_at": "2024-12-11T16:45:39.026164+01:00",
-          "description": "This is the description",
-          "name": "myrole",
-          "labels": [
-            2
-          ]
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/labels/?name=postit",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
-            {
-              "created_at": "2024-12-11T16:45:38.691439+01:00",
-              "updated_at": "2024-12-11T16:45:38.691461+01:00",
-              "name": "postit",
-              "description": "A label again"
-            }
-          ]
-        }
-      },
-      {
         "method": "PATCH",
         "url": "/api/v1/hostpolicy/roles/myrole",
         "data": {
@@ -37000,7 +33055,7 @@
             {
               "hosts": [],
               "atoms": [],
-              "updated_at": "2024-12-11T16:45:39.632188+01:00",
+              "updated_at": "2025-08-26T11:57:09.516781+02:00",
               "description": "This is the description",
               "name": "myrole",
               "labels": []
@@ -37328,33 +33383,14 @@
           "previous": null,
           "results": [
             {
-              "created_at": "2024-12-11T16:45:39.885936+01:00",
-              "updated_at": "2024-12-11T16:45:40.035819+01:00",
+              "created_at": "2025-08-26T11:57:09.653456+02:00",
+              "updated_at": "2025-08-26T11:57:09.783797+02:00",
               "group": "mygroup",
               "range": "192.168.0.0/16",
               "regex": ".*",
               "labels": [
                 2
               ]
-            }
-          ]
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/labels/?name=postit",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
-            {
-              "created_at": "2024-12-11T16:45:38.691439+01:00",
-              "updated_at": "2024-12-11T16:45:38.691461+01:00",
-              "name": "postit",
-              "description": "A label again"
             }
           ]
         }
@@ -37373,8 +33409,8 @@
         "data": {},
         "status": 200,
         "response": {
-          "created_at": "2024-12-11T16:45:39.885936+01:00",
-          "updated_at": "2024-12-11T16:45:40.433444+01:00",
+          "created_at": "2025-08-26T11:57:09.653456+02:00",
+          "updated_at": "2025-08-26T11:57:10.070646+02:00",
           "group": "mygroup",
           "range": "192.168.0.0/16",
           "regex": ".*",
@@ -38153,8 +34189,8 @@
       "Attributes:",
       " foo: True",
       " bar: True",
-      "Created:      Tue May 13 11:03:24 2025",
-      "Updated:      Tue May 13 11:03:24 2025"
+      "Created:      Tue Aug 26 11:57:10 2025",
+      "Updated:      Tue Aug 26 11:57:10 2025"
     ],
     "api_requests": [
       {
@@ -38181,22 +34217,10 @@
                 }
               ],
               "community_mapping_prefix": null,
-              "created_at": "2025-05-13T11:03:24.946070+02:00",
-              "updated_at": "2025-05-13T11:03:24.946081+02:00"
+              "created_at": "2025-08-26T11:57:10.778366+02:00",
+              "updated_at": "2025-08-26T11:57:10.778380+02:00"
             }
           ]
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/?policy=1",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
         }
       }
     ],
@@ -38215,8 +34239,8 @@
       "Description: Automatic host configuration",
       "Attributes:",
       " baz: True",
-      "Created:      Tue May 13 11:03:25 2025",
-      "Updated:      Tue May 13 11:03:25 2025"
+      "Created:      Tue Aug 26 11:57:10 2025",
+      "Updated:      Tue Aug 26 11:57:10 2025"
     ],
     "api_requests": [
       {
@@ -38239,22 +34263,10 @@
                 }
               ],
               "community_mapping_prefix": null,
-              "created_at": "2025-05-13T11:03:25.047003+02:00",
-              "updated_at": "2025-05-13T11:03:25.047017+02:00"
+              "created_at": "2025-08-26T11:57:10.902897+02:00",
+              "updated_at": "2025-08-26T11:57:10.902914+02:00"
             }
           ]
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/?policy=2",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
         }
       }
     ],
@@ -38274,36 +34286,6 @@
     "api_requests": [
       {
         "method": "GET",
-        "url": "/api/v1/networkpolicies/?name=securepolicy",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
-            {
-              "name": "securepolicy",
-              "description": "Secure policy for a network",
-              "attributes": [
-                {
-                  "name": "foo",
-                  "value": true
-                },
-                {
-                  "name": "bar",
-                  "value": true
-                }
-              ],
-              "community_mapping_prefix": null,
-              "created_at": "2025-05-13T11:03:24.946070+02:00",
-              "updated_at": "2025-05-13T11:03:24.946081+02:00"
-            }
-          ]
-        }
-      },
-      {
-        "method": "GET",
         "url": "/api/v1/networks/10.0.2.0/28",
         "data": {},
         "status": 200,
@@ -38311,8 +34293,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-05-13T11:03:24.588229+02:00",
-          "updated_at": "2025-05-13T11:03:24.588281+02:00",
+          "created_at": "2025-08-26T11:57:10.295797+02:00",
+          "updated_at": "2025-08-26T11:57:10.295808+02:00",
           "network": "10.0.2.0/28",
           "description": "TinyNet",
           "vlan": null,
@@ -38357,12 +34339,12 @@
                   }
                 ],
                 "community_mapping_prefix": null,
-                "created_at": "2025-05-13T11:03:24.946070+02:00",
-                "updated_at": "2025-05-13T11:03:24.946081+02:00"
+                "created_at": "2025-08-26T11:57:10.778366+02:00",
+                "updated_at": "2025-08-26T11:57:10.778380+02:00"
               },
               "communities": [],
-              "created_at": "2025-05-13T11:03:24.588229+02:00",
-              "updated_at": "2025-05-13T11:03:25.469906+02:00",
+              "created_at": "2025-08-26T11:57:10.295797+02:00",
+              "updated_at": "2025-08-26T11:57:11.250049+02:00",
               "network": "10.0.2.0/28",
               "description": "TinyNet",
               "vlan": null,
@@ -38469,69 +34451,6 @@
     "output": [],
     "api_requests": [
       {
-        "method": "GET",
-        "url": "/api/v1/networkpolicies/?name=autoconfigure",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
-            {
-              "name": "autoconfigure",
-              "description": "Automatic host configuration",
-              "attributes": [
-                {
-                  "name": "baz",
-                  "value": true
-                }
-              ],
-              "community_mapping_prefix": null,
-              "created_at": "2025-05-13T11:03:25.047003+02:00",
-              "updated_at": "2025-05-13T11:03:25.047017+02:00"
-            }
-          ]
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/10.0.2.0/28",
-        "data": {},
-        "status": 200,
-        "response": {
-          "excluded_ranges": [],
-          "policy": {
-            "name": "securepolicy",
-            "description": "Secure policy for a network",
-            "attributes": [
-              {
-                "name": "foo",
-                "value": true
-              },
-              {
-                "name": "bar",
-                "value": true
-              }
-            ],
-            "community_mapping_prefix": null,
-            "created_at": "2025-05-13T11:03:24.946070+02:00",
-            "updated_at": "2025-05-13T11:03:24.946081+02:00"
-          },
-          "communities": [],
-          "created_at": "2025-05-13T11:03:24.588229+02:00",
-          "updated_at": "2025-05-13T11:03:25.469906+02:00",
-          "network": "10.0.2.0/28",
-          "description": "TinyNet",
-          "vlan": null,
-          "dns_delegated": false,
-          "category": "",
-          "location": "",
-          "frozen": false,
-          "reserved": 3
-        }
-      },
-      {
         "method": "PATCH",
         "url": "/api/v1/networks/10.0.2.0/28",
         "data": {
@@ -38561,12 +34480,12 @@
                   }
                 ],
                 "community_mapping_prefix": null,
-                "created_at": "2025-05-13T11:03:25.047003+02:00",
-                "updated_at": "2025-05-13T11:03:25.047017+02:00"
+                "created_at": "2025-08-26T11:57:10.902897+02:00",
+                "updated_at": "2025-08-26T11:57:10.902914+02:00"
               },
               "communities": [],
-              "created_at": "2025-05-13T11:03:24.588229+02:00",
-              "updated_at": "2025-05-13T11:03:25.634174+02:00",
+              "created_at": "2025-08-26T11:57:10.295797+02:00",
+              "updated_at": "2025-08-26T11:57:11.371629+02:00",
               "network": "10.0.2.0/28",
               "description": "TinyNet",
               "vlan": null,
@@ -38768,72 +34687,6 @@
     "error": [],
     "output": [],
     "api_requests": [
-      {
-        "method": "GET",
-        "url": "/api/v1/networkpolicies/?name=autoconfigure",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
-            {
-              "name": "autoconfigure",
-              "description": "Automatic host configuration",
-              "attributes": [
-                {
-                  "name": "baz",
-                  "value": true
-                }
-              ],
-              "community_mapping_prefix": null,
-              "created_at": "2025-05-13T11:03:25.047003+02:00",
-              "updated_at": "2025-05-13T11:03:25.047017+02:00"
-            }
-          ]
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/?policy=2",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
-            {
-              "excluded_ranges": [],
-              "policy": {
-                "name": "autoconfigure",
-                "description": "Automatic host configuration",
-                "attributes": [
-                  {
-                    "name": "baz",
-                    "value": true
-                  }
-                ],
-                "community_mapping_prefix": null,
-                "created_at": "2025-05-13T11:03:25.047003+02:00",
-                "updated_at": "2025-05-13T11:03:25.047017+02:00"
-              },
-              "communities": [],
-              "created_at": "2025-05-13T11:03:24.588229+02:00",
-              "updated_at": "2025-05-13T11:03:25.634174+02:00",
-              "network": "10.0.2.0/28",
-              "description": "TinyNet",
-              "vlan": null,
-              "dns_delegated": false,
-              "category": "",
-              "location": "",
-              "frozen": false,
-              "reserved": 3
-            }
-          ]
-        }
-      },
       {
         "method": "DELETE",
         "url": "/api/v1/networkpolicies/2",
@@ -39049,31 +34902,10 @@
                 }
               ],
               "community_mapping_prefix": null,
-              "created_at": "2025-05-13T11:03:24.946070+02:00",
-              "updated_at": "2025-05-13T11:03:24.946081+02:00"
+              "created_at": "2025-08-26T11:57:10.778366+02:00",
+              "updated_at": "2025-08-26T11:57:10.778380+02:00"
             }
           ]
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/10.0.2.0/28",
-        "data": {},
-        "status": 200,
-        "response": {
-          "excluded_ranges": [],
-          "policy": null,
-          "communities": [],
-          "created_at": "2025-05-13T11:03:24.588229+02:00",
-          "updated_at": "2025-05-13T11:03:25.634174+02:00",
-          "network": "10.0.2.0/28",
-          "description": "TinyNet",
-          "vlan": null,
-          "dns_delegated": false,
-          "category": "",
-          "location": "",
-          "frozen": false,
-          "reserved": 3
         }
       },
       {
@@ -39110,12 +34942,12 @@
                   }
                 ],
                 "community_mapping_prefix": null,
-                "created_at": "2025-05-13T11:03:24.946070+02:00",
-                "updated_at": "2025-05-13T11:03:24.946081+02:00"
+                "created_at": "2025-08-26T11:57:10.778366+02:00",
+                "updated_at": "2025-08-26T11:57:10.778380+02:00"
               },
               "communities": [],
-              "created_at": "2025-05-13T11:03:24.588229+02:00",
-              "updated_at": "2025-05-13T11:03:26.187174+02:00",
+              "created_at": "2025-08-26T11:57:10.295797+02:00",
+              "updated_at": "2025-08-26T11:57:11.801533+02:00",
               "network": "10.0.2.0/28",
               "description": "TinyNet",
               "vlan": null,
@@ -40082,27 +35914,7 @@
     "warning": [],
     "error": [],
     "output": [],
-    "api_requests": [
-      {
-        "method": "GET",
-        "url": "/api/v1/networkpolicyattributes/?name=bar",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
-            {
-              "name": "bar",
-              "description": "Bar attribute",
-              "created_at": "2025-03-21T16:15:43.324192+01:00",
-              "updated_at": "2025-03-21T16:15:43.324202+01:00"
-            }
-          ]
-        }
-      }
-    ],
+    "api_requests": [],
     "time": null
   },
   {
@@ -41044,123 +36856,6 @@
     "api_requests": [
       {
         "method": "GET",
-        "url": "/api/v1/hosts/tinyhost.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2025-06-19T13:09:26.813141+02:00",
-              "updated_at": "2025-06-19T13:09:26.907642+02:00",
-              "ipaddress": "10.0.2.4",
-              "host": 30
-            }
-          ],
-          "cnames": [],
-          "mxs": [],
-          "txts": [
-            {
-              "created_at": "2025-06-19T13:09:26.794935+02:00",
-              "updated_at": "2025-06-19T13:09:26.794941+02:00",
-              "txt": "v=spf1 -all",
-              "host": 30
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [
-            {
-              "ipaddress": 33,
-              "community": {
-                "name": "guests",
-                "description": "Guest hosts.",
-                "network": 10,
-                "hosts": [
-                  "tinyhost.example.org"
-                ],
-                "global_name": "community01",
-                "created_at": "2025-06-19T13:09:27.063496+02:00",
-                "updated_at": "2025-06-19T13:09:27.063505+02:00"
-              }
-            }
-          ],
-          "created_at": "2025-06-19T13:09:26.792878+02:00",
-          "updated_at": "2025-06-19T13:09:26.792888+02:00",
-          "name": "tinyhost.example.org",
-          "contact": "tinyhost@example.org",
-          "ttl": null,
-          "comment": "",
-          "zone": 1
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/ip/10.0.2.4",
-        "data": {},
-        "status": 200,
-        "response": {
-          "excluded_ranges": [],
-          "policy": {
-            "name": "insecurepolicy",
-            "description": "Insecure policy for a network",
-            "attributes": [
-              {
-                "name": "bar",
-                "value": true
-              },
-              {
-                "name": "baz",
-                "value": true
-              }
-            ],
-            "community_mapping_prefix": null,
-            "created_at": "2025-06-19T13:09:24.724408+02:00",
-            "updated_at": "2025-06-19T13:09:26.512391+02:00"
-          },
-          "communities": [
-            {
-              "name": "guests",
-              "description": "Guest hosts.",
-              "network": 10,
-              "hosts": [
-                "tinyhost.example.org"
-              ],
-              "global_name": "community01",
-              "created_at": "2025-06-19T13:09:27.063496+02:00",
-              "updated_at": "2025-06-19T13:09:27.063505+02:00"
-            },
-            {
-              "name": "lab",
-              "description": "Lab hosts.",
-              "network": 10,
-              "hosts": [],
-              "global_name": "community02",
-              "created_at": "2025-06-19T13:09:27.124655+02:00",
-              "updated_at": "2025-06-19T13:09:27.124668+02:00"
-            }
-          ],
-          "created_at": "2025-06-19T13:09:24.299643+02:00",
-          "updated_at": "2025-06-19T13:09:25.887950+02:00",
-          "network": "10.0.2.0/28",
-          "description": "TinyNet",
-          "vlan": null,
-          "dns_delegated": false,
-          "category": "",
-          "location": "",
-          "frozen": false,
-          "reserved": 3
-        }
-      },
-      {
-        "method": "GET",
         "url": "/api/v1/networks/?id=10",
         "data": {},
         "status": 200,
@@ -41185,8 +36880,8 @@
                   }
                 ],
                 "community_mapping_prefix": null,
-                "created_at": "2025-06-19T13:09:24.724408+02:00",
-                "updated_at": "2025-06-19T13:09:26.512391+02:00"
+                "created_at": "2025-08-26T11:57:10.778366+02:00",
+                "updated_at": "2025-08-26T11:57:12.406598+02:00"
               },
               "communities": [
                 {
@@ -41197,8 +36892,8 @@
                     "tinyhost.example.org"
                   ],
                   "global_name": "community01",
-                  "created_at": "2025-06-19T13:09:27.063496+02:00",
-                  "updated_at": "2025-06-19T13:09:27.063505+02:00"
+                  "created_at": "2025-08-26T11:57:12.991213+02:00",
+                  "updated_at": "2025-08-26T11:57:12.991222+02:00"
                 },
                 {
                   "name": "lab",
@@ -41206,12 +36901,12 @@
                   "network": 10,
                   "hosts": [],
                   "global_name": "community02",
-                  "created_at": "2025-06-19T13:09:27.124655+02:00",
-                  "updated_at": "2025-06-19T13:09:27.124668+02:00"
+                  "created_at": "2025-08-26T11:57:13.046176+02:00",
+                  "updated_at": "2025-08-26T11:57:13.046186+02:00"
                 }
               ],
-              "created_at": "2025-06-19T13:09:24.299643+02:00",
-              "updated_at": "2025-06-19T13:09:25.887950+02:00",
+              "created_at": "2025-08-26T11:57:10.295797+02:00",
+              "updated_at": "2025-08-26T11:57:11.801533+02:00",
               "network": "10.0.2.0/28",
               "description": "TinyNet",
               "vlan": null,
@@ -41236,8 +36931,8 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2025-06-19T13:09:26.813141+02:00",
-              "updated_at": "2025-06-19T13:09:26.907642+02:00",
+              "created_at": "2025-08-26T11:57:12.758134+02:00",
+              "updated_at": "2025-08-26T11:57:12.848178+02:00",
               "ipaddress": "10.0.2.4",
               "host": 30
             }
@@ -41246,8 +36941,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-06-19T13:09:26.794935+02:00",
-              "updated_at": "2025-06-19T13:09:26.794941+02:00",
+              "created_at": "2025-08-26T11:57:12.740145+02:00",
+              "updated_at": "2025-08-26T11:57:12.740150+02:00",
               "txt": "v=spf1 -all",
               "host": 30
             }
@@ -41272,13 +36967,13 @@
                   "tinyhost.example.org"
                 ],
                 "global_name": "community02",
-                "created_at": "2025-06-19T13:09:27.124655+02:00",
-                "updated_at": "2025-06-19T13:09:27.124668+02:00"
+                "created_at": "2025-08-26T11:57:13.046176+02:00",
+                "updated_at": "2025-08-26T11:57:13.046186+02:00"
               }
             }
           ],
-          "created_at": "2025-06-19T13:09:26.792878+02:00",
-          "updated_at": "2025-06-19T13:09:26.792888+02:00",
+          "created_at": "2025-08-26T11:57:12.737925+02:00",
+          "updated_at": "2025-08-26T11:57:12.737933+02:00",
           "name": "tinyhost.example.org",
           "contact": "tinyhost@example.org",
           "ttl": null,
@@ -41519,71 +37214,12 @@
       "Name:         lab",
       "Description:  Lab hosts.",
       "Global name:  community02",
-      "Created:      Mon May 19 10:28:12 2025",
-      "Updated:      Mon May 19 10:28:12 2025",
+      "Created:      Tue Aug 26 11:57:13 2025",
+      "Updated:      Tue Aug 26 11:57:13 2025",
       "Hosts:",
       "              tinyhost.example.org"
     ],
-    "api_requests": [
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/10.0.2.0/28",
-        "data": {},
-        "status": 200,
-        "response": {
-          "excluded_ranges": [],
-          "policy": {
-            "name": "insecurepolicy",
-            "description": "Insecure policy for a network",
-            "attributes": [
-              {
-                "name": "bar",
-                "value": true
-              },
-              {
-                "name": "baz",
-                "value": true
-              }
-            ],
-            "community_mapping_prefix": null,
-            "created_at": "2025-05-19T10:28:08.859834+02:00",
-            "updated_at": "2025-05-19T10:28:11.415014+02:00"
-          },
-          "communities": [
-            {
-              "name": "guests",
-              "description": "Guest hosts.",
-              "network": 10,
-              "hosts": [],
-              "global_name": "community01",
-              "created_at": "2025-05-19T10:28:12.296707+02:00",
-              "updated_at": "2025-05-19T10:28:12.296718+02:00"
-            },
-            {
-              "name": "lab",
-              "description": "Lab hosts.",
-              "network": 10,
-              "hosts": [
-                "tinyhost.example.org"
-              ],
-              "global_name": "community02",
-              "created_at": "2025-05-19T10:28:12.364819+02:00",
-              "updated_at": "2025-05-19T10:28:12.364828+02:00"
-            }
-          ],
-          "created_at": "2025-05-19T10:28:08.477801+02:00",
-          "updated_at": "2025-05-19T10:28:10.632088+02:00",
-          "network": "10.0.2.0/28",
-          "description": "TinyNet",
-          "vlan": null,
-          "dns_delegated": false,
-          "category": "",
-          "location": "",
-          "frozen": false,
-          "reserved": 3
-        }
-      }
-    ],
+    "api_requests": [],
     "time": null
   },
   {
@@ -42279,44 +37915,6 @@
     "api_requests": [
       {
         "method": "GET",
-        "url": "/api/v1/networks/10.0.3.0/24",
-        "data": {},
-        "status": 200,
-        "response": {
-          "excluded_ranges": [],
-          "policy": {
-            "name": "customprefix",
-            "description": "Custom community mapping prefix",
-            "attributes": [],
-            "community_mapping_prefix": "custom",
-            "created_at": "2025-05-19T15:03:51.281802+02:00",
-            "updated_at": "2025-05-19T15:03:51.817521+02:00"
-          },
-          "communities": [
-            {
-              "name": "foo",
-              "description": "Foo community",
-              "network": 11,
-              "hosts": [],
-              "global_name": "custom01",
-              "created_at": "2025-05-19T15:03:51.631001+02:00",
-              "updated_at": "2025-05-19T15:03:51.631022+02:00"
-            }
-          ],
-          "created_at": "2025-05-19T15:03:51.389153+02:00",
-          "updated_at": "2025-05-19T15:03:51.487147+02:00",
-          "network": "10.0.3.0/24",
-          "description": "CustomPrefixNet",
-          "vlan": null,
-          "dns_delegated": false,
-          "category": "",
-          "location": "",
-          "frozen": false,
-          "reserved": 3
-        }
-      },
-      {
-        "method": "GET",
         "url": "/api/v1/networks/10.0.3.0/24/used_count",
         "data": {},
         "status": 200,
@@ -42657,8 +38255,8 @@
               }
             ],
             "community_mapping_prefix": null,
-            "created_at": "2025-05-19T14:13:39.226705+02:00",
-            "updated_at": "2025-05-19T14:13:41.357575+02:00"
+            "created_at": "2025-08-26T11:57:10.778366+02:00",
+            "updated_at": "2025-08-26T11:57:12.406598+02:00"
           },
           "communities": [
             {
@@ -42667,8 +38265,8 @@
               "network": 10,
               "hosts": [],
               "global_name": "community01",
-              "created_at": "2025-05-19T14:13:42.346255+02:00",
-              "updated_at": "2025-05-19T14:13:42.346270+02:00"
+              "created_at": "2025-08-26T11:57:12.991213+02:00",
+              "updated_at": "2025-08-26T11:57:12.991222+02:00"
             },
             {
               "name": "labequipment",
@@ -42678,12 +38276,12 @@
                 "tinyhost.example.org"
               ],
               "global_name": "community02",
-              "created_at": "2025-05-19T14:13:42.444081+02:00",
-              "updated_at": "2025-05-19T14:13:43.922436+02:00"
+              "created_at": "2025-08-26T11:57:13.046176+02:00",
+              "updated_at": "2025-08-26T11:57:14.191052+02:00"
             }
           ],
-          "created_at": "2025-05-19T14:13:38.844138+02:00",
-          "updated_at": "2025-05-19T14:13:40.451944+02:00",
+          "created_at": "2025-08-26T11:57:10.295797+02:00",
+          "updated_at": "2025-08-26T11:57:11.801533+02:00",
           "network": "10.0.2.0/28",
           "description": "TinyNet",
           "vlan": null,
@@ -42692,71 +38290,6 @@
           "location": "",
           "frozen": false,
           "reserved": 3
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/?id=10",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
-            {
-              "excluded_ranges": [],
-              "policy": {
-                "name": "insecurepolicy",
-                "description": "Insecure policy for a network",
-                "attributes": [
-                  {
-                    "name": "bar",
-                    "value": true
-                  },
-                  {
-                    "name": "baz",
-                    "value": true
-                  }
-                ],
-                "community_mapping_prefix": null,
-                "created_at": "2025-05-19T14:13:39.226705+02:00",
-                "updated_at": "2025-05-19T14:13:41.357575+02:00"
-              },
-              "communities": [
-                {
-                  "name": "guests",
-                  "description": "Guest hosts.",
-                  "network": 10,
-                  "hosts": [],
-                  "global_name": "community01",
-                  "created_at": "2025-05-19T14:13:42.346255+02:00",
-                  "updated_at": "2025-05-19T14:13:42.346270+02:00"
-                },
-                {
-                  "name": "labequipment",
-                  "description": "Lab hosts.",
-                  "network": 10,
-                  "hosts": [
-                    "tinyhost.example.org"
-                  ],
-                  "global_name": "community02",
-                  "created_at": "2025-05-19T14:13:42.444081+02:00",
-                  "updated_at": "2025-05-19T14:13:43.922436+02:00"
-                }
-              ],
-              "created_at": "2025-05-19T14:13:38.844138+02:00",
-              "updated_at": "2025-05-19T14:13:40.451944+02:00",
-              "network": "10.0.2.0/28",
-              "description": "TinyNet",
-              "vlan": null,
-              "dns_delegated": false,
-              "category": "",
-              "location": "",
-              "frozen": false,
-              "reserved": 3
-            }
-          ]
         }
       },
       {
@@ -42774,8 +38307,8 @@
             "tinyhost.example.org"
           ],
           "global_name": "community02",
-          "created_at": "2025-05-19T14:13:42.444081+02:00",
-          "updated_at": "2025-05-19T14:13:44.080076+02:00"
+          "created_at": "2025-08-26T11:57:13.046176+02:00",
+          "updated_at": "2025-08-26T11:57:14.329854+02:00"
         }
       },
       {
@@ -42804,8 +38337,8 @@
                   }
                 ],
                 "community_mapping_prefix": null,
-                "created_at": "2025-05-19T14:13:39.226705+02:00",
-                "updated_at": "2025-05-19T14:13:41.357575+02:00"
+                "created_at": "2025-08-26T11:57:10.778366+02:00",
+                "updated_at": "2025-08-26T11:57:12.406598+02:00"
               },
               "communities": [
                 {
@@ -42814,8 +38347,8 @@
                   "network": 10,
                   "hosts": [],
                   "global_name": "community01",
-                  "created_at": "2025-05-19T14:13:42.346255+02:00",
-                  "updated_at": "2025-05-19T14:13:42.346270+02:00"
+                  "created_at": "2025-08-26T11:57:12.991213+02:00",
+                  "updated_at": "2025-08-26T11:57:12.991222+02:00"
                 },
                 {
                   "name": "labequipment",
@@ -42825,12 +38358,12 @@
                     "tinyhost.example.org"
                   ],
                   "global_name": "community02",
-                  "created_at": "2025-05-19T14:13:42.444081+02:00",
-                  "updated_at": "2025-05-19T14:13:44.080076+02:00"
+                  "created_at": "2025-08-26T11:57:13.046176+02:00",
+                  "updated_at": "2025-08-26T11:57:14.329854+02:00"
                 }
               ],
-              "created_at": "2025-05-19T14:13:38.844138+02:00",
-              "updated_at": "2025-05-19T14:13:40.451944+02:00",
+              "created_at": "2025-08-26T11:57:10.295797+02:00",
+              "updated_at": "2025-08-26T11:57:11.801533+02:00",
               "network": "10.0.2.0/28",
               "description": "TinyNet",
               "vlan": null,
@@ -42856,8 +38389,8 @@
             "tinyhost.example.org"
           ],
           "global_name": "community02",
-          "created_at": "2025-05-19T14:13:42.444081+02:00",
-          "updated_at": "2025-05-19T14:13:44.080076+02:00"
+          "created_at": "2025-08-26T11:57:13.046176+02:00",
+          "updated_at": "2025-08-26T11:57:14.329854+02:00"
         }
       }
     ],
@@ -42960,8 +38493,8 @@
       "              10.0.2.5   <not set>   ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Thu Jun 19 13:09:28 2025",
-      "Updated:      Thu Jun 19 13:09:28 2025"
+      "Created:      Tue Aug 26 11:57:14 2025",
+      "Updated:      Tue Aug 26 11:57:14 2025"
     ],
     "api_requests": [
       {
@@ -43005,18 +38538,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2025-06-19T13:08:49.394396+02:00",
-                "updated_at": "2025-06-19T13:08:49.394408+02:00",
+                "created_at": "2025-08-26T11:56:35.781651+02:00",
+                "updated_at": "2025-08-26T11:56:35.781663+02:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-06-19T13:08:48.992266+02:00",
-            "updated_at": "2025-06-19T13:09:26.906874+02:00",
+            "created_at": "2025-08-26T11:56:35.478972+02:00",
+            "updated_at": "2025-08-26T11:57:12.847631+02:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-06-19T13:08:49.869830+02:00",
+            "serialno_updated_at": "2025-08-26T11:56:36.090230+02:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -43024,64 +38557,6 @@
             "default_ttl": 300,
             "name": "example.org"
           }
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/10.0.2.0/28",
-        "data": {},
-        "status": 200,
-        "response": {
-          "excluded_ranges": [],
-          "policy": {
-            "name": "insecurepolicy",
-            "description": "Insecure policy for a network",
-            "attributes": [
-              {
-                "name": "bar",
-                "value": true
-              },
-              {
-                "name": "baz",
-                "value": true
-              }
-            ],
-            "community_mapping_prefix": null,
-            "created_at": "2025-06-19T13:09:24.724408+02:00",
-            "updated_at": "2025-06-19T13:09:26.512391+02:00"
-          },
-          "communities": [
-            {
-              "name": "guests",
-              "description": "Guest hosts.",
-              "network": 10,
-              "hosts": [],
-              "global_name": "community01",
-              "created_at": "2025-06-19T13:09:27.063496+02:00",
-              "updated_at": "2025-06-19T13:09:27.063505+02:00"
-            },
-            {
-              "name": "labequipment",
-              "description": "Lab equipment (expensive)",
-              "network": 10,
-              "hosts": [
-                "tinyhost.example.org"
-              ],
-              "global_name": "community02",
-              "created_at": "2025-06-19T13:09:27.124655+02:00",
-              "updated_at": "2025-06-19T13:09:28.512444+02:00"
-            }
-          ],
-          "created_at": "2025-06-19T13:09:24.299643+02:00",
-          "updated_at": "2025-06-19T13:09:25.887950+02:00",
-          "network": "10.0.2.0/28",
-          "description": "TinyNet",
-          "vlan": null,
-          "dns_delegated": false,
-          "category": "",
-          "location": "",
-          "frozen": false,
-          "reserved": 3
         }
       },
       {
@@ -43103,8 +38578,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-06-19T13:09:28.719290+02:00",
-              "updated_at": "2025-06-19T13:09:28.719298+02:00",
+              "created_at": "2025-08-26T11:57:14.509299+02:00",
+              "updated_at": "2025-08-26T11:57:14.509305+02:00",
               "ipaddress": "10.0.2.5",
               "host": 31
             }
@@ -43113,8 +38588,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-06-19T13:09:28.702377+02:00",
-              "updated_at": "2025-06-19T13:09:28.702388+02:00",
+              "created_at": "2025-08-26T11:57:14.494113+02:00",
+              "updated_at": "2025-08-26T11:57:14.494120+02:00",
               "txt": "v=spf1 -all",
               "host": 31
             }
@@ -43129,8 +38604,8 @@
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-06-19T13:09:28.699734+02:00",
-          "updated_at": "2025-06-19T13:09:28.699754+02:00",
+          "created_at": "2025-08-26T11:57:14.491950+02:00",
+          "updated_at": "2025-08-26T11:57:14.491957+02:00",
           "name": "tinierhost.example.org",
           "contact": "tinierhost@example.org",
           "ttl": null,
@@ -43159,8 +38634,8 @@
               }
             ],
             "community_mapping_prefix": null,
-            "created_at": "2025-06-19T13:09:24.724408+02:00",
-            "updated_at": "2025-06-19T13:09:26.512391+02:00"
+            "created_at": "2025-08-26T11:57:10.778366+02:00",
+            "updated_at": "2025-08-26T11:57:12.406598+02:00"
           },
           "communities": [
             {
@@ -43169,8 +38644,8 @@
               "network": 10,
               "hosts": [],
               "global_name": "community01",
-              "created_at": "2025-06-19T13:09:27.063496+02:00",
-              "updated_at": "2025-06-19T13:09:27.063505+02:00"
+              "created_at": "2025-08-26T11:57:12.991213+02:00",
+              "updated_at": "2025-08-26T11:57:12.991222+02:00"
             },
             {
               "name": "labequipment",
@@ -43180,12 +38655,12 @@
                 "tinyhost.example.org"
               ],
               "global_name": "community02",
-              "created_at": "2025-06-19T13:09:27.124655+02:00",
-              "updated_at": "2025-06-19T13:09:28.512444+02:00"
+              "created_at": "2025-08-26T11:57:13.046176+02:00",
+              "updated_at": "2025-08-26T11:57:14.329854+02:00"
             }
           ],
-          "created_at": "2025-06-19T13:09:24.299643+02:00",
-          "updated_at": "2025-06-19T13:09:25.887950+02:00",
+          "created_at": "2025-08-26T11:57:10.295797+02:00",
+          "updated_at": "2025-08-26T11:57:11.801533+02:00",
           "network": "10.0.2.0/28",
           "description": "TinyNet",
           "vlan": null,
@@ -43220,8 +38695,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-06-19T13:09:28.719290+02:00",
-              "updated_at": "2025-06-19T13:09:28.719298+02:00",
+              "created_at": "2025-08-26T11:57:14.509299+02:00",
+              "updated_at": "2025-08-26T11:57:14.509305+02:00",
               "ipaddress": "10.0.2.5",
               "host": 31
             }
@@ -43230,8 +38705,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-06-19T13:09:28.702377+02:00",
-              "updated_at": "2025-06-19T13:09:28.702388+02:00",
+              "created_at": "2025-08-26T11:57:14.494113+02:00",
+              "updated_at": "2025-08-26T11:57:14.494120+02:00",
               "txt": "v=spf1 -all",
               "host": 31
             }
@@ -43246,71 +38721,13 @@
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-06-19T13:09:28.699734+02:00",
-          "updated_at": "2025-06-19T13:09:28.699754+02:00",
+          "created_at": "2025-08-26T11:57:14.491950+02:00",
+          "updated_at": "2025-08-26T11:57:14.491957+02:00",
           "name": "tinierhost.example.org",
           "contact": "tinierhost@example.org",
           "ttl": null,
           "comment": "",
           "zone": 1
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/ip/10.0.2.5",
-        "data": {},
-        "status": 200,
-        "response": {
-          "excluded_ranges": [],
-          "policy": {
-            "name": "insecurepolicy",
-            "description": "Insecure policy for a network",
-            "attributes": [
-              {
-                "name": "bar",
-                "value": true
-              },
-              {
-                "name": "baz",
-                "value": true
-              }
-            ],
-            "community_mapping_prefix": null,
-            "created_at": "2025-06-19T13:09:24.724408+02:00",
-            "updated_at": "2025-06-19T13:09:26.512391+02:00"
-          },
-          "communities": [
-            {
-              "name": "guests",
-              "description": "Guest hosts.",
-              "network": 10,
-              "hosts": [],
-              "global_name": "community01",
-              "created_at": "2025-06-19T13:09:27.063496+02:00",
-              "updated_at": "2025-06-19T13:09:27.063505+02:00"
-            },
-            {
-              "name": "labequipment",
-              "description": "Lab equipment (expensive)",
-              "network": 10,
-              "hosts": [
-                "tinyhost.example.org"
-              ],
-              "global_name": "community02",
-              "created_at": "2025-06-19T13:09:27.124655+02:00",
-              "updated_at": "2025-06-19T13:09:28.512444+02:00"
-            }
-          ],
-          "created_at": "2025-06-19T13:09:24.299643+02:00",
-          "updated_at": "2025-06-19T13:09:25.887950+02:00",
-          "network": "10.0.2.0/28",
-          "description": "TinyNet",
-          "vlan": null,
-          "dns_delegated": false,
-          "category": "",
-          "location": "",
-          "frozen": false,
-          "reserved": 3
         }
       },
       {
@@ -43339,8 +38756,8 @@
                   }
                 ],
                 "community_mapping_prefix": null,
-                "created_at": "2025-06-19T13:09:24.724408+02:00",
-                "updated_at": "2025-06-19T13:09:26.512391+02:00"
+                "created_at": "2025-08-26T11:57:10.778366+02:00",
+                "updated_at": "2025-08-26T11:57:12.406598+02:00"
               },
               "communities": [
                 {
@@ -43349,8 +38766,8 @@
                   "network": 10,
                   "hosts": [],
                   "global_name": "community01",
-                  "created_at": "2025-06-19T13:09:27.063496+02:00",
-                  "updated_at": "2025-06-19T13:09:27.063505+02:00"
+                  "created_at": "2025-08-26T11:57:12.991213+02:00",
+                  "updated_at": "2025-08-26T11:57:12.991222+02:00"
                 },
                 {
                   "name": "labequipment",
@@ -43360,12 +38777,12 @@
                     "tinyhost.example.org"
                   ],
                   "global_name": "community02",
-                  "created_at": "2025-06-19T13:09:27.124655+02:00",
-                  "updated_at": "2025-06-19T13:09:28.512444+02:00"
+                  "created_at": "2025-08-26T11:57:13.046176+02:00",
+                  "updated_at": "2025-08-26T11:57:14.329854+02:00"
                 }
               ],
-              "created_at": "2025-06-19T13:09:24.299643+02:00",
-              "updated_at": "2025-06-19T13:09:25.887950+02:00",
+              "created_at": "2025-08-26T11:57:10.295797+02:00",
+              "updated_at": "2025-08-26T11:57:11.801533+02:00",
               "network": "10.0.2.0/28",
               "description": "TinyNet",
               "vlan": null,
@@ -43898,8 +39315,8 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:34:aa:bb:cd",
-              "created_at": "2025-06-19T13:09:29.183899+02:00",
-              "updated_at": "2025-06-19T13:09:29.272173+02:00",
+              "created_at": "2025-08-26T11:57:14.957408+02:00",
+              "updated_at": "2025-08-26T11:57:15.059190+02:00",
               "ipaddress": "10.0.0.4",
               "host": 32
             }
@@ -43908,8 +39325,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-06-19T13:09:29.164111+02:00",
-              "updated_at": "2025-06-19T13:09:29.164117+02:00",
+              "created_at": "2025-08-26T11:57:14.937138+02:00",
+              "updated_at": "2025-08-26T11:57:14.937147+02:00",
               "txt": "v=spf1 -all",
               "host": 32
             }
@@ -43924,34 +39341,13 @@
           "loc": null,
           "bacnetid": null,
           "communities": [],
-          "created_at": "2025-06-19T13:09:29.161836+02:00",
-          "updated_at": "2025-06-19T13:09:29.161847+02:00",
+          "created_at": "2025-08-26T11:57:14.935007+02:00",
+          "updated_at": "2025-08-26T11:57:14.935016+02:00",
           "name": "mediumhost.example.org",
           "contact": "mediumhost@example.org",
           "ttl": null,
           "comment": "",
           "zone": 1
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/ip/10.0.0.4",
-        "data": {},
-        "status": 200,
-        "response": {
-          "excluded_ranges": [],
-          "policy": null,
-          "communities": [],
-          "created_at": "2025-06-19T13:09:28.960243+02:00",
-          "updated_at": "2025-06-19T13:09:28.960252+02:00",
-          "network": "10.0.0.0/24",
-          "description": "MediumNet",
-          "vlan": null,
-          "dns_delegated": false,
-          "category": "",
-          "location": "",
-          "frozen": false,
-          "reserved": 3
         }
       }
     ],
@@ -43969,50 +39365,6 @@
     "error": [],
     "output": [],
     "api_requests": [
-      {
-        "method": "GET",
-        "url": "/api/v1/hosts/mediumhost.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "11:22:34:aa:bb:cd",
-              "created_at": "2025-06-19T13:09:29.183899+02:00",
-              "updated_at": "2025-06-19T13:09:29.272173+02:00",
-              "ipaddress": "10.0.0.4",
-              "host": 32
-            }
-          ],
-          "cnames": [],
-          "mxs": [],
-          "txts": [
-            {
-              "created_at": "2025-06-19T13:09:29.164111+02:00",
-              "updated_at": "2025-06-19T13:09:29.164117+02:00",
-              "txt": "v=spf1 -all",
-              "host": 32
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "created_at": "2025-06-19T13:09:29.161836+02:00",
-          "updated_at": "2025-06-19T13:09:29.161847+02:00",
-          "name": "mediumhost.example.org",
-          "contact": "mediumhost@example.org",
-          "ttl": null,
-          "comment": "",
-          "zone": 1
-        }
-      },
       {
         "method": "DELETE",
         "url": "/api/v1/hosts/mediumhost.example.org",
@@ -44290,8 +39642,8 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2025-06-19T13:09:26.813141+02:00",
-              "updated_at": "2025-06-19T13:09:26.907642+02:00",
+              "created_at": "2025-08-26T11:57:12.758134+02:00",
+              "updated_at": "2025-08-26T11:57:12.848178+02:00",
               "ipaddress": "10.0.2.4",
               "host": 30
             }
@@ -44300,8 +39652,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-06-19T13:09:26.794935+02:00",
-              "updated_at": "2025-06-19T13:09:26.794941+02:00",
+              "created_at": "2025-08-26T11:57:12.740145+02:00",
+              "updated_at": "2025-08-26T11:57:12.740150+02:00",
               "txt": "v=spf1 -all",
               "host": 30
             }
@@ -44326,83 +39678,18 @@
                   "tinyhost.example.org"
                 ],
                 "global_name": "community02",
-                "created_at": "2025-06-19T13:09:27.124655+02:00",
-                "updated_at": "2025-06-19T13:09:28.512444+02:00"
+                "created_at": "2025-08-26T11:57:13.046176+02:00",
+                "updated_at": "2025-08-26T11:57:14.329854+02:00"
               }
             }
           ],
-          "created_at": "2025-06-19T13:09:26.792878+02:00",
-          "updated_at": "2025-06-19T13:09:26.792888+02:00",
+          "created_at": "2025-08-26T11:57:12.737925+02:00",
+          "updated_at": "2025-08-26T11:57:12.737933+02:00",
           "name": "tinyhost.example.org",
           "contact": "tinyhost@example.org",
           "ttl": null,
           "comment": "",
           "zone": 1
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/?id=10",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
-            {
-              "excluded_ranges": [],
-              "policy": {
-                "name": "insecurepolicy",
-                "description": "Insecure policy for a network",
-                "attributes": [
-                  {
-                    "name": "bar",
-                    "value": true
-                  },
-                  {
-                    "name": "baz",
-                    "value": true
-                  }
-                ],
-                "community_mapping_prefix": null,
-                "created_at": "2025-06-19T13:09:24.724408+02:00",
-                "updated_at": "2025-06-19T13:09:26.512391+02:00"
-              },
-              "communities": [
-                {
-                  "name": "guests",
-                  "description": "Guest hosts.",
-                  "network": 10,
-                  "hosts": [],
-                  "global_name": "community01",
-                  "created_at": "2025-06-19T13:09:27.063496+02:00",
-                  "updated_at": "2025-06-19T13:09:27.063505+02:00"
-                },
-                {
-                  "name": "labequipment",
-                  "description": "Lab equipment (expensive)",
-                  "network": 10,
-                  "hosts": [
-                    "tinyhost.example.org"
-                  ],
-                  "global_name": "community02",
-                  "created_at": "2025-06-19T13:09:27.124655+02:00",
-                  "updated_at": "2025-06-19T13:09:28.512444+02:00"
-                }
-              ],
-              "created_at": "2025-06-19T13:09:24.299643+02:00",
-              "updated_at": "2025-06-19T13:09:25.887950+02:00",
-              "network": "10.0.2.0/28",
-              "description": "TinyNet",
-              "vlan": null,
-              "dns_delegated": false,
-              "category": "",
-              "location": "",
-              "frozen": false,
-              "reserved": 3
-            }
-          ]
         }
       },
       {
@@ -44447,8 +39734,8 @@
               }
             ],
             "community_mapping_prefix": null,
-            "created_at": "2025-05-19T14:13:39.226705+02:00",
-            "updated_at": "2025-05-19T14:13:41.357575+02:00"
+            "created_at": "2025-08-26T11:57:10.778366+02:00",
+            "updated_at": "2025-08-26T11:57:12.406598+02:00"
           },
           "communities": [
             {
@@ -44457,8 +39744,8 @@
               "network": 10,
               "hosts": [],
               "global_name": "community01",
-              "created_at": "2025-05-19T14:13:42.346255+02:00",
-              "updated_at": "2025-05-19T14:13:42.346270+02:00"
+              "created_at": "2025-08-26T11:57:12.991213+02:00",
+              "updated_at": "2025-08-26T11:57:12.991222+02:00"
             },
             {
               "name": "labequipment",
@@ -44466,12 +39753,12 @@
               "network": 10,
               "hosts": [],
               "global_name": "community02",
-              "created_at": "2025-05-19T14:13:42.444081+02:00",
-              "updated_at": "2025-05-19T14:13:44.080076+02:00"
+              "created_at": "2025-08-26T11:57:13.046176+02:00",
+              "updated_at": "2025-08-26T11:57:14.329854+02:00"
             }
           ],
-          "created_at": "2025-05-19T14:13:38.844138+02:00",
-          "updated_at": "2025-05-19T14:13:40.451944+02:00",
+          "created_at": "2025-08-26T11:57:10.295797+02:00",
+          "updated_at": "2025-08-26T11:57:11.801533+02:00",
           "network": "10.0.2.0/28",
           "description": "TinyNet",
           "vlan": null,
@@ -44508,8 +39795,8 @@
                   }
                 ],
                 "community_mapping_prefix": null,
-                "created_at": "2025-05-19T14:13:39.226705+02:00",
-                "updated_at": "2025-05-19T14:13:41.357575+02:00"
+                "created_at": "2025-08-26T11:57:10.778366+02:00",
+                "updated_at": "2025-08-26T11:57:12.406598+02:00"
               },
               "communities": [
                 {
@@ -44518,8 +39805,8 @@
                   "network": 10,
                   "hosts": [],
                   "global_name": "community01",
-                  "created_at": "2025-05-19T14:13:42.346255+02:00",
-                  "updated_at": "2025-05-19T14:13:42.346270+02:00"
+                  "created_at": "2025-08-26T11:57:12.991213+02:00",
+                  "updated_at": "2025-08-26T11:57:12.991222+02:00"
                 },
                 {
                   "name": "labequipment",
@@ -44527,12 +39814,12 @@
                   "network": 10,
                   "hosts": [],
                   "global_name": "community02",
-                  "created_at": "2025-05-19T14:13:42.444081+02:00",
-                  "updated_at": "2025-05-19T14:13:44.080076+02:00"
+                  "created_at": "2025-08-26T11:57:13.046176+02:00",
+                  "updated_at": "2025-08-26T11:57:14.329854+02:00"
                 }
               ],
-              "created_at": "2025-05-19T14:13:38.844138+02:00",
-              "updated_at": "2025-05-19T14:13:40.451944+02:00",
+              "created_at": "2025-08-26T11:57:10.295797+02:00",
+              "updated_at": "2025-08-26T11:57:11.801533+02:00",
               "network": "10.0.2.0/28",
               "description": "TinyNet",
               "vlan": null,
@@ -44555,69 +39842,6 @@
           "next": null,
           "previous": null,
           "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/?id=10",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
-            {
-              "excluded_ranges": [],
-              "policy": {
-                "name": "insecurepolicy",
-                "description": "Insecure policy for a network",
-                "attributes": [
-                  {
-                    "name": "bar",
-                    "value": true
-                  },
-                  {
-                    "name": "baz",
-                    "value": true
-                  }
-                ],
-                "community_mapping_prefix": null,
-                "created_at": "2025-05-19T14:13:39.226705+02:00",
-                "updated_at": "2025-05-19T14:13:41.357575+02:00"
-              },
-              "communities": [
-                {
-                  "name": "guests",
-                  "description": "Guest hosts.",
-                  "network": 10,
-                  "hosts": [],
-                  "global_name": "community01",
-                  "created_at": "2025-05-19T14:13:42.346255+02:00",
-                  "updated_at": "2025-05-19T14:13:42.346270+02:00"
-                },
-                {
-                  "name": "labequipment",
-                  "description": "Lab equipment (expensive)",
-                  "network": 10,
-                  "hosts": [],
-                  "global_name": "community02",
-                  "created_at": "2025-05-19T14:13:42.444081+02:00",
-                  "updated_at": "2025-05-19T14:13:44.080076+02:00"
-                }
-              ],
-              "created_at": "2025-05-19T14:13:38.844138+02:00",
-              "updated_at": "2025-05-19T14:13:40.451944+02:00",
-              "network": "10.0.2.0/28",
-              "description": "TinyNet",
-              "vlan": null,
-              "dns_delegated": false,
-              "category": "",
-              "location": "",
-              "frozen": false,
-              "reserved": 3
-            }
-          ]
         }
       },
       {
@@ -44662,8 +39886,8 @@
               }
             ],
             "community_mapping_prefix": null,
-            "created_at": "2025-05-19T14:13:39.226705+02:00",
-            "updated_at": "2025-05-19T14:13:41.357575+02:00"
+            "created_at": "2025-08-26T11:57:10.778366+02:00",
+            "updated_at": "2025-08-26T11:57:12.406598+02:00"
           },
           "communities": [
             {
@@ -44672,12 +39896,12 @@
               "network": 10,
               "hosts": [],
               "global_name": "community01",
-              "created_at": "2025-05-19T14:13:42.346255+02:00",
-              "updated_at": "2025-05-19T14:13:42.346270+02:00"
+              "created_at": "2025-08-26T11:57:12.991213+02:00",
+              "updated_at": "2025-08-26T11:57:12.991222+02:00"
             }
           ],
-          "created_at": "2025-05-19T14:13:38.844138+02:00",
-          "updated_at": "2025-05-19T14:13:40.451944+02:00",
+          "created_at": "2025-08-26T11:57:10.295797+02:00",
+          "updated_at": "2025-08-26T11:57:11.801533+02:00",
           "network": "10.0.2.0/28",
           "description": "TinyNet",
           "vlan": null,
@@ -44714,8 +39938,8 @@
                   }
                 ],
                 "community_mapping_prefix": null,
-                "created_at": "2025-05-19T14:13:39.226705+02:00",
-                "updated_at": "2025-05-19T14:13:41.357575+02:00"
+                "created_at": "2025-08-26T11:57:10.778366+02:00",
+                "updated_at": "2025-08-26T11:57:12.406598+02:00"
               },
               "communities": [
                 {
@@ -44724,12 +39948,12 @@
                   "network": 10,
                   "hosts": [],
                   "global_name": "community01",
-                  "created_at": "2025-05-19T14:13:42.346255+02:00",
-                  "updated_at": "2025-05-19T14:13:42.346270+02:00"
+                  "created_at": "2025-08-26T11:57:12.991213+02:00",
+                  "updated_at": "2025-08-26T11:57:12.991222+02:00"
                 }
               ],
-              "created_at": "2025-05-19T14:13:38.844138+02:00",
-              "updated_at": "2025-05-19T14:13:40.451944+02:00",
+              "created_at": "2025-08-26T11:57:10.295797+02:00",
+              "updated_at": "2025-08-26T11:57:11.801533+02:00",
               "network": "10.0.2.0/28",
               "description": "TinyNet",
               "vlan": null,
@@ -44752,60 +39976,6 @@
           "next": null,
           "previous": null,
           "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/?id=10",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
-            {
-              "excluded_ranges": [],
-              "policy": {
-                "name": "insecurepolicy",
-                "description": "Insecure policy for a network",
-                "attributes": [
-                  {
-                    "name": "bar",
-                    "value": true
-                  },
-                  {
-                    "name": "baz",
-                    "value": true
-                  }
-                ],
-                "community_mapping_prefix": null,
-                "created_at": "2025-05-19T14:13:39.226705+02:00",
-                "updated_at": "2025-05-19T14:13:41.357575+02:00"
-              },
-              "communities": [
-                {
-                  "name": "guests",
-                  "description": "Guest hosts.",
-                  "network": 10,
-                  "hosts": [],
-                  "global_name": "community01",
-                  "created_at": "2025-05-19T14:13:42.346255+02:00",
-                  "updated_at": "2025-05-19T14:13:42.346270+02:00"
-                }
-              ],
-              "created_at": "2025-05-19T14:13:38.844138+02:00",
-              "updated_at": "2025-05-19T14:13:40.451944+02:00",
-              "network": "10.0.2.0/28",
-              "description": "TinyNet",
-              "vlan": null,
-              "dns_delegated": false,
-              "category": "",
-              "location": "",
-              "frozen": false,
-              "reserved": 3
-            }
-          ]
         }
       },
       {

--- a/data/mreg-cli.conf
+++ b/data/mreg-cli.conf
@@ -7,3 +7,5 @@
 # logfile=cli.log
 category_tags=cat1,cat2,cat3
 location_tags=loc1,loc2,loc3
+cache=true
+cache_ttl=300

--- a/mreg_cli/cache.py
+++ b/mreg_cli/cache.py
@@ -1,0 +1,104 @@
+import logging
+from typing import Any, Callable, Literal, ParamSpec, Protocol, TypeVar
+
+from diskcache import Cache
+
+logger = logging.getLogger(__name__)
+
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
+
+class CacheLike(Protocol):
+    """Interface for `diskcache.Cache`-like objects."""
+
+    def clear(self, retry: bool = False) -> int: ...
+    def delete(self, key: str, retry: bool = False) -> bool: ...
+    def get(self, key: str, default: str | None = None) -> Any: ...
+    def evict(self, tag: str, retry: bool = False) -> int: ...
+    def memoize(
+        self,
+        name: str | None = None,
+        typed: bool = False,
+        expire: int | float | None = None,
+        tag: str | None = None,
+        ignore: tuple[str, ...] = (),
+    ) -> Any: ...
+    def set(
+        self,
+        key: str,
+        value: Any,
+        expire: float | None = None,
+        read: bool = False,
+        tag: str | None = None,
+        retry: bool = False,
+    ) -> Literal[True]: ...
+    def touch(self, key: str, expire: int | float | None = None) -> bool: ...
+    def volume(self) -> int: ...
+
+
+class NullCache:
+    """A no-op cache implementation that conforms to the CacheLike protocol.
+
+    Exposes most of the same methods as `diskcache.Cache`.
+    """
+
+    def memoize(
+        self,
+        name: str | None = None,
+        typed: bool = False,
+        expire: int | float | None = None,
+        tag: str | None = None,
+        ignore: tuple[str, ...] = (),
+    ) -> Callable[[Callable[P, T]], Callable[P, T]]:
+        """Returns a decorator that does nothing"""
+
+        def decorator(func: Callable[P, T]) -> Callable[P, T]:
+            return func  # Just return the original function unchanged
+
+        return decorator
+
+    def evict(self, tag: str, retry: bool = False) -> int:
+        return 0
+
+    def clear(self, retry: bool = False) -> int:
+        return 0
+
+    def delete(self, key: str, retry: bool = False) -> bool:
+        return True
+
+    def get(self, key: str, default: str | None = None) -> str | None:
+        return default
+
+    def set(
+        self,
+        key: str,
+        value: Any,
+        expire: float | None = None,
+        read: bool = False,
+        tag: str | None = None,
+        retry: bool = False,
+    ) -> Literal[True]:
+        return True
+
+    def touch(self, key: str, expire: int | float | None = None) -> bool:
+        return True
+
+    def volume(self) -> int:
+        return 0
+
+
+def create_cache() -> CacheLike:
+    """Create the global mreg-cli cache.
+
+    Falls back to a no-op cache object if the diskcache cache cannot be created.
+    """
+    try:
+        return Cache()
+    except Exception as e:
+        logger.exception("Failed to create cache: %s", e)
+        return NullCache()
+
+
+cache = create_cache()

--- a/mreg_cli/cache.py
+++ b/mreg_cli/cache.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Callable, Literal, ParamSpec, Protocol, TypeVar
+from typing import Any, Callable, Literal, ParamSpec, Protocol, TypeVar, runtime_checkable
 
 from diskcache import Cache
 
@@ -10,6 +10,7 @@ P = ParamSpec("P")
 T = TypeVar("T")
 
 
+@runtime_checkable
 class CacheLike(Protocol):
     """Interface for `diskcache.Cache`-like objects."""
 
@@ -29,7 +30,7 @@ class CacheLike(Protocol):
         self,
         key: str,
         value: Any,
-        expire: float | None = None,
+        expire: int | float | None = None,
         read: bool = False,
         tag: str | None = None,
         retry: bool = False,
@@ -75,7 +76,7 @@ class NullCache:
         self,
         key: str,
         value: Any,
-        expire: float | None = None,
+        expire: int | float | None = None,
         read: bool = False,
         tag: str | None = None,
         retry: bool = False,

--- a/mreg_cli/cache.py
+++ b/mreg_cli/cache.py
@@ -201,12 +201,16 @@ def cache_api_get(cache: CacheLike, config: MregCliConfig) -> None:
     import mreg_cli.utilities.api
 
     global _ORIGINAL_API_DO_GET
+    if _ORIGINAL_API_DO_GET is None:
+        _ORIGINAL_API_DO_GET = mreg_cli.utilities.api._do_get  # pyright: ignore[reportConstantRedefinition]
 
-    _ORIGINAL_API_DO_GET = mreg_cli.utilities.api._do_get  # pyright: ignore[reportConstantRedefinition]
+    # Ensure we use the original function
+    # (important if this function is called multiple times)
+    do_get = _ORIGINAL_API_DO_GET
 
     # Patch the mreg_cli.utilities.api._do_get function
     mreg_cli.utilities.api._do_get = cache.memoize(expire=config.get_cache_ttl(), tag="api")(
-        _ORIGINAL_API_DO_GET
+        do_get
     )
 
 

--- a/mreg_cli/cli.py
+++ b/mreg_cli/cli.py
@@ -19,6 +19,7 @@ from prompt_toolkit.completion import CompleteEvent, Completer, Completion
 from pydantic import ValidationError as PydanticValidationError
 
 # Import all the commands
+from mreg_cli.commands.cache import CacheCommands
 from mreg_cli.commands.dhcp import DHCPCommands
 from mreg_cli.commands.group import GroupCommands
 from mreg_cli.commands.help import HelpCommands
@@ -299,6 +300,7 @@ commands: list[type[BaseCommandSubclass]] = [
     LabelCommands,
     RecordingCommmands,
     LoggingCommmands,
+    CacheCommands,
     RootCommmands,
 ]
 for command in commands:

--- a/mreg_cli/commands/cache.py
+++ b/mreg_cli/commands/cache.py
@@ -1,0 +1,47 @@
+"""Cache command for the CLI."""
+
+from __future__ import annotations
+
+import argparse
+from typing import Any
+
+from mreg_cli.cache import cache, get_cache_info
+from mreg_cli.commands.base import BaseCommand
+from mreg_cli.commands.registry import CommandRegistry
+from mreg_cli.outputmanager import OutputManager
+
+command_registry = CommandRegistry()
+
+
+class CacheCommands(BaseCommand):
+    """Group commands for the CLI."""
+
+    def __init__(self, cli: Any) -> None:
+        """Initialize the cache commands."""
+        super().__init__(cli, command_registry, "cache", "Manage cache.", "Manage cache.")
+
+
+@command_registry.register_command(
+    prog="clear", description="Clear the cache", short_desc="Clear the cache"
+)
+def cache_clear(_: argparse.Namespace) -> None:
+    """Clear the cache."""
+    try:
+        b = cache.clear()
+    except Exception as e:
+        OutputManager().add_error(f"Failed to clear cache: {e}")
+        return
+    OutputManager().add_ok(f"Cleared cache, {b} items removed.")
+
+
+@command_registry.register_command(
+    prog="info", description="Show cache information", short_desc="Show cache info"
+)
+def cache_info(_: argparse.Namespace) -> None:
+    """Show cache information."""
+    try:
+        info = get_cache_info()
+        OutputManager().add_formatted_table(*info.as_table_args())
+    except Exception as e:
+        OutputManager().add_error(f"Failed to retrieve cache info: {e}")
+        return

--- a/mreg_cli/commands/cache.py
+++ b/mreg_cli/commands/cache.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import argparse
 from typing import Any
 
-from mreg_cli.cache import cache, get_cache_info
+from mreg_cli.cache import get_cache, get_cache_info
 from mreg_cli.commands.base import BaseCommand
 from mreg_cli.commands.registry import CommandRegistry
+from mreg_cli.config import MregCliConfig
 from mreg_cli.outputmanager import OutputManager
 
 command_registry = CommandRegistry()
@@ -27,6 +28,7 @@ class CacheCommands(BaseCommand):
 def cache_clear(_: argparse.Namespace) -> None:
     """Clear the cache."""
     try:
+        cache = get_cache()
         b = cache.clear()
     except Exception as e:
         OutputManager().add_error(f"Failed to clear cache: {e}")
@@ -39,6 +41,11 @@ def cache_clear(_: argparse.Namespace) -> None:
 )
 def cache_info(_: argparse.Namespace) -> None:
     """Show cache information."""
+    conf = MregCliConfig()
+    if not conf.get_cache_enabled():
+        OutputManager().add_line("Caching is disabled.")
+        return
+
     try:
         info = get_cache_info()
         OutputManager().add_formatted_table(*info.as_table_args())

--- a/mreg_cli/config.py
+++ b/mreg_cli/config.py
@@ -75,11 +75,12 @@ DEFAULT_HTTP_TIMEOUT = 20  # seconds
 DEFAULT_CACHE_TTL = 300  # seconds
 
 
-def is_bool_true(value: str | None) -> bool:
+def is_bool_true(value: str | bool | None) -> bool:
     """Check if a string value is has a 'truthy' value.
 
-    NOTE: 'truthy' in the sense that it is a valid YAML-like bool value."""
-    v = value or ""
+    NOTE: 'truthy' in the sense that it is a valid YAML-like bool value.
+    """
+    v = str(value) if value else ""
     return v.lower() in ["true", "1", "yes", "y"]
 
 

--- a/mreg_cli/config.py
+++ b/mreg_cli/config.py
@@ -250,6 +250,10 @@ class MregCliConfig:
         """Get the cache enabled status from the application."""
         return is_bool_true(self.get("cache", "true"))
 
+    def set_cache_enabled(self, enabled: bool) -> None:
+        """Set the cache enabled status in the application."""
+        self._config_cmd["cache"] = "true" if enabled else "false"
+
     def get_cache_ttl(self) -> int:
         """Get the cache TTL (time-to-live) from the application."""
         ttl = self.get("cache_ttl", DEFAULT_CACHE_TTL)

--- a/mreg_cli/config.py
+++ b/mreg_cli/config.py
@@ -72,6 +72,24 @@ LOGGING_FORMAT = "%(asctime)s - %(levelname)-8s - %(name)s - %(message)s"
 DEFAULT_PROMPT = "{user}@{host}"
 
 DEFAULT_HTTP_TIMEOUT = 20  # seconds
+DEFAULT_CACHE_TTL = 300  # seconds
+
+
+def is_bool_true(value: str | None) -> bool:
+    """Check if a string value is has a 'truthy' value.
+
+    NOTE: 'truthy' in the sense that it is a valid YAML-like bool value."""
+    v = value or ""
+    return v.lower() in ["true", "1", "yes", "y"]
+
+
+def as_int(value: str | int | None, default: int, name: str = "value") -> int:
+    """Convert a string value to an integer, or return the default."""
+    try:
+        return int(value)  # pyright: ignore[reportArgumentType]
+    except (ValueError, TypeError):
+        logger.warning("Invalid %s value, using default %d seconds.", name, default)
+        return default
 
 
 class MregCliConfig:
@@ -228,6 +246,15 @@ class MregCliConfig:
         logger.debug("no config file found in config paths")
         return None
 
+    def get_cache_enabled(self) -> bool:
+        """Get the cache enabled status from the application."""
+        return is_bool_true(self.get("cache", "true"))
+
+    def get_cache_ttl(self) -> int:
+        """Get the cache TTL (time-to-live) from the application."""
+        ttl = self.get("cache_ttl", DEFAULT_CACHE_TTL)
+        return as_int(ttl, DEFAULT_CACHE_TTL, "Cache TTL")
+
     def get_default_domain(self):
         """Get the default domain from the application."""
         return self.get("domain", "uio.no")
@@ -267,13 +294,7 @@ class MregCliConfig:
         :returns: HTTP timeout in seconds.
         """
         timeout = self.get("timeout", DEFAULT_HTTP_TIMEOUT)
-        try:
-            return int(timeout)
-        except ValueError:
-            logger.warning(
-                "Invalid timeout value, using default %d seconds.", DEFAULT_HTTP_TIMEOUT
-            )
-            return DEFAULT_HTTP_TIMEOUT
+        return as_int(timeout, DEFAULT_HTTP_TIMEOUT, "HTTP Timeout")
 
     def _calculate_column_width(self, data: dict[str, Any], min_width: int = 8) -> int:
         """Calculate the maximum column width, ensuring a minimum width.

--- a/mreg_cli/config.py
+++ b/mreg_cli/config.py
@@ -156,7 +156,7 @@ class MregCliConfig:
 
         :param argparse.Namespace args: Command line arguments.
         """
-        conf = {k: v for k, v in vars(args).items() if v}
+        conf = {k: v for k, v in vars(args).items() if v not in [None, ""]}
         self._config_cmd.update(conf)
 
     def get_config(self, reload: bool = False) -> None:

--- a/mreg_cli/main.py
+++ b/mreg_cli/main.py
@@ -10,6 +10,7 @@ import logging
 from prompt_toolkit.shortcuts import CompleteStyle, PromptSession
 
 import mreg_cli.utilities.api as api
+from mreg_cli import cache
 from mreg_cli.__about__ import __version__
 from mreg_cli.cli import cli, source
 from mreg_cli.config import MregCliConfig
@@ -154,6 +155,9 @@ def main():
     elif config.get("url") is None:
         print("mreg url not set in config or as argument")
         return
+
+    # Configure application
+    cache.configure(config)
 
     try:
         try_token_or_login(

--- a/mreg_cli/main.py
+++ b/mreg_cli/main.py
@@ -69,12 +69,25 @@ def main():
         help="default %(metavar)s (default: %(default)s)",
         metavar="DOMAIN",
     )
-
     mreg_args.add_argument(
         "-p",
         "--prompt",
         help="default %(metavar)s), defaults to the server name if not set.",
         metavar="PROMPT",
+    )
+    mreg_args.add_argument(
+        "--no-cache",
+        dest="cache",
+        help="Disable caching of API responses.",
+        action="store_false",  # NOTE: inverted flag
+        default=True,
+    )
+    mreg_args.add_argument(
+        "--cache-ttl",
+        dest="cache_ttl",
+        help="Maximum time to live for cache entries in seconds.",
+        type=int,
+        default=300,
     )
 
     output_args = parser.add_argument_group("output settings")

--- a/mreg_cli/utilities/api.py
+++ b/mreg_cli/utilities/api.py
@@ -23,7 +23,7 @@ from requests import Response
 
 from mreg_cli.__about__ import __version__
 from mreg_cli.api.errors import parse_mreg_error
-from mreg_cli.cache import cache
+from mreg_cli.cache import get_cache
 from mreg_cli.config import MregCliConfig
 from mreg_cli.exceptions import (
     APINotOk,
@@ -335,9 +335,27 @@ def get(path: str, params: QueryParams | None = ..., *, ok404: bool) -> Response
 def get(path: str, params: QueryParams | None = ...) -> Response: ...
 
 
-@cache.memoize(expire=300, tag="api")
 def get(path: str, params: QueryParams | None = None, ok404: bool = False) -> Response | None:
     """Make a standard get request."""
+    return _do_get(path, params, ok404)
+
+
+def _do_get(path: str, params: QueryParams | None = None, ok404: bool = False) -> Response | None:
+    """Perform a GET request.
+
+    Separated out from get(), so that we can patch this function with a memoized version
+    without affecting other modules that do `from mreg_cli.utilities.api import get`, as
+    they would then operate on the unpatched version instead of the modified one,
+    since their `get` symbol differs from the `get` symbol in this module
+    in a scenario where `get` itself is patched _after_ it is imported elsewhere.
+
+    The caching module can modify this function instead of `get`,
+    allowing other modules to be oblivious of the caching behavior, and freely
+    import `get` into their namespaces.
+
+    Yes... Patching sucks when you have other modules that import scoped symbols
+    into their own namespace.
+    """
     if params is None:
         params = {}
     return _request_wrapper("get", path, params=params, ok404=ok404)
@@ -604,6 +622,7 @@ def clear_cache(f: Callable[P, T]) -> Callable[P, T]:
     def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
         result = f(*args, **kwargs)
         try:
+            cache = get_cache()
             cache.evict("api")
         except Exception as e:
             logger.error(f"Error clearing cache: {e}")

--- a/mreg_cli/utilities/api.py
+++ b/mreg_cli/utilities/api.py
@@ -623,7 +623,7 @@ def clear_cache(f: Callable[P, T]) -> Callable[P, T]:
         result = f(*args, **kwargs)
         try:
             cache = get_cache()
-            cache.evict("api")
+            cache.cache.evict("api")  # does not reset stats
         except Exception as e:
             logger.error(f"Error clearing cache: {e}")
         return result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
     "pydantic[email]>=2.7.1",
     "pydantic-extra-types>=2.1.0",
     "platformdirs>=4.3.0",
+    "diskcache>=5.6.3",
 ]
 dynamic = ["version"]
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -103,12 +103,13 @@ def test_get_cache_not_configured(mock_cache_config: MagicMock) -> None:
 
 
 def test_get_cache_info_noarg() -> None:
-    """Test MregCliCache.get_cache_info() with an empty cache."""
+    """Test MregCliCache.get_cache_info() with the default cache."""
     # Clear cache first
 
     cache = get_cache()
 
     cache.clear()
+    assert isinstance(cache.cache, diskcache.Cache)
 
     info = cache.get_info()
     # Mock the directory property (non-deterministic)
@@ -126,7 +127,7 @@ def test_get_cache_info_noarg() -> None:
     )
 
 
-def test_get_cache_info_diskcache_cache() -> None:
+def test_get_cache_info_nullcache() -> None:
     """Test get_cache_info() with a NullCache cache."""
     c = NullCache()
     cache = MregCliCache(c)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,8 +1,11 @@
+from __future__ import annotations
+
 from unittest.mock import patch
 
 import diskcache
+from inline_snapshot import snapshot
 
-from mreg_cli.cache import CacheLike, NullCache, create_cache
+from mreg_cli.cache import CacheLike, NullCache, create_cache, get_cache_info
 
 
 def test_mreg_cli_cache_is_diskcache_cache() -> None:
@@ -53,3 +56,34 @@ def test_nullcache_methods() -> None:
     assert cache.touch("key") is True
     assert cache.touch("key", expire=60) is True
     assert cache.volume() == 0
+
+
+def test_get_cache_info_noarg() -> None:
+    """Test that get_cache_info() returns the expected CacheInfo given no arguments."""
+    # Clear cache first
+    from mreg_cli.cache import cache
+
+    cache.clear()
+
+    info = get_cache_info()
+    # Mock the directory property (non-deterministic)
+    info.directory = "mocked_directory"
+
+    assert info.model_dump(mode="json") == snapshot(
+        {
+            "items": 0,
+            "size": "32.0KiB",
+            "hits": 0,
+            "misses": 0,
+            "directory": "mocked_directory",
+            "disk": "Disk",
+        }
+    )
+
+
+def test_get_cache_info_diskcache_cache() -> None:
+    """Test get_cache_info() with a diskcache.Cache argument."""
+    c = diskcache.Cache()
+    info = get_cache_info(c)
+    # Mock directory
+    info.directory = "mocked_directory"

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,55 @@
+from unittest.mock import patch
+
+import diskcache
+
+from mreg_cli.cache import CacheLike, NullCache, create_cache
+
+
+def test_mreg_cli_cache_is_diskcache_cache() -> None:
+    """Ensure that create_cache returns a diskcache.Cache object."""
+    c = create_cache()
+    assert isinstance(c, diskcache.Cache)
+
+
+def test_diskcache_cache_is_cachelike() -> None:
+    """Test that the diskcache.Cache class conforms to the CacheLike protocol."""
+    # Create a new cache
+    c = diskcache.Cache(name="diskcache_cache_is_cachelike")
+    assert isinstance(c, CacheLike)
+
+
+def test_diskcache_cache_init_error() -> None:
+    """Test that a diskcache.Cache() init error returns a NullCache."""
+    with patch("mreg_cli.cache.Cache") as mock_cache:
+        # Make Cache() raise an exception during initialization
+        mock_cache.side_effect = Exception("Disk cache initialization failed")
+        # Verify that the result is an instance of NullCache
+        result = create_cache()
+        assert isinstance(result, NullCache)
+
+
+def test_nullcache_memoize() -> None:
+    """Test that NullCache.memoize() returns the original function."""
+    cache = NullCache()
+
+    def sample_function(x: int) -> int:
+        return x * 2
+
+    memoized_function = cache.memoize()(sample_function)
+    assert memoized_function is sample_function
+
+
+def test_nullcache_methods() -> None:
+    """Test that NullCache methods work as expected."""
+    cache = NullCache()
+    assert cache.evict(tag="test", retry=True) == 0
+    assert cache.clear(retry=True) == 0
+    assert cache.delete("key") is True
+    assert cache.delete("key", retry=True) is True
+    assert cache.get("key") is None
+    assert cache.get("key", default="default") == "default"
+    assert cache.set("key", "value") is True
+    assert cache.set("key", "value", expire=60, read=True, tag="test", retry=True) is True
+    assert cache.touch("key") is True
+    assert cache.touch("key", expire=60) is True
+    assert cache.volume() == 0

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -10,11 +10,11 @@ from inline_snapshot import snapshot
 import mreg_cli.cache
 from mreg_cli.cache import (
     CacheLike,
+    MregCliCache,
     NullCache,
     _create_cache,
     configure,
     get_cache,
-    get_cache_info,
 )
 from mreg_cli.config import MregCliConfig
 
@@ -99,18 +99,18 @@ def test_get_cache_not_configured(mock_cache_config: MagicMock) -> None:
 
     configure(mock_cache_config)
     cache = get_cache()
-    assert isinstance(cache, NullCache)
+    assert isinstance(cache.cache, NullCache)
 
 
 def test_get_cache_info_noarg() -> None:
-    """Test that get_cache_info() returns the expected CacheInfo given no arguments."""
+    """Test MregCliCache.get_cache_info() with an empty cache."""
     # Clear cache first
 
     cache = get_cache()
 
     cache.clear()
 
-    info = get_cache_info()
+    info = cache.get_info()
     # Mock the directory property (non-deterministic)
     info.directory = "mocked_directory"
 
@@ -127,18 +127,17 @@ def test_get_cache_info_noarg() -> None:
 
 
 def test_get_cache_info_diskcache_cache() -> None:
-    """Test get_cache_info() with a diskcache.Cache argument."""
-    c = diskcache.Cache()
-    info = get_cache_info(c)
-    # Mock directory
-    info.directory = "mocked_directory"
+    """Test get_cache_info() with a NullCache cache."""
+    c = NullCache()
+    cache = MregCliCache(c)
+    info = cache.get_info()
     assert info.model_dump(mode="json") == snapshot(
         {
             "items": 0,
-            "size": "32.0KiB",
+            "size": "0B",
             "hits": 0,
             "misses": 0,
             "ttl": 300,
-            "directory": "mocked_directory",
+            "directory": "",
         }
     )

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -70,14 +70,7 @@ def test_get_cache_info_noarg() -> None:
     info.directory = "mocked_directory"
 
     assert info.model_dump(mode="json") == snapshot(
-        {
-            "items": 0,
-            "size": "32.0KiB",
-            "hits": 0,
-            "misses": 0,
-            "directory": "mocked_directory",
-            "disk": "Disk",
-        }
+        {"items": 0, "size": "32.0KiB", "hits": 0, "misses": 0, "directory": "mocked_directory"}
     )
 
 
@@ -87,3 +80,6 @@ def test_get_cache_info_diskcache_cache() -> None:
     info = get_cache_info(c)
     # Mock directory
     info.directory = "mocked_directory"
+    assert info.model_dump(mode="json") == snapshot(
+        {"items": 0, "size": "32.0KiB", "hits": 0, "misses": 0, "directory": "mocked_directory"}
+    )

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -115,7 +115,14 @@ def test_get_cache_info_noarg() -> None:
     info.directory = "mocked_directory"
 
     assert info.model_dump(mode="json") == snapshot(
-        {"items": 0, "size": "32.0KiB", "hits": 0, "misses": 0, "directory": "mocked_directory"}
+        {
+            "items": 0,
+            "size": "32.0KiB",
+            "hits": 0,
+            "misses": 0,
+            "ttl": 300,
+            "directory": "mocked_directory",
+        }
     )
 
 
@@ -126,5 +133,12 @@ def test_get_cache_info_diskcache_cache() -> None:
     # Mock directory
     info.directory = "mocked_directory"
     assert info.model_dump(mode="json") == snapshot(
-        {"items": 0, "size": "32.0KiB", "hits": 0, "misses": 0, "directory": "mocked_directory"}
+        {
+            "items": 0,
+            "size": "32.0KiB",
+            "hits": 0,
+            "misses": 0,
+            "ttl": 300,
+            "directory": "mocked_directory",
+        }
     )

--- a/tests/utilities/test_api.py
+++ b/tests/utilities/test_api.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Iterator
 from typing import Any
 
 import pytest
@@ -8,16 +7,8 @@ from inline_snapshot import snapshot
 from pytest_httpserver import HTTPServer
 from werkzeug import Response
 
-from mreg_cli.cache import cache
 from mreg_cli.exceptions import MultipleEntitiesFound, ValidationError
 from mreg_cli.utilities.api import _strip_none, get_list, get_list_unique  # type: ignore
-
-
-@pytest.fixture(autouse=True)
-def clear_cache() -> Iterator[None]:
-    """Fixture that clears the mreg-cli cache between tests."""
-    yield
-    cache.clear()
 
 
 @pytest.mark.parametrize(
@@ -42,7 +33,7 @@ def test_strip_none(inp: dict[str, Any], expect: dict[str, Any]) -> None:
 
 
 def test_get_list_paginated(httpserver: HTTPServer) -> None:
-    httpserver.expect_oneshot_request("/foobar").respond_with_json(
+    httpserver.expect_oneshot_request("/test_get_list_paginated").respond_with_json(
         {
             "results": [{"foo": "bar"}],
             "count": 1,
@@ -50,12 +41,12 @@ def test_get_list_paginated(httpserver: HTTPServer) -> None:
             "previous": None,
         }
     )
-    resp = get_list("/foobar")
+    resp = get_list("/test_get_list_paginated")
     assert resp == snapshot([{"foo": "bar"}])
 
 
 def test_get_list_paginated_empty(httpserver: HTTPServer) -> None:
-    httpserver.expect_oneshot_request("/foobar").respond_with_json(
+    httpserver.expect_oneshot_request("/test_get_list_paginated_empty").respond_with_json(
         {
             "results": [],
             "count": 0,
@@ -63,66 +54,76 @@ def test_get_list_paginated_empty(httpserver: HTTPServer) -> None:
             "previous": None,
         }
     )
-    resp = get_list("/foobar")
+    resp = get_list("/test_get_list_paginated_empty")
     assert resp == snapshot([])
 
 
 def test_get_list_paginated_multiple_pages(httpserver: HTTPServer) -> None:
-    httpserver.expect_oneshot_request("/foobar").respond_with_json(
+    httpserver.expect_oneshot_request("/test_get_list_paginated_multiple_pages").respond_with_json(
         {
             "results": [{"foo": "bar"}],
             "count": 1,
-            "next": "/foobar?page=2",
+            "next": "/test_get_list_paginated_multiple_pages?page=2",
             "previous": None,
         }
     )
-    httpserver.expect_oneshot_request("/foobar", query_string="page=2").respond_with_json(
+    httpserver.expect_oneshot_request(
+        "/test_get_list_paginated_multiple_pages", query_string="page=2"
+    ).respond_with_json(
         {
             "results": [{"baz": "qux"}],
             "count": 1,
             "next": None,
-            "previous": "/foobar",
+            "previous": "/test_get_list_paginated_multiple_pages",
         }
     )
-    resp = get_list("/foobar")
+    resp = get_list("/test_get_list_paginated_multiple_pages")
     assert resp == snapshot([{"foo": "bar"}, {"baz": "qux"}])
 
 
 def test_get_list_paginated_multiple_pages_ok404(httpserver: HTTPServer) -> None:
     """Paginated response with 404 on next page is ignored when `ok404=True`."""
-    httpserver.expect_oneshot_request("/foobar").respond_with_json(
+    httpserver.expect_oneshot_request(
+        "/test_get_list_paginated_multiple_pages_ok404"
+    ).respond_with_json(
         {
             "results": [{"foo": "bar"}],
             "count": 1,
-            "next": "/foobar?page=2",
+            "next": "/test_get_list_paginated_multiple_pages_ok404?page=2",
             "previous": None,
         }
     )
-    httpserver.expect_oneshot_request("/foobar", query_string="page=2").respond_with_response(
-        Response(status=404)
+    httpserver.expect_oneshot_request(
+        "/test_get_list_paginated_multiple_pages_ok404", query_string="page=2"
+    ).respond_with_response(Response(status=404))
+    assert get_list("/test_get_list_paginated_multiple_pages_ok404", ok404=True) == snapshot(
+        [{"foo": "bar"}]
     )
-    assert get_list("/foobar", ok404=True) == snapshot([{"foo": "bar"}])
 
 
 def test_get_list_paginated_multiple_pages_inconsistent_count(httpserver: HTTPServer) -> None:
     """Inconsistent count in paginated response is ignored."""
-    httpserver.expect_oneshot_request("/foobar").respond_with_json(
+    httpserver.expect_oneshot_request(
+        "/test_get_list_paginated_multiple_pages_inconsistent_count"
+    ).respond_with_json(
         {
             "results": [{"foo": "bar"}, {"baz": "qux"}],
             "count": 1,  # wrong count
-            "next": "/foobar?page=2",
+            "next": "/test_get_list_paginated_multiple_pages_inconsistent_count?page=2",
             "previous": None,
         }
     )
-    httpserver.expect_oneshot_request("/foobar", query_string="page=2").respond_with_json(
+    httpserver.expect_oneshot_request(
+        "/test_get_list_paginated_multiple_pages_inconsistent_count", query_string="page=2"
+    ).respond_with_json(
         {
             "results": [{"quux": "spam"}],
             "count": 2,  # wrong count
             "next": None,
-            "previous": "/foobar",
+            "previous": "/test_get_list_paginated_multiple_pages_inconsistent_count?page=1",
         }
     )
-    resp = get_list("/foobar")
+    resp = get_list("/test_get_list_paginated_multiple_pages_inconsistent_count")
     assert resp == snapshot([{"foo": "bar"}, {"baz": "qux"}, {"quux": "spam"}])
 
 
@@ -138,7 +139,7 @@ def test_get_list_paginated_multiple_pages_inconsistent_count(httpserver: HTTPSe
 )
 def test_get_list_paginated_invalid(httpserver: HTTPServer, results: Any) -> None:
     """Invalid JSON or non-array response is an error."""
-    httpserver.expect_oneshot_request("/foobar").respond_with_data(
+    httpserver.expect_oneshot_request("/test_get_list_paginated_invalid").respond_with_data(
         f"""{{
             "results": {results},
             "count": 1,
@@ -147,56 +148,58 @@ def test_get_list_paginated_invalid(httpserver: HTTPServer, results: Any) -> Non
             }}"""
     )
     with pytest.raises(ValidationError) as exc_info:
-        get_list("/foobar")
+        get_list("/test_get_list_paginated_invalid")
     assert "did not return valid paginated JSON" in exc_info.exconly()
 
 
 def test_get_list_non_paginated(httpserver: HTTPServer) -> None:
     """Inconsistent count in paginated response is ignored."""
-    httpserver.expect_oneshot_request("/foobar").respond_with_json(
+    httpserver.expect_oneshot_request("/test_get_list_non_paginated").respond_with_json(
         [
             "foo",
             "bar",
             {"baz": "qux"},
         ]
     )
-    resp = get_list("/foobar")
+    resp = get_list("/test_get_list_non_paginated")
     assert resp == snapshot(["foo", "bar", {"baz": "qux"}])
 
 
 def test_get_list_non_paginated_empty(httpserver: HTTPServer) -> None:
     """Inconsistent count in paginated response is ignored."""
-    httpserver.expect_oneshot_request("/foobar").respond_with_json([])
-    resp = get_list("/foobar")
+    httpserver.expect_oneshot_request("/test_get_list_non_paginated_empty").respond_with_json([])
+    resp = get_list("/test_get_list_non_paginated_empty")
     assert resp == snapshot([])
 
 
 def test_get_list_non_paginated_non_array(httpserver: HTTPServer) -> None:
     """Non-paginated non-array response is an error."""
-    httpserver.expect_oneshot_request("/foobar").respond_with_json(
+    httpserver.expect_oneshot_request("/test_get_list_non_paginated_non_array").respond_with_json(
         {
             "not": "an array",
         }
     )
     with pytest.raises(ValidationError) as exc_info:
-        get_list("/foobar")
+        get_list("/test_get_list_non_paginated_non_array")
     assert "did not return a valid JSON" in exc_info.exconly()
 
 
 def test_get_list_non_paginated_invalid_json(httpserver: HTTPServer) -> None:
     """Non-paginated response with invalid JSON is an error."""
-    httpserver.expect_oneshot_request("/foobar").respond_with_data(
+    httpserver.expect_oneshot_request(
+        "/test_get_list_non_paginated_invalid_json"
+    ).respond_with_data(
         "[{'key': 'value'}, 'foo',]",  # strings must be double quoted
         content_type="application/json",
     )
     with pytest.raises(ValidationError) as exc_info:
-        get_list("/foobar")
+        get_list("/test_get_list_non_paginated_invalid_json")
     assert "did not return a valid JSON" in exc_info.exconly()
 
 
 def test_get_list_unique_paginated(httpserver: HTTPServer) -> None:
     """Non-paginated response with invalid JSON is an error."""
-    httpserver.expect_oneshot_request("/foobar").respond_with_json(
+    httpserver.expect_oneshot_request("/test_get_list_unique_paginated").respond_with_json(
         {
             "results": [{"foo": "bar"}],
             "count": 1,
@@ -204,30 +207,34 @@ def test_get_list_unique_paginated(httpserver: HTTPServer) -> None:
             "previous": None,
         }
     )
-    resp = get_list_unique("/foobar", params={})
+    resp = get_list_unique("/test_get_list_unique_paginated", params={})
     assert resp == snapshot({"foo": "bar"})
 
 
 def test_get_list_unique_paginated_too_many_results(httpserver: HTTPServer) -> None:
     """get_list_unique with multiple unique results is an error."""
-    httpserver.expect_oneshot_request("/foobar").respond_with_json(
+    httpserver.expect_oneshot_request(
+        "/test_get_list_unique_paginated_too_many_results"
+    ).respond_with_json(
         {
             "results": [{"foo": "bar"}],
             "count": 1,
-            "next": "/foobar?page=2",
+            "next": "/test_get_list_unique_paginated_too_many_results?page=2",
             "previous": None,
         }
     )
-    httpserver.expect_oneshot_request("/foobar", query_string="page=2").respond_with_json(
+    httpserver.expect_oneshot_request(
+        "/test_get_list_unique_paginated_too_many_results", query_string="page=2"
+    ).respond_with_json(
         {
             "results": [{"baz": "qux"}],
             "count": 1,
             "next": None,
-            "previous": "/foobar",
+            "previous": "/test_get_list_unique_paginated_too_many_results?page=1",
         }
     )
     with pytest.raises(MultipleEntitiesFound) as exc_info:
-        get_list_unique("/foobar", params={})
+        get_list_unique("/test_get_list_unique_paginated_too_many_results", params={})
     assert exc_info.exconly() == snapshot(
         "mreg_cli.exceptions.MultipleEntitiesFound: Expected a unique result, got 2 distinct results."
     )
@@ -235,29 +242,35 @@ def test_get_list_unique_paginated_too_many_results(httpserver: HTTPServer) -> N
 
 def test_get_list_unique_paginated_duplicate_result_ok(httpserver: HTTPServer) -> None:
     """get_list_unique with _only_ duplicate results is ok."""
-    httpserver.expect_oneshot_request("/foobar").respond_with_json(
+    httpserver.expect_oneshot_request(
+        "/test_get_list_unique_paginated_duplicate_result_ok"
+    ).respond_with_json(
         {
             "results": [{"foo": "bar"}],
             "count": 1,
-            "next": "/foobar?page=2",
+            "next": "/test_get_list_unique_paginated_duplicate_result_ok?page=2",
             "previous": None,
         }
     )
-    httpserver.expect_oneshot_request("/foobar", query_string="page=2").respond_with_json(
+    httpserver.expect_oneshot_request(
+        "/test_get_list_unique_paginated_duplicate_result_ok", query_string="page=2"
+    ).respond_with_json(
         {
             "results": [{"foo": "bar"}],
             "count": 1,
             "next": None,
-            "previous": "/foobar",
+            "previous": "/test_get_list_unique_paginated_duplicate_result_ok?page=1",
         }
     )
-    resp = get_list_unique("/foobar", params={})
+    resp = get_list_unique("/test_get_list_unique_paginated_duplicate_result_ok", params={})
     assert resp == snapshot({"foo": "bar"})
 
 
 def test_get_list_unique_paginated_no_result(httpserver: HTTPServer) -> None:
     """No result is None."""
-    httpserver.expect_oneshot_request("/foobar").respond_with_json(
+    httpserver.expect_oneshot_request(
+        "/test_get_list_unique_paginated_no_result"
+    ).respond_with_json(
         {
             "results": [],
             "count": 0,
@@ -265,12 +278,14 @@ def test_get_list_unique_paginated_no_result(httpserver: HTTPServer) -> None:
             "previous": None,
         }
     )
-    resp = get_list_unique("/foobar", params={})
+    resp = get_list_unique("/test_get_list_unique_paginated_no_result", params={})
     assert resp is None
 
 
 def test_get_list_unique_non_paginated_no_result(httpserver: HTTPServer) -> None:
     """No result is None."""
-    httpserver.expect_oneshot_request("/foobar").respond_with_json([])
-    resp = get_list_unique("/foobar", params={})
+    httpserver.expect_oneshot_request(
+        "/test_get_list_unique_non_paginated_no_result"
+    ).respond_with_json([])
+    resp = get_list_unique("/test_get_list_unique_non_paginated_no_result", params={})
     assert resp is None

--- a/tests/utilities/test_api.py
+++ b/tests/utilities/test_api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Iterator
 from typing import Any
 
 import pytest
@@ -7,8 +8,16 @@ from inline_snapshot import snapshot
 from pytest_httpserver import HTTPServer
 from werkzeug import Response
 
+from mreg_cli.cache import cache
 from mreg_cli.exceptions import MultipleEntitiesFound, ValidationError
 from mreg_cli.utilities.api import _strip_none, get_list, get_list_unique  # type: ignore
+
+
+@pytest.fixture(autouse=True)
+def clear_cache() -> Iterator[None]:
+    """Fixture that clears the mreg-cli cache between tests."""
+    yield
+    cache.clear()
 
 
 @pytest.mark.parametrize(

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 2
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version < '3.13'",
@@ -9,18 +10,18 @@ resolution-markers = [
 name = "altgraph"
 version = "0.17.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/de/a8/7145824cf0b9e3c28046520480f207df47e927df83aa9555fb47f8505922/altgraph-0.17.4.tar.gz", hash = "sha256:1b5afbb98f6c4dcadb2e2ae6ab9fa994bbb8c1d75f4fa96d340f9437ae454406", size = 48418 }
+sdist = { url = "https://files.pythonhosted.org/packages/de/a8/7145824cf0b9e3c28046520480f207df47e927df83aa9555fb47f8505922/altgraph-0.17.4.tar.gz", hash = "sha256:1b5afbb98f6c4dcadb2e2ae6ab9fa994bbb8c1d75f4fa96d340f9437ae454406", size = 48418, upload_time = "2023-09-25T09:04:52.164Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/3f/3bc3f1d83f6e4a7fcb834d3720544ca597590425be5ba9db032b2bf322a2/altgraph-0.17.4-py2.py3-none-any.whl", hash = "sha256:642743b4750de17e655e6711601b077bc6598dbfa3ba5fa2b2a35ce12b508dff", size = 21212 },
+    { url = "https://files.pythonhosted.org/packages/4d/3f/3bc3f1d83f6e4a7fcb834d3720544ca597590425be5ba9db032b2bf322a2/altgraph-0.17.4-py2.py3-none-any.whl", hash = "sha256:642743b4750de17e655e6711601b077bc6598dbfa3ba5fa2b2a35ce12b508dff", size = 21212, upload_time = "2023-09-25T09:04:50.691Z" },
 ]
 
 [[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081 }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload_time = "2024-05-20T21:33:25.928Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643 },
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload_time = "2024-05-20T21:33:24.1Z" },
 ]
 
 [[package]]
@@ -30,9 +31,9 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "six" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/45/1d/f03bcb60c4a3212e15f99a56085d93093a497718adf828d050b9d675da81/asttokens-2.4.1.tar.gz", hash = "sha256:b03869718ba9a6eb027e134bfdf69f38a236d681c83c160d510768af11254ba0", size = 62284 }
+sdist = { url = "https://files.pythonhosted.org/packages/45/1d/f03bcb60c4a3212e15f99a56085d93093a497718adf828d050b9d675da81/asttokens-2.4.1.tar.gz", hash = "sha256:b03869718ba9a6eb027e134bfdf69f38a236d681c83c160d510768af11254ba0", size = 62284, upload_time = "2023-10-26T10:03:05.06Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/45/86/4736ac618d82a20d87d2f92ae19441ebc7ac9e7a581d7e58bbe79233b24a/asttokens-2.4.1-py2.py3-none-any.whl", hash = "sha256:051ed49c3dcae8913ea7cd08e46a606dba30b79993209636c4875bc1d637bc24", size = 27764 },
+    { url = "https://files.pythonhosted.org/packages/45/86/4736ac618d82a20d87d2f92ae19441ebc7ac9e7a581d7e58bbe79233b24a/asttokens-2.4.1-py2.py3-none-any.whl", hash = "sha256:051ed49c3dcae8913ea7cd08e46a606dba30b79993209636c4875bc1d637bc24", size = 27764, upload_time = "2023-10-26T10:03:01.789Z" },
 ]
 
 [[package]]
@@ -46,21 +47,21 @@ dependencies = [
     { name = "pathspec" },
     { name = "platformdirs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d8/0d/cc2fb42b8c50d80143221515dd7e4766995bd07c56c9a3ed30baf080b6dc/black-24.10.0.tar.gz", hash = "sha256:846ea64c97afe3bc677b761787993be4991810ecc7a4a937816dd6bddedc4875", size = 645813 }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/0d/cc2fb42b8c50d80143221515dd7e4766995bd07c56c9a3ed30baf080b6dc/black-24.10.0.tar.gz", hash = "sha256:846ea64c97afe3bc677b761787993be4991810ecc7a4a937816dd6bddedc4875", size = 645813, upload_time = "2024-10-07T19:20:50.361Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/cc/7496bb63a9b06a954d3d0ac9fe7a73f3bf1cd92d7a58877c27f4ad1e9d41/black-24.10.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5a2221696a8224e335c28816a9d331a6c2ae15a2ee34ec857dcf3e45dbfa99ad", size = 1607468 },
-    { url = "https://files.pythonhosted.org/packages/2b/e3/69a738fb5ba18b5422f50b4f143544c664d7da40f09c13969b2fd52900e0/black-24.10.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f9da3333530dbcecc1be13e69c250ed8dfa67f43c4005fb537bb426e19200d50", size = 1437270 },
-    { url = "https://files.pythonhosted.org/packages/c9/9b/2db8045b45844665c720dcfe292fdaf2e49825810c0103e1191515fc101a/black-24.10.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4007b1393d902b48b36958a216c20c4482f601569d19ed1df294a496eb366392", size = 1737061 },
-    { url = "https://files.pythonhosted.org/packages/a3/95/17d4a09a5be5f8c65aa4a361444d95edc45def0de887810f508d3f65db7a/black-24.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:394d4ddc64782e51153eadcaaca95144ac4c35e27ef9b0a42e121ae7e57a9175", size = 1423293 },
-    { url = "https://files.pythonhosted.org/packages/90/04/bf74c71f592bcd761610bbf67e23e6a3cff824780761f536512437f1e655/black-24.10.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b5e39e0fae001df40f95bd8cc36b9165c5e2ea88900167bddf258bacef9bbdc3", size = 1644256 },
-    { url = "https://files.pythonhosted.org/packages/4c/ea/a77bab4cf1887f4b2e0bce5516ea0b3ff7d04ba96af21d65024629afedb6/black-24.10.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d37d422772111794b26757c5b55a3eade028aa3fde43121ab7b673d050949d65", size = 1448534 },
-    { url = "https://files.pythonhosted.org/packages/4e/3e/443ef8bc1fbda78e61f79157f303893f3fddf19ca3c8989b163eb3469a12/black-24.10.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:14b3502784f09ce2443830e3133dacf2c0110d45191ed470ecb04d0f5f6fcb0f", size = 1761892 },
-    { url = "https://files.pythonhosted.org/packages/52/93/eac95ff229049a6901bc84fec6908a5124b8a0b7c26ea766b3b8a5debd22/black-24.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:30d2c30dc5139211dda799758559d1b049f7f14c580c409d6ad925b74a4208a8", size = 1434796 },
-    { url = "https://files.pythonhosted.org/packages/d0/a0/a993f58d4ecfba035e61fca4e9f64a2ecae838fc9f33ab798c62173ed75c/black-24.10.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1cbacacb19e922a1d75ef2b6ccaefcd6e93a2c05ede32f06a21386a04cedb981", size = 1643986 },
-    { url = "https://files.pythonhosted.org/packages/37/d5/602d0ef5dfcace3fb4f79c436762f130abd9ee8d950fa2abdbf8bbc555e0/black-24.10.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1f93102e0c5bb3907451063e08b9876dbeac810e7da5a8bfb7aeb5a9ef89066b", size = 1448085 },
-    { url = "https://files.pythonhosted.org/packages/47/6d/a3a239e938960df1a662b93d6230d4f3e9b4a22982d060fc38c42f45a56b/black-24.10.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ddacb691cdcdf77b96f549cf9591701d8db36b2f19519373d60d31746068dbf2", size = 1760928 },
-    { url = "https://files.pythonhosted.org/packages/dd/cf/af018e13b0eddfb434df4d9cd1b2b7892bab119f7a20123e93f6910982e8/black-24.10.0-cp313-cp313-win_amd64.whl", hash = "sha256:680359d932801c76d2e9c9068d05c6b107f2584b2a5b88831c83962eb9984c1b", size = 1436875 },
-    { url = "https://files.pythonhosted.org/packages/8d/a7/4b27c50537ebca8bec139b872861f9d2bf501c5ec51fcf897cb924d9e264/black-24.10.0-py3-none-any.whl", hash = "sha256:3bb2b7a1f7b685f85b11fed1ef10f8a9148bceb49853e47a294a3dd963c1dd7d", size = 206898 },
+    { url = "https://files.pythonhosted.org/packages/c2/cc/7496bb63a9b06a954d3d0ac9fe7a73f3bf1cd92d7a58877c27f4ad1e9d41/black-24.10.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5a2221696a8224e335c28816a9d331a6c2ae15a2ee34ec857dcf3e45dbfa99ad", size = 1607468, upload_time = "2024-10-07T19:26:14.966Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/e3/69a738fb5ba18b5422f50b4f143544c664d7da40f09c13969b2fd52900e0/black-24.10.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f9da3333530dbcecc1be13e69c250ed8dfa67f43c4005fb537bb426e19200d50", size = 1437270, upload_time = "2024-10-07T19:25:24.291Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/9b/2db8045b45844665c720dcfe292fdaf2e49825810c0103e1191515fc101a/black-24.10.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4007b1393d902b48b36958a216c20c4482f601569d19ed1df294a496eb366392", size = 1737061, upload_time = "2024-10-07T19:23:52.18Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/95/17d4a09a5be5f8c65aa4a361444d95edc45def0de887810f508d3f65db7a/black-24.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:394d4ddc64782e51153eadcaaca95144ac4c35e27ef9b0a42e121ae7e57a9175", size = 1423293, upload_time = "2024-10-07T19:24:41.7Z" },
+    { url = "https://files.pythonhosted.org/packages/90/04/bf74c71f592bcd761610bbf67e23e6a3cff824780761f536512437f1e655/black-24.10.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b5e39e0fae001df40f95bd8cc36b9165c5e2ea88900167bddf258bacef9bbdc3", size = 1644256, upload_time = "2024-10-07T19:27:53.355Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/ea/a77bab4cf1887f4b2e0bce5516ea0b3ff7d04ba96af21d65024629afedb6/black-24.10.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d37d422772111794b26757c5b55a3eade028aa3fde43121ab7b673d050949d65", size = 1448534, upload_time = "2024-10-07T19:26:44.953Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/3e/443ef8bc1fbda78e61f79157f303893f3fddf19ca3c8989b163eb3469a12/black-24.10.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:14b3502784f09ce2443830e3133dacf2c0110d45191ed470ecb04d0f5f6fcb0f", size = 1761892, upload_time = "2024-10-07T19:24:10.264Z" },
+    { url = "https://files.pythonhosted.org/packages/52/93/eac95ff229049a6901bc84fec6908a5124b8a0b7c26ea766b3b8a5debd22/black-24.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:30d2c30dc5139211dda799758559d1b049f7f14c580c409d6ad925b74a4208a8", size = 1434796, upload_time = "2024-10-07T19:25:06.239Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/a0/a993f58d4ecfba035e61fca4e9f64a2ecae838fc9f33ab798c62173ed75c/black-24.10.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1cbacacb19e922a1d75ef2b6ccaefcd6e93a2c05ede32f06a21386a04cedb981", size = 1643986, upload_time = "2024-10-07T19:28:50.684Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d5/602d0ef5dfcace3fb4f79c436762f130abd9ee8d950fa2abdbf8bbc555e0/black-24.10.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1f93102e0c5bb3907451063e08b9876dbeac810e7da5a8bfb7aeb5a9ef89066b", size = 1448085, upload_time = "2024-10-07T19:28:12.093Z" },
+    { url = "https://files.pythonhosted.org/packages/47/6d/a3a239e938960df1a662b93d6230d4f3e9b4a22982d060fc38c42f45a56b/black-24.10.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ddacb691cdcdf77b96f549cf9591701d8db36b2f19519373d60d31746068dbf2", size = 1760928, upload_time = "2024-10-07T19:24:15.233Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/cf/af018e13b0eddfb434df4d9cd1b2b7892bab119f7a20123e93f6910982e8/black-24.10.0-cp313-cp313-win_amd64.whl", hash = "sha256:680359d932801c76d2e9c9068d05c6b107f2584b2a5b88831c83962eb9984c1b", size = 1436875, upload_time = "2024-10-07T19:24:42.762Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/a7/4b27c50537ebca8bec139b872861f9d2bf501c5ec51fcf897cb924d9e264/black-24.10.0-py3-none-any.whl", hash = "sha256:3bb2b7a1f7b685f85b11fed1ef10f8a9148bceb49853e47a294a3dd963c1dd7d", size = 206898, upload_time = "2024-10-07T19:20:48.317Z" },
 ]
 
 [[package]]
@@ -72,75 +73,75 @@ dependencies = [
     { name = "packaging" },
     { name = "pyproject-hooks" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/46/aeab111f8e06793e4f0e421fcad593d547fb8313b50990f31681ee2fb1ad/build-1.2.2.post1.tar.gz", hash = "sha256:b36993e92ca9375a219c99e606a122ff365a760a2d4bba0caa09bd5278b608b7", size = 46701 }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/46/aeab111f8e06793e4f0e421fcad593d547fb8313b50990f31681ee2fb1ad/build-1.2.2.post1.tar.gz", hash = "sha256:b36993e92ca9375a219c99e606a122ff365a760a2d4bba0caa09bd5278b608b7", size = 46701, upload_time = "2024-10-06T17:22:25.251Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/c2/80633736cd183ee4a62107413def345f7e6e3c01563dbca1417363cf957e/build-1.2.2.post1-py3-none-any.whl", hash = "sha256:1d61c0887fa860c01971625baae8bdd338e517b836a2f70dd1f7aa3a6b2fc5b5", size = 22950 },
+    { url = "https://files.pythonhosted.org/packages/84/c2/80633736cd183ee4a62107413def345f7e6e3c01563dbca1417363cf957e/build-1.2.2.post1-py3-none-any.whl", hash = "sha256:1d61c0887fa860c01971625baae8bdd338e517b836a2f70dd1f7aa3a6b2fc5b5", size = 22950, upload_time = "2024-10-06T17:22:23.299Z" },
 ]
 
 [[package]]
 name = "cachetools"
 version = "5.5.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c3/38/a0f315319737ecf45b4319a8cd1f3a908e29d9277b46942263292115eee7/cachetools-5.5.0.tar.gz", hash = "sha256:2cc24fb4cbe39633fb7badd9db9ca6295d766d9c2995f245725a46715d050f2a", size = 27661 }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/38/a0f315319737ecf45b4319a8cd1f3a908e29d9277b46942263292115eee7/cachetools-5.5.0.tar.gz", hash = "sha256:2cc24fb4cbe39633fb7badd9db9ca6295d766d9c2995f245725a46715d050f2a", size = 27661, upload_time = "2024-08-18T20:28:44.639Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/07/14f8ad37f2d12a5ce41206c21820d8cb6561b728e51fad4530dff0552a67/cachetools-5.5.0-py3-none-any.whl", hash = "sha256:02134e8439cdc2ffb62023ce1debca2944c3f289d66bb17ead3ab3dede74b292", size = 9524 },
+    { url = "https://files.pythonhosted.org/packages/a4/07/14f8ad37f2d12a5ce41206c21820d8cb6561b728e51fad4530dff0552a67/cachetools-5.5.0-py3-none-any.whl", hash = "sha256:02134e8439cdc2ffb62023ce1debca2944c3f289d66bb17ead3ab3dede74b292", size = 9524, upload_time = "2024-08-18T20:28:43.404Z" },
 ]
 
 [[package]]
 name = "certifi"
 version = "2024.8.30"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/ee/9b19140fe824b367c04c5e1b369942dd754c4c5462d5674002f75c4dedc1/certifi-2024.8.30.tar.gz", hash = "sha256:bec941d2aa8195e248a60b31ff9f0558284cf01a52591ceda73ea9afffd69fd9", size = 168507 }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/ee/9b19140fe824b367c04c5e1b369942dd754c4c5462d5674002f75c4dedc1/certifi-2024.8.30.tar.gz", hash = "sha256:bec941d2aa8195e248a60b31ff9f0558284cf01a52591ceda73ea9afffd69fd9", size = 168507, upload_time = "2024-08-30T01:55:04.365Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/90/3c9ff0512038035f59d279fddeb79f5f1eccd8859f06d6163c58798b9487/certifi-2024.8.30-py3-none-any.whl", hash = "sha256:922820b53db7a7257ffbda3f597266d435245903d80737e34f8a45ff3e3230d8", size = 167321 },
+    { url = "https://files.pythonhosted.org/packages/12/90/3c9ff0512038035f59d279fddeb79f5f1eccd8859f06d6163c58798b9487/certifi-2024.8.30-py3-none-any.whl", hash = "sha256:922820b53db7a7257ffbda3f597266d435245903d80737e34f8a45ff3e3230d8", size = 167321, upload_time = "2024-08-30T01:55:02.591Z" },
 ]
 
 [[package]]
 name = "chardet"
 version = "5.2.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f3/0d/f7b6ab21ec75897ed80c17d79b15951a719226b9fababf1e40ea74d69079/chardet-5.2.0.tar.gz", hash = "sha256:1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7", size = 2069618 }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/0d/f7b6ab21ec75897ed80c17d79b15951a719226b9fababf1e40ea74d69079/chardet-5.2.0.tar.gz", hash = "sha256:1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7", size = 2069618, upload_time = "2023-08-01T19:23:02.662Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/6f/f5fbc992a329ee4e0f288c1fe0e2ad9485ed064cac731ed2fe47dcc38cbf/chardet-5.2.0-py3-none-any.whl", hash = "sha256:e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970", size = 199385 },
+    { url = "https://files.pythonhosted.org/packages/38/6f/f5fbc992a329ee4e0f288c1fe0e2ad9485ed064cac731ed2fe47dcc38cbf/chardet-5.2.0-py3-none-any.whl", hash = "sha256:e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970", size = 199385, upload_time = "2023-08-01T19:23:00.661Z" },
 ]
 
 [[package]]
 name = "charset-normalizer"
 version = "3.3.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/63/09/c1bc53dab74b1816a00d8d030de5bf98f724c52c1635e07681d312f20be8/charset-normalizer-3.3.2.tar.gz", hash = "sha256:f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5", size = 104809 }
+sdist = { url = "https://files.pythonhosted.org/packages/63/09/c1bc53dab74b1816a00d8d030de5bf98f724c52c1635e07681d312f20be8/charset-normalizer-3.3.2.tar.gz", hash = "sha256:f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5", size = 104809, upload_time = "2023-11-01T04:04:59.997Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/77/02839016f6fbbf808e8b38601df6e0e66c17bbab76dff4613f7511413597/charset_normalizer-3.3.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:802fe99cca7457642125a8a88a084cef28ff0cf9407060f7b93dca5aa25480db", size = 191647 },
-    { url = "https://files.pythonhosted.org/packages/3e/33/21a875a61057165e92227466e54ee076b73af1e21fe1b31f1e292251aa1e/charset_normalizer-3.3.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:573f6eac48f4769d667c4442081b1794f52919e7edada77495aaed9236d13a96", size = 121434 },
-    { url = "https://files.pythonhosted.org/packages/dd/51/68b61b90b24ca35495956b718f35a9756ef7d3dd4b3c1508056fa98d1a1b/charset_normalizer-3.3.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:549a3a73da901d5bc3ce8d24e0600d1fa85524c10287f6004fbab87672bf3e1e", size = 118979 },
-    { url = "https://files.pythonhosted.org/packages/e4/a6/7ee57823d46331ddc37dd00749c95b0edec2c79b15fc0d6e6efb532e89ac/charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f27273b60488abe721a075bcca6d7f3964f9f6f067c8c4c605743023d7d3944f", size = 136582 },
-    { url = "https://files.pythonhosted.org/packages/74/f1/0d9fe69ac441467b737ba7f48c68241487df2f4522dd7246d9426e7c690e/charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1ceae2f17a9c33cb48e3263960dc5fc8005351ee19db217e9b1bb15d28c02574", size = 146645 },
-    { url = "https://files.pythonhosted.org/packages/05/31/e1f51c76db7be1d4aef220d29fbfa5dbb4a99165d9833dcbf166753b6dc0/charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:65f6f63034100ead094b8744b3b97965785388f308a64cf8d7c34f2f2e5be0c4", size = 139398 },
-    { url = "https://files.pythonhosted.org/packages/40/26/f35951c45070edc957ba40a5b1db3cf60a9dbb1b350c2d5bef03e01e61de/charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:753f10e867343b4511128c6ed8c82f7bec3bd026875576dfd88483c5c73b2fd8", size = 140273 },
-    { url = "https://files.pythonhosted.org/packages/07/07/7e554f2bbce3295e191f7e653ff15d55309a9ca40d0362fcdab36f01063c/charset_normalizer-3.3.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4a78b2b446bd7c934f5dcedc588903fb2f5eec172f3d29e52a9096a43722adfc", size = 142577 },
-    { url = "https://files.pythonhosted.org/packages/d8/b5/eb705c313100defa57da79277d9207dc8d8e45931035862fa64b625bfead/charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:e537484df0d8f426ce2afb2d0f8e1c3d0b114b83f8850e5f2fbea0e797bd82ae", size = 137747 },
-    { url = "https://files.pythonhosted.org/packages/19/28/573147271fd041d351b438a5665be8223f1dd92f273713cb882ddafe214c/charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:eb6904c354526e758fda7167b33005998fb68c46fbc10e013ca97f21ca5c8887", size = 143375 },
-    { url = "https://files.pythonhosted.org/packages/cf/7c/f3b682fa053cc21373c9a839e6beba7705857075686a05c72e0f8c4980ca/charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:deb6be0ac38ece9ba87dea880e438f25ca3eddfac8b002a2ec3d9183a454e8ae", size = 148474 },
-    { url = "https://files.pythonhosted.org/packages/1e/49/7ab74d4ac537ece3bc3334ee08645e231f39f7d6df6347b29a74b0537103/charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:4ab2fe47fae9e0f9dee8c04187ce5d09f48eabe611be8259444906793ab7cbce", size = 140232 },
-    { url = "https://files.pythonhosted.org/packages/2d/dc/9dacba68c9ac0ae781d40e1a0c0058e26302ea0660e574ddf6797a0347f7/charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:80402cd6ee291dcb72644d6eac93785fe2c8b9cb30893c1af5b8fdd753b9d40f", size = 140859 },
-    { url = "https://files.pythonhosted.org/packages/6c/c2/4a583f800c0708dd22096298e49f887b49d9746d0e78bfc1d7e29816614c/charset_normalizer-3.3.2-cp311-cp311-win32.whl", hash = "sha256:7cd13a2e3ddeed6913a65e66e94b51d80a041145a026c27e6bb76c31a853c6ab", size = 92509 },
-    { url = "https://files.pythonhosted.org/packages/57/ec/80c8d48ac8b1741d5b963797b7c0c869335619e13d4744ca2f67fc11c6fc/charset_normalizer-3.3.2-cp311-cp311-win_amd64.whl", hash = "sha256:663946639d296df6a2bb2aa51b60a2454ca1cb29835324c640dafb5ff2131a77", size = 99870 },
-    { url = "https://files.pythonhosted.org/packages/d1/b2/fcedc8255ec42afee97f9e6f0145c734bbe104aac28300214593eb326f1d/charset_normalizer-3.3.2-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:0b2b64d2bb6d3fb9112bafa732def486049e63de9618b5843bcdd081d8144cd8", size = 192892 },
-    { url = "https://files.pythonhosted.org/packages/2e/7d/2259318c202f3d17f3fe6438149b3b9e706d1070fe3fcbb28049730bb25c/charset_normalizer-3.3.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:ddbb2551d7e0102e7252db79ba445cdab71b26640817ab1e3e3648dad515003b", size = 122213 },
-    { url = "https://files.pythonhosted.org/packages/3a/52/9f9d17c3b54dc238de384c4cb5a2ef0e27985b42a0e5cc8e8a31d918d48d/charset_normalizer-3.3.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:55086ee1064215781fff39a1af09518bc9255b50d6333f2e4c74ca09fac6a8f6", size = 119404 },
-    { url = "https://files.pythonhosted.org/packages/99/b0/9c365f6d79a9f0f3c379ddb40a256a67aa69c59609608fe7feb6235896e1/charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f4a014bc36d3c57402e2977dada34f9c12300af536839dc38c0beab8878f38a", size = 137275 },
-    { url = "https://files.pythonhosted.org/packages/91/33/749df346e93d7a30cdcb90cbfdd41a06026317bfbfb62cd68307c1a3c543/charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a10af20b82360ab00827f916a6058451b723b4e65030c5a18577c8b2de5b3389", size = 147518 },
-    { url = "https://files.pythonhosted.org/packages/72/1a/641d5c9f59e6af4c7b53da463d07600a695b9824e20849cb6eea8a627761/charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8d756e44e94489e49571086ef83b2bb8ce311e730092d2c34ca8f7d925cb20aa", size = 140182 },
-    { url = "https://files.pythonhosted.org/packages/ee/fb/14d30eb4956408ee3ae09ad34299131fb383c47df355ddb428a7331cfa1e/charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90d558489962fd4918143277a773316e56c72da56ec7aa3dc3dbbe20fdfed15b", size = 141869 },
-    { url = "https://files.pythonhosted.org/packages/df/3e/a06b18788ca2eb6695c9b22325b6fde7dde0f1d1838b1792a0076f58fe9d/charset_normalizer-3.3.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6ac7ffc7ad6d040517be39eb591cac5ff87416c2537df6ba3cba3bae290c0fed", size = 144042 },
-    { url = "https://files.pythonhosted.org/packages/45/59/3d27019d3b447a88fe7e7d004a1e04be220227760264cc41b405e863891b/charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:7ed9e526742851e8d5cc9e6cf41427dfc6068d4f5a3bb03659444b4cabf6bc26", size = 138275 },
-    { url = "https://files.pythonhosted.org/packages/7b/ef/5eb105530b4da8ae37d506ccfa25057961b7b63d581def6f99165ea89c7e/charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:8bdb58ff7ba23002a4c5808d608e4e6c687175724f54a5dade5fa8c67b604e4d", size = 144819 },
-    { url = "https://files.pythonhosted.org/packages/a2/51/e5023f937d7f307c948ed3e5c29c4b7a3e42ed2ee0b8cdf8f3a706089bf0/charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_ppc64le.whl", hash = "sha256:6b3251890fff30ee142c44144871185dbe13b11bab478a88887a639655be1068", size = 149415 },
-    { url = "https://files.pythonhosted.org/packages/24/9d/2e3ef673dfd5be0154b20363c5cdcc5606f35666544381bee15af3778239/charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_s390x.whl", hash = "sha256:b4a23f61ce87adf89be746c8a8974fe1c823c891d8f86eb218bb957c924bb143", size = 141212 },
-    { url = "https://files.pythonhosted.org/packages/5b/ae/ce2c12fcac59cb3860b2e2d76dc405253a4475436b1861d95fe75bdea520/charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:efcb3f6676480691518c177e3b465bcddf57cea040302f9f4e6e191af91174d4", size = 142167 },
-    { url = "https://files.pythonhosted.org/packages/ed/3a/a448bf035dce5da359daf9ae8a16b8a39623cc395a2ffb1620aa1bce62b0/charset_normalizer-3.3.2-cp312-cp312-win32.whl", hash = "sha256:d965bba47ddeec8cd560687584e88cf699fd28f192ceb452d1d7ee807c5597b7", size = 93041 },
-    { url = "https://files.pythonhosted.org/packages/b6/7c/8debebb4f90174074b827c63242c23851bdf00a532489fba57fef3416e40/charset_normalizer-3.3.2-cp312-cp312-win_amd64.whl", hash = "sha256:96b02a3dc4381e5494fad39be677abcb5e6634bf7b4fa83a6dd3112607547001", size = 100397 },
-    { url = "https://files.pythonhosted.org/packages/28/76/e6222113b83e3622caa4bb41032d0b1bf785250607392e1b778aca0b8a7d/charset_normalizer-3.3.2-py3-none-any.whl", hash = "sha256:3e4d1f6587322d2788836a99c69062fbb091331ec940e02d12d179c1d53e25fc", size = 48543 },
+    { url = "https://files.pythonhosted.org/packages/68/77/02839016f6fbbf808e8b38601df6e0e66c17bbab76dff4613f7511413597/charset_normalizer-3.3.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:802fe99cca7457642125a8a88a084cef28ff0cf9407060f7b93dca5aa25480db", size = 191647, upload_time = "2023-11-01T04:02:55.329Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/33/21a875a61057165e92227466e54ee076b73af1e21fe1b31f1e292251aa1e/charset_normalizer-3.3.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:573f6eac48f4769d667c4442081b1794f52919e7edada77495aaed9236d13a96", size = 121434, upload_time = "2023-11-01T04:02:57.173Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/51/68b61b90b24ca35495956b718f35a9756ef7d3dd4b3c1508056fa98d1a1b/charset_normalizer-3.3.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:549a3a73da901d5bc3ce8d24e0600d1fa85524c10287f6004fbab87672bf3e1e", size = 118979, upload_time = "2023-11-01T04:02:58.442Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/a6/7ee57823d46331ddc37dd00749c95b0edec2c79b15fc0d6e6efb532e89ac/charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f27273b60488abe721a075bcca6d7f3964f9f6f067c8c4c605743023d7d3944f", size = 136582, upload_time = "2023-11-01T04:02:59.776Z" },
+    { url = "https://files.pythonhosted.org/packages/74/f1/0d9fe69ac441467b737ba7f48c68241487df2f4522dd7246d9426e7c690e/charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1ceae2f17a9c33cb48e3263960dc5fc8005351ee19db217e9b1bb15d28c02574", size = 146645, upload_time = "2023-11-01T04:03:02.186Z" },
+    { url = "https://files.pythonhosted.org/packages/05/31/e1f51c76db7be1d4aef220d29fbfa5dbb4a99165d9833dcbf166753b6dc0/charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:65f6f63034100ead094b8744b3b97965785388f308a64cf8d7c34f2f2e5be0c4", size = 139398, upload_time = "2023-11-01T04:03:04.255Z" },
+    { url = "https://files.pythonhosted.org/packages/40/26/f35951c45070edc957ba40a5b1db3cf60a9dbb1b350c2d5bef03e01e61de/charset_normalizer-3.3.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:753f10e867343b4511128c6ed8c82f7bec3bd026875576dfd88483c5c73b2fd8", size = 140273, upload_time = "2023-11-01T04:03:05.983Z" },
+    { url = "https://files.pythonhosted.org/packages/07/07/7e554f2bbce3295e191f7e653ff15d55309a9ca40d0362fcdab36f01063c/charset_normalizer-3.3.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4a78b2b446bd7c934f5dcedc588903fb2f5eec172f3d29e52a9096a43722adfc", size = 142577, upload_time = "2023-11-01T04:03:07.567Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/b5/eb705c313100defa57da79277d9207dc8d8e45931035862fa64b625bfead/charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:e537484df0d8f426ce2afb2d0f8e1c3d0b114b83f8850e5f2fbea0e797bd82ae", size = 137747, upload_time = "2023-11-01T04:03:08.886Z" },
+    { url = "https://files.pythonhosted.org/packages/19/28/573147271fd041d351b438a5665be8223f1dd92f273713cb882ddafe214c/charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:eb6904c354526e758fda7167b33005998fb68c46fbc10e013ca97f21ca5c8887", size = 143375, upload_time = "2023-11-01T04:03:10.613Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/7c/f3b682fa053cc21373c9a839e6beba7705857075686a05c72e0f8c4980ca/charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:deb6be0ac38ece9ba87dea880e438f25ca3eddfac8b002a2ec3d9183a454e8ae", size = 148474, upload_time = "2023-11-01T04:03:11.973Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/49/7ab74d4ac537ece3bc3334ee08645e231f39f7d6df6347b29a74b0537103/charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:4ab2fe47fae9e0f9dee8c04187ce5d09f48eabe611be8259444906793ab7cbce", size = 140232, upload_time = "2023-11-01T04:03:13.505Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/dc/9dacba68c9ac0ae781d40e1a0c0058e26302ea0660e574ddf6797a0347f7/charset_normalizer-3.3.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:80402cd6ee291dcb72644d6eac93785fe2c8b9cb30893c1af5b8fdd753b9d40f", size = 140859, upload_time = "2023-11-01T04:03:17.362Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c2/4a583f800c0708dd22096298e49f887b49d9746d0e78bfc1d7e29816614c/charset_normalizer-3.3.2-cp311-cp311-win32.whl", hash = "sha256:7cd13a2e3ddeed6913a65e66e94b51d80a041145a026c27e6bb76c31a853c6ab", size = 92509, upload_time = "2023-11-01T04:03:21.453Z" },
+    { url = "https://files.pythonhosted.org/packages/57/ec/80c8d48ac8b1741d5b963797b7c0c869335619e13d4744ca2f67fc11c6fc/charset_normalizer-3.3.2-cp311-cp311-win_amd64.whl", hash = "sha256:663946639d296df6a2bb2aa51b60a2454ca1cb29835324c640dafb5ff2131a77", size = 99870, upload_time = "2023-11-01T04:03:22.723Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/b2/fcedc8255ec42afee97f9e6f0145c734bbe104aac28300214593eb326f1d/charset_normalizer-3.3.2-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:0b2b64d2bb6d3fb9112bafa732def486049e63de9618b5843bcdd081d8144cd8", size = 192892, upload_time = "2023-11-01T04:03:24.135Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/7d/2259318c202f3d17f3fe6438149b3b9e706d1070fe3fcbb28049730bb25c/charset_normalizer-3.3.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:ddbb2551d7e0102e7252db79ba445cdab71b26640817ab1e3e3648dad515003b", size = 122213, upload_time = "2023-11-01T04:03:25.66Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/52/9f9d17c3b54dc238de384c4cb5a2ef0e27985b42a0e5cc8e8a31d918d48d/charset_normalizer-3.3.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:55086ee1064215781fff39a1af09518bc9255b50d6333f2e4c74ca09fac6a8f6", size = 119404, upload_time = "2023-11-01T04:03:27.04Z" },
+    { url = "https://files.pythonhosted.org/packages/99/b0/9c365f6d79a9f0f3c379ddb40a256a67aa69c59609608fe7feb6235896e1/charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f4a014bc36d3c57402e2977dada34f9c12300af536839dc38c0beab8878f38a", size = 137275, upload_time = "2023-11-01T04:03:28.466Z" },
+    { url = "https://files.pythonhosted.org/packages/91/33/749df346e93d7a30cdcb90cbfdd41a06026317bfbfb62cd68307c1a3c543/charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a10af20b82360ab00827f916a6058451b723b4e65030c5a18577c8b2de5b3389", size = 147518, upload_time = "2023-11-01T04:03:29.82Z" },
+    { url = "https://files.pythonhosted.org/packages/72/1a/641d5c9f59e6af4c7b53da463d07600a695b9824e20849cb6eea8a627761/charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8d756e44e94489e49571086ef83b2bb8ce311e730092d2c34ca8f7d925cb20aa", size = 140182, upload_time = "2023-11-01T04:03:31.511Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/fb/14d30eb4956408ee3ae09ad34299131fb383c47df355ddb428a7331cfa1e/charset_normalizer-3.3.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90d558489962fd4918143277a773316e56c72da56ec7aa3dc3dbbe20fdfed15b", size = 141869, upload_time = "2023-11-01T04:03:32.887Z" },
+    { url = "https://files.pythonhosted.org/packages/df/3e/a06b18788ca2eb6695c9b22325b6fde7dde0f1d1838b1792a0076f58fe9d/charset_normalizer-3.3.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6ac7ffc7ad6d040517be39eb591cac5ff87416c2537df6ba3cba3bae290c0fed", size = 144042, upload_time = "2023-11-01T04:03:34.412Z" },
+    { url = "https://files.pythonhosted.org/packages/45/59/3d27019d3b447a88fe7e7d004a1e04be220227760264cc41b405e863891b/charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:7ed9e526742851e8d5cc9e6cf41427dfc6068d4f5a3bb03659444b4cabf6bc26", size = 138275, upload_time = "2023-11-01T04:03:35.759Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/ef/5eb105530b4da8ae37d506ccfa25057961b7b63d581def6f99165ea89c7e/charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:8bdb58ff7ba23002a4c5808d608e4e6c687175724f54a5dade5fa8c67b604e4d", size = 144819, upload_time = "2023-11-01T04:03:37.216Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/51/e5023f937d7f307c948ed3e5c29c4b7a3e42ed2ee0b8cdf8f3a706089bf0/charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_ppc64le.whl", hash = "sha256:6b3251890fff30ee142c44144871185dbe13b11bab478a88887a639655be1068", size = 149415, upload_time = "2023-11-01T04:03:38.694Z" },
+    { url = "https://files.pythonhosted.org/packages/24/9d/2e3ef673dfd5be0154b20363c5cdcc5606f35666544381bee15af3778239/charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_s390x.whl", hash = "sha256:b4a23f61ce87adf89be746c8a8974fe1c823c891d8f86eb218bb957c924bb143", size = 141212, upload_time = "2023-11-01T04:03:40.07Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/ae/ce2c12fcac59cb3860b2e2d76dc405253a4475436b1861d95fe75bdea520/charset_normalizer-3.3.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:efcb3f6676480691518c177e3b465bcddf57cea040302f9f4e6e191af91174d4", size = 142167, upload_time = "2023-11-01T04:03:41.491Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/3a/a448bf035dce5da359daf9ae8a16b8a39623cc395a2ffb1620aa1bce62b0/charset_normalizer-3.3.2-cp312-cp312-win32.whl", hash = "sha256:d965bba47ddeec8cd560687584e88cf699fd28f192ceb452d1d7ee807c5597b7", size = 93041, upload_time = "2023-11-01T04:03:42.836Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/7c/8debebb4f90174074b827c63242c23851bdf00a532489fba57fef3416e40/charset_normalizer-3.3.2-cp312-cp312-win_amd64.whl", hash = "sha256:96b02a3dc4381e5494fad39be677abcb5e6634bf7b4fa83a6dd3112607547001", size = 100397, upload_time = "2023-11-01T04:03:44.467Z" },
+    { url = "https://files.pythonhosted.org/packages/28/76/e6222113b83e3622caa4bb41032d0b1bf785250607392e1b778aca0b8a7d/charset_normalizer-3.3.2-py3-none-any.whl", hash = "sha256:3e4d1f6587322d2788836a99c69062fbb091331ec940e02d12d179c1d53e25fc", size = 48543, upload_time = "2023-11-01T04:04:58.622Z" },
 ]
 
 [[package]]
@@ -148,38 +149,47 @@ name = "click"
 version = "8.1.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/96/d3/f04c7bfcf5c1862a2a5b845c6b2b360488cf47af55dfa79c98f6a6bf98b5/click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de", size = 336121 }
+sdist = { url = "https://files.pythonhosted.org/packages/96/d3/f04c7bfcf5c1862a2a5b845c6b2b360488cf47af55dfa79c98f6a6bf98b5/click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de", size = 336121, upload_time = "2023-08-17T17:29:11.868Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/2e/d53fa4befbf2cfa713304affc7ca780ce4fc1fd8710527771b58311a3229/click-8.1.7-py3-none-any.whl", hash = "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28", size = 97941 },
+    { url = "https://files.pythonhosted.org/packages/00/2e/d53fa4befbf2cfa713304affc7ca780ce4fc1fd8710527771b58311a3229/click-8.1.7-py3-none-any.whl", hash = "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28", size = 97941, upload_time = "2023-08-17T17:29:10.08Z" },
 ]
 
 [[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697 }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload_time = "2022-10-25T02:36:22.414Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335 },
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload_time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "diskcache"
+version = "5.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/21/1c1ffc1a039ddcc459db43cc108658f32c57d271d7289a2794e401d0fdb6/diskcache-5.6.3.tar.gz", hash = "sha256:2c3a3fa2743d8535d832ec61c2054a1641f41775aa7c556758a109941e33e4fc", size = 67916, upload_time = "2023-08-31T06:12:00.316Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/27/4570e78fc0bf5ea0ca45eb1de3818a23787af9b390c0b0a0033a1b8236f9/diskcache-5.6.3-py3-none-any.whl", hash = "sha256:5e31b2d5fbad117cc363ebaf6b689474db18a1f6438bc82358b024abd4c2ca19", size = 45550, upload_time = "2023-08-31T06:11:58.822Z" },
 ]
 
 [[package]]
 name = "distlib"
 version = "0.3.9"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0d/dd/1bec4c5ddb504ca60fc29472f3d27e8d4da1257a854e1d96742f15c1d02d/distlib-0.3.9.tar.gz", hash = "sha256:a60f20dea646b8a33f3e7772f74dc0b2d0772d2837ee1342a00645c81edf9403", size = 613923 }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/dd/1bec4c5ddb504ca60fc29472f3d27e8d4da1257a854e1d96742f15c1d02d/distlib-0.3.9.tar.gz", hash = "sha256:a60f20dea646b8a33f3e7772f74dc0b2d0772d2837ee1342a00645c81edf9403", size = 613923, upload_time = "2024-10-09T18:35:47.551Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/a1/cf2472db20f7ce4a6be1253a81cfdf85ad9c7885ffbed7047fb72c24cf87/distlib-0.3.9-py2.py3-none-any.whl", hash = "sha256:47f8c22fd27c27e25a65601af709b38e4f0a45ea4fc2e710f65755fa8caaaf87", size = 468973 },
+    { url = "https://files.pythonhosted.org/packages/91/a1/cf2472db20f7ce4a6be1253a81cfdf85ad9c7885ffbed7047fb72c24cf87/distlib-0.3.9-py2.py3-none-any.whl", hash = "sha256:47f8c22fd27c27e25a65601af709b38e4f0a45ea4fc2e710f65755fa8caaaf87", size = 468973, upload_time = "2024-10-09T18:35:44.272Z" },
 ]
 
 [[package]]
 name = "dnspython"
 version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b5/4a/263763cb2ba3816dd94b08ad3a33d5fdae34ecb856678773cc40a3605829/dnspython-2.7.0.tar.gz", hash = "sha256:ce9c432eda0dc91cf618a5cedf1a4e142651196bbcd2c80e89ed5a907e5cfaf1", size = 345197 }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/4a/263763cb2ba3816dd94b08ad3a33d5fdae34ecb856678773cc40a3605829/dnspython-2.7.0.tar.gz", hash = "sha256:ce9c432eda0dc91cf618a5cedf1a4e142651196bbcd2c80e89ed5a907e5cfaf1", size = 345197, upload_time = "2024-10-05T20:14:59.362Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/1b/e0a87d256e40e8c888847551b20a017a6b98139178505dc7ffb96f04e954/dnspython-2.7.0-py3-none-any.whl", hash = "sha256:b4c34b7d10b51bcc3a5071e7b8dee77939f1e878477eeecc965e9835f63c6c86", size = 313632 },
+    { url = "https://files.pythonhosted.org/packages/68/1b/e0a87d256e40e8c888847551b20a017a6b98139178505dc7ffb96f04e954/dnspython-2.7.0-py3-none-any.whl", hash = "sha256:b4c34b7d10b51bcc3a5071e7b8dee77939f1e878477eeecc965e9835f63c6c86", size = 313632, upload_time = "2024-10-05T20:14:57.687Z" },
 ]
 
 [[package]]
@@ -190,45 +200,45 @@ dependencies = [
     { name = "dnspython" },
     { name = "idna" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/48/ce/13508a1ec3f8bb981ae4ca79ea40384becc868bfae97fd1c942bb3a001b1/email_validator-2.2.0.tar.gz", hash = "sha256:cb690f344c617a714f22e66ae771445a1ceb46821152df8e165c5f9a364582b7", size = 48967 }
+sdist = { url = "https://files.pythonhosted.org/packages/48/ce/13508a1ec3f8bb981ae4ca79ea40384becc868bfae97fd1c942bb3a001b1/email_validator-2.2.0.tar.gz", hash = "sha256:cb690f344c617a714f22e66ae771445a1ceb46821152df8e165c5f9a364582b7", size = 48967, upload_time = "2024-06-20T11:30:30.034Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/ee/bf0adb559ad3c786f12bcbc9296b3f5675f529199bef03e2df281fa1fadb/email_validator-2.2.0-py3-none-any.whl", hash = "sha256:561977c2d73ce3611850a06fa56b414621e0c8faa9d66f2611407d87465da631", size = 33521 },
+    { url = "https://files.pythonhosted.org/packages/d7/ee/bf0adb559ad3c786f12bcbc9296b3f5675f529199bef03e2df281fa1fadb/email_validator-2.2.0-py3-none-any.whl", hash = "sha256:561977c2d73ce3611850a06fa56b414621e0c8faa9d66f2611407d87465da631", size = 33521, upload_time = "2024-06-20T11:30:28.248Z" },
 ]
 
 [[package]]
 name = "executing"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8c/e3/7d45f492c2c4a0e8e0fad57d081a7c8a0286cdd86372b070cca1ec0caa1e/executing-2.1.0.tar.gz", hash = "sha256:8ea27ddd260da8150fa5a708269c4a10e76161e2496ec3e587da9e3c0fe4b9ab", size = 977485 }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/e3/7d45f492c2c4a0e8e0fad57d081a7c8a0286cdd86372b070cca1ec0caa1e/executing-2.1.0.tar.gz", hash = "sha256:8ea27ddd260da8150fa5a708269c4a10e76161e2496ec3e587da9e3c0fe4b9ab", size = 977485, upload_time = "2024-09-01T12:37:35.708Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/fd/afcd0496feca3276f509df3dbd5dae726fcc756f1a08d9e25abe1733f962/executing-2.1.0-py2.py3-none-any.whl", hash = "sha256:8d63781349375b5ebccc3142f4b30350c0cd9c79f921cde38be2be4637e98eaf", size = 25805 },
+    { url = "https://files.pythonhosted.org/packages/b5/fd/afcd0496feca3276f509df3dbd5dae726fcc756f1a08d9e25abe1733f962/executing-2.1.0-py2.py3-none-any.whl", hash = "sha256:8d63781349375b5ebccc3142f4b30350c0cd9c79f921cde38be2be4637e98eaf", size = 25805, upload_time = "2024-09-01T12:37:33.007Z" },
 ]
 
 [[package]]
 name = "filelock"
 version = "3.16.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9d/db/3ef5bb276dae18d6ec2124224403d1d67bccdbefc17af4cc8f553e341ab1/filelock-3.16.1.tar.gz", hash = "sha256:c249fbfcd5db47e5e2d6d62198e565475ee65e4831e2561c8e313fa7eb961435", size = 18037 }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/db/3ef5bb276dae18d6ec2124224403d1d67bccdbefc17af4cc8f553e341ab1/filelock-3.16.1.tar.gz", hash = "sha256:c249fbfcd5db47e5e2d6d62198e565475ee65e4831e2561c8e313fa7eb961435", size = 18037, upload_time = "2024-09-17T19:02:01.779Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/f8/feced7779d755758a52d1f6635d990b8d98dc0a29fa568bbe0625f18fdf3/filelock-3.16.1-py3-none-any.whl", hash = "sha256:2082e5703d51fbf98ea75855d9d5527e33d8ff23099bec374a134febee6946b0", size = 16163 },
+    { url = "https://files.pythonhosted.org/packages/b9/f8/feced7779d755758a52d1f6635d990b8d98dc0a29fa568bbe0625f18fdf3/filelock-3.16.1-py3-none-any.whl", hash = "sha256:2082e5703d51fbf98ea75855d9d5527e33d8ff23099bec374a134febee6946b0", size = 16163, upload_time = "2024-09-17T19:02:00.268Z" },
 ]
 
 [[package]]
 name = "idna"
 version = "3.10"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490 }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload_time = "2024-09-15T18:07:39.745Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442 },
+    { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload_time = "2024-09-15T18:07:37.964Z" },
 ]
 
 [[package]]
 name = "iniconfig"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3", size = 4646 }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/4b/cbd8e699e64a6f16ca3a8220661b5f83792b3017d0f79807cb8708d33913/iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3", size = 4646, upload_time = "2023-01-07T11:08:11.254Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374", size = 5892 },
+    { url = "https://files.pythonhosted.org/packages/ef/a6/62565a6e1cf69e10f5727360368e451d4b7f58beeac6173dc9db836a5b46/iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374", size = 5892, upload_time = "2023-01-07T11:08:09.864Z" },
 ]
 
 [[package]]
@@ -243,9 +253,9 @@ dependencies = [
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/45/a9/b6b9db4f2ef1e3261460701a429f8248e517cb8d18e27ff05f4690ac0a73/inline_snapshot-0.14.0.tar.gz", hash = "sha256:54fdf7831055d06a2423054875d640102865a164cc8291a8086e44dd9b4fd316", size = 209662 }
+sdist = { url = "https://files.pythonhosted.org/packages/45/a9/b6b9db4f2ef1e3261460701a429f8248e517cb8d18e27ff05f4690ac0a73/inline_snapshot-0.14.0.tar.gz", hash = "sha256:54fdf7831055d06a2423054875d640102865a164cc8291a8086e44dd9b4fd316", size = 209662, upload_time = "2024-11-10T21:43:37.629Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5e/a3/8ca14974625632d56d7e9f899d76d15dc4acd94ec15c179ca528beadeb4a/inline_snapshot-0.14.0-py3-none-any.whl", hash = "sha256:dc246d28b720f6050404b72cc1d171b0671e1494249197753d23771ff228748c", size = 31807 },
+    { url = "https://files.pythonhosted.org/packages/5e/a3/8ca14974625632d56d7e9f899d76d15dc4acd94ec15c179ca528beadeb4a/inline_snapshot-0.14.0-py3-none-any.whl", hash = "sha256:dc246d28b720f6050404b72cc1d171b0671e1494249197753d23771ff228748c", size = 31807, upload_time = "2024-11-10T21:43:39.12Z" },
 ]
 
 [[package]]
@@ -255,9 +265,9 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "altgraph" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/95/ee/af1a3842bdd5902ce133bd246eb7ffd4375c38642aeb5dc0ae3a0329dfa2/macholib-1.16.3.tar.gz", hash = "sha256:07ae9e15e8e4cd9a788013d81f5908b3609aa76f9b1421bae9c4d7606ec86a30", size = 59309 }
+sdist = { url = "https://files.pythonhosted.org/packages/95/ee/af1a3842bdd5902ce133bd246eb7ffd4375c38642aeb5dc0ae3a0329dfa2/macholib-1.16.3.tar.gz", hash = "sha256:07ae9e15e8e4cd9a788013d81f5908b3609aa76f9b1421bae9c4d7606ec86a30", size = 59309, upload_time = "2023-09-25T09:10:16.155Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/5d/c059c180c84f7962db0aeae7c3b9303ed1d73d76f2bfbc32bc231c8be314/macholib-1.16.3-py2.py3-none-any.whl", hash = "sha256:0e315d7583d38b8c77e815b1ecbdbf504a8258d8b3e17b61165c6feb60d18f2c", size = 38094 },
+    { url = "https://files.pythonhosted.org/packages/d1/5d/c059c180c84f7962db0aeae7c3b9303ed1d73d76f2bfbc32bc231c8be314/macholib-1.16.3-py2.py3-none-any.whl", hash = "sha256:0e315d7583d38b8c77e815b1ecbdbf504a8258d8b3e17b61165c6feb60d18f2c", size = 38094, upload_time = "2023-09-25T09:10:14.188Z" },
 ]
 
 [[package]]
@@ -267,73 +277,73 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mdurl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596 }
+sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596, upload_time = "2023-06-03T06:41:14.443Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528 },
+    { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528, upload_time = "2023-06-03T06:41:11.019Z" },
 ]
 
 [[package]]
 name = "markupsafe"
 version = "3.0.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b2/97/5d42485e71dfc078108a86d6de8fa46db44a1a9295e89c5d6d4a06e23a62/markupsafe-3.0.2.tar.gz", hash = "sha256:ee55d3edf80167e48ea11a923c7386f4669df67d7994554387f84e7d8b0a2bf0", size = 20537 }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/97/5d42485e71dfc078108a86d6de8fa46db44a1a9295e89c5d6d4a06e23a62/markupsafe-3.0.2.tar.gz", hash = "sha256:ee55d3edf80167e48ea11a923c7386f4669df67d7994554387f84e7d8b0a2bf0", size = 20537, upload_time = "2024-10-18T15:21:54.129Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6b/28/bbf83e3f76936960b850435576dd5e67034e200469571be53f69174a2dfd/MarkupSafe-3.0.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:9025b4018f3a1314059769c7bf15441064b2207cb3f065e6ea1e7359cb46db9d", size = 14353 },
-    { url = "https://files.pythonhosted.org/packages/6c/30/316d194b093cde57d448a4c3209f22e3046c5bb2fb0820b118292b334be7/MarkupSafe-3.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:93335ca3812df2f366e80509ae119189886b0f3c2b81325d39efdb84a1e2ae93", size = 12392 },
-    { url = "https://files.pythonhosted.org/packages/f2/96/9cdafba8445d3a53cae530aaf83c38ec64c4d5427d975c974084af5bc5d2/MarkupSafe-3.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2cb8438c3cbb25e220c2ab33bb226559e7afb3baec11c4f218ffa7308603c832", size = 23984 },
-    { url = "https://files.pythonhosted.org/packages/f1/a4/aefb044a2cd8d7334c8a47d3fb2c9f328ac48cb349468cc31c20b539305f/MarkupSafe-3.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a123e330ef0853c6e822384873bef7507557d8e4a082961e1defa947aa59ba84", size = 23120 },
-    { url = "https://files.pythonhosted.org/packages/8d/21/5e4851379f88f3fad1de30361db501300d4f07bcad047d3cb0449fc51f8c/MarkupSafe-3.0.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1e084f686b92e5b83186b07e8a17fc09e38fff551f3602b249881fec658d3eca", size = 23032 },
-    { url = "https://files.pythonhosted.org/packages/00/7b/e92c64e079b2d0d7ddf69899c98842f3f9a60a1ae72657c89ce2655c999d/MarkupSafe-3.0.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d8213e09c917a951de9d09ecee036d5c7d36cb6cb7dbaece4c71a60d79fb9798", size = 24057 },
-    { url = "https://files.pythonhosted.org/packages/f9/ac/46f960ca323037caa0a10662ef97d0a4728e890334fc156b9f9e52bcc4ca/MarkupSafe-3.0.2-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:5b02fb34468b6aaa40dfc198d813a641e3a63b98c2b05a16b9f80b7ec314185e", size = 23359 },
-    { url = "https://files.pythonhosted.org/packages/69/84/83439e16197337b8b14b6a5b9c2105fff81d42c2a7c5b58ac7b62ee2c3b1/MarkupSafe-3.0.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0bff5e0ae4ef2e1ae4fdf2dfd5b76c75e5c2fa4132d05fc1b0dabcd20c7e28c4", size = 23306 },
-    { url = "https://files.pythonhosted.org/packages/9a/34/a15aa69f01e2181ed8d2b685c0d2f6655d5cca2c4db0ddea775e631918cd/MarkupSafe-3.0.2-cp311-cp311-win32.whl", hash = "sha256:6c89876f41da747c8d3677a2b540fb32ef5715f97b66eeb0c6b66f5e3ef6f59d", size = 15094 },
-    { url = "https://files.pythonhosted.org/packages/da/b8/3a3bd761922d416f3dc5d00bfbed11f66b1ab89a0c2b6e887240a30b0f6b/MarkupSafe-3.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:70a87b411535ccad5ef2f1df5136506a10775d267e197e4cf531ced10537bd6b", size = 15521 },
-    { url = "https://files.pythonhosted.org/packages/22/09/d1f21434c97fc42f09d290cbb6350d44eb12f09cc62c9476effdb33a18aa/MarkupSafe-3.0.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:9778bd8ab0a994ebf6f84c2b949e65736d5575320a17ae8984a77fab08db94cf", size = 14274 },
-    { url = "https://files.pythonhosted.org/packages/6b/b0/18f76bba336fa5aecf79d45dcd6c806c280ec44538b3c13671d49099fdd0/MarkupSafe-3.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:846ade7b71e3536c4e56b386c2a47adf5741d2d8b94ec9dc3e92e5e1ee1e2225", size = 12348 },
-    { url = "https://files.pythonhosted.org/packages/e0/25/dd5c0f6ac1311e9b40f4af06c78efde0f3b5cbf02502f8ef9501294c425b/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1c99d261bd2d5f6b59325c92c73df481e05e57f19837bdca8413b9eac4bd8028", size = 24149 },
-    { url = "https://files.pythonhosted.org/packages/f3/f0/89e7aadfb3749d0f52234a0c8c7867877876e0a20b60e2188e9850794c17/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e17c96c14e19278594aa4841ec148115f9c7615a47382ecb6b82bd8fea3ab0c8", size = 23118 },
-    { url = "https://files.pythonhosted.org/packages/d5/da/f2eeb64c723f5e3777bc081da884b414671982008c47dcc1873d81f625b6/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:88416bd1e65dcea10bc7569faacb2c20ce071dd1f87539ca2ab364bf6231393c", size = 22993 },
-    { url = "https://files.pythonhosted.org/packages/da/0e/1f32af846df486dce7c227fe0f2398dc7e2e51d4a370508281f3c1c5cddc/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2181e67807fc2fa785d0592dc2d6206c019b9502410671cc905d132a92866557", size = 24178 },
-    { url = "https://files.pythonhosted.org/packages/c4/f6/bb3ca0532de8086cbff5f06d137064c8410d10779c4c127e0e47d17c0b71/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:52305740fe773d09cffb16f8ed0427942901f00adedac82ec8b67752f58a1b22", size = 23319 },
-    { url = "https://files.pythonhosted.org/packages/a2/82/8be4c96ffee03c5b4a034e60a31294daf481e12c7c43ab8e34a1453ee48b/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ad10d3ded218f1039f11a75f8091880239651b52e9bb592ca27de44eed242a48", size = 23352 },
-    { url = "https://files.pythonhosted.org/packages/51/ae/97827349d3fcffee7e184bdf7f41cd6b88d9919c80f0263ba7acd1bbcb18/MarkupSafe-3.0.2-cp312-cp312-win32.whl", hash = "sha256:0f4ca02bea9a23221c0182836703cbf8930c5e9454bacce27e767509fa286a30", size = 15097 },
-    { url = "https://files.pythonhosted.org/packages/c1/80/a61f99dc3a936413c3ee4e1eecac96c0da5ed07ad56fd975f1a9da5bc630/MarkupSafe-3.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:8e06879fc22a25ca47312fbe7c8264eb0b662f6db27cb2d3bbbc74b1df4b9b87", size = 15601 },
-    { url = "https://files.pythonhosted.org/packages/83/0e/67eb10a7ecc77a0c2bbe2b0235765b98d164d81600746914bebada795e97/MarkupSafe-3.0.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ba9527cdd4c926ed0760bc301f6728ef34d841f405abf9d4f959c478421e4efd", size = 14274 },
-    { url = "https://files.pythonhosted.org/packages/2b/6d/9409f3684d3335375d04e5f05744dfe7e9f120062c9857df4ab490a1031a/MarkupSafe-3.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f8b3d067f2e40fe93e1ccdd6b2e1d16c43140e76f02fb1319a05cf2b79d99430", size = 12352 },
-    { url = "https://files.pythonhosted.org/packages/d2/f5/6eadfcd3885ea85fe2a7c128315cc1bb7241e1987443d78c8fe712d03091/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:569511d3b58c8791ab4c2e1285575265991e6d8f8700c7be0e88f86cb0672094", size = 24122 },
-    { url = "https://files.pythonhosted.org/packages/0c/91/96cf928db8236f1bfab6ce15ad070dfdd02ed88261c2afafd4b43575e9e9/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:15ab75ef81add55874e7ab7055e9c397312385bd9ced94920f2802310c930396", size = 23085 },
-    { url = "https://files.pythonhosted.org/packages/c2/cf/c9d56af24d56ea04daae7ac0940232d31d5a8354f2b457c6d856b2057d69/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f3818cb119498c0678015754eba762e0d61e5b52d34c8b13d770f0719f7b1d79", size = 22978 },
-    { url = "https://files.pythonhosted.org/packages/2a/9f/8619835cd6a711d6272d62abb78c033bda638fdc54c4e7f4272cf1c0962b/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cdb82a876c47801bb54a690c5ae105a46b392ac6099881cdfb9f6e95e4014c6a", size = 24208 },
-    { url = "https://files.pythonhosted.org/packages/f9/bf/176950a1792b2cd2102b8ffeb5133e1ed984547b75db47c25a67d3359f77/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:cabc348d87e913db6ab4aa100f01b08f481097838bdddf7c7a84b7575b7309ca", size = 23357 },
-    { url = "https://files.pythonhosted.org/packages/ce/4f/9a02c1d335caabe5c4efb90e1b6e8ee944aa245c1aaaab8e8a618987d816/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:444dcda765c8a838eaae23112db52f1efaf750daddb2d9ca300bcae1039adc5c", size = 23344 },
-    { url = "https://files.pythonhosted.org/packages/ee/55/c271b57db36f748f0e04a759ace9f8f759ccf22b4960c270c78a394f58be/MarkupSafe-3.0.2-cp313-cp313-win32.whl", hash = "sha256:bcf3e58998965654fdaff38e58584d8937aa3096ab5354d493c77d1fdd66d7a1", size = 15101 },
-    { url = "https://files.pythonhosted.org/packages/29/88/07df22d2dd4df40aba9f3e402e6dc1b8ee86297dddbad4872bd5e7b0094f/MarkupSafe-3.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:e6a2a455bd412959b57a172ce6328d2dd1f01cb2135efda2e4576e8a23fa3b0f", size = 15603 },
-    { url = "https://files.pythonhosted.org/packages/62/6a/8b89d24db2d32d433dffcd6a8779159da109842434f1dd2f6e71f32f738c/MarkupSafe-3.0.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:b5a6b3ada725cea8a5e634536b1b01c30bcdcd7f9c6fff4151548d5bf6b3a36c", size = 14510 },
-    { url = "https://files.pythonhosted.org/packages/7a/06/a10f955f70a2e5a9bf78d11a161029d278eeacbd35ef806c3fd17b13060d/MarkupSafe-3.0.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a904af0a6162c73e3edcb969eeeb53a63ceeb5d8cf642fade7d39e7963a22ddb", size = 12486 },
-    { url = "https://files.pythonhosted.org/packages/34/cf/65d4a571869a1a9078198ca28f39fba5fbb910f952f9dbc5220afff9f5e6/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4aa4e5faecf353ed117801a068ebab7b7e09ffb6e1d5e412dc852e0da018126c", size = 25480 },
-    { url = "https://files.pythonhosted.org/packages/0c/e3/90e9651924c430b885468b56b3d597cabf6d72be4b24a0acd1fa0e12af67/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c0ef13eaeee5b615fb07c9a7dadb38eac06a0608b41570d8ade51c56539e509d", size = 23914 },
-    { url = "https://files.pythonhosted.org/packages/66/8c/6c7cf61f95d63bb866db39085150df1f2a5bd3335298f14a66b48e92659c/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d16a81a06776313e817c951135cf7340a3e91e8c1ff2fac444cfd75fffa04afe", size = 23796 },
-    { url = "https://files.pythonhosted.org/packages/bb/35/cbe9238ec3f47ac9a7c8b3df7a808e7cb50fe149dc7039f5f454b3fba218/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:6381026f158fdb7c72a168278597a5e3a5222e83ea18f543112b2662a9b699c5", size = 25473 },
-    { url = "https://files.pythonhosted.org/packages/e6/32/7621a4382488aa283cc05e8984a9c219abad3bca087be9ec77e89939ded9/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:3d79d162e7be8f996986c064d1c7c817f6df3a77fe3d6859f6f9e7be4b8c213a", size = 24114 },
-    { url = "https://files.pythonhosted.org/packages/0d/80/0985960e4b89922cb5a0bac0ed39c5b96cbc1a536a99f30e8c220a996ed9/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:131a3c7689c85f5ad20f9f6fb1b866f402c445b220c19fe4308c0b147ccd2ad9", size = 24098 },
-    { url = "https://files.pythonhosted.org/packages/82/78/fedb03c7d5380df2427038ec8d973587e90561b2d90cd472ce9254cf348b/MarkupSafe-3.0.2-cp313-cp313t-win32.whl", hash = "sha256:ba8062ed2cf21c07a9e295d5b8a2a5ce678b913b45fdf68c32d95d6c1291e0b6", size = 15208 },
-    { url = "https://files.pythonhosted.org/packages/4f/65/6079a46068dfceaeabb5dcad6d674f5f5c61a6fa5673746f42a9f4c233b3/MarkupSafe-3.0.2-cp313-cp313t-win_amd64.whl", hash = "sha256:e444a31f8db13eb18ada366ab3cf45fd4b31e4db1236a4448f68778c1d1a5a2f", size = 15739 },
+    { url = "https://files.pythonhosted.org/packages/6b/28/bbf83e3f76936960b850435576dd5e67034e200469571be53f69174a2dfd/MarkupSafe-3.0.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:9025b4018f3a1314059769c7bf15441064b2207cb3f065e6ea1e7359cb46db9d", size = 14353, upload_time = "2024-10-18T15:21:02.187Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/30/316d194b093cde57d448a4c3209f22e3046c5bb2fb0820b118292b334be7/MarkupSafe-3.0.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:93335ca3812df2f366e80509ae119189886b0f3c2b81325d39efdb84a1e2ae93", size = 12392, upload_time = "2024-10-18T15:21:02.941Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/96/9cdafba8445d3a53cae530aaf83c38ec64c4d5427d975c974084af5bc5d2/MarkupSafe-3.0.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2cb8438c3cbb25e220c2ab33bb226559e7afb3baec11c4f218ffa7308603c832", size = 23984, upload_time = "2024-10-18T15:21:03.953Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/a4/aefb044a2cd8d7334c8a47d3fb2c9f328ac48cb349468cc31c20b539305f/MarkupSafe-3.0.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a123e330ef0853c6e822384873bef7507557d8e4a082961e1defa947aa59ba84", size = 23120, upload_time = "2024-10-18T15:21:06.495Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/21/5e4851379f88f3fad1de30361db501300d4f07bcad047d3cb0449fc51f8c/MarkupSafe-3.0.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1e084f686b92e5b83186b07e8a17fc09e38fff551f3602b249881fec658d3eca", size = 23032, upload_time = "2024-10-18T15:21:07.295Z" },
+    { url = "https://files.pythonhosted.org/packages/00/7b/e92c64e079b2d0d7ddf69899c98842f3f9a60a1ae72657c89ce2655c999d/MarkupSafe-3.0.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d8213e09c917a951de9d09ecee036d5c7d36cb6cb7dbaece4c71a60d79fb9798", size = 24057, upload_time = "2024-10-18T15:21:08.073Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/ac/46f960ca323037caa0a10662ef97d0a4728e890334fc156b9f9e52bcc4ca/MarkupSafe-3.0.2-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:5b02fb34468b6aaa40dfc198d813a641e3a63b98c2b05a16b9f80b7ec314185e", size = 23359, upload_time = "2024-10-18T15:21:09.318Z" },
+    { url = "https://files.pythonhosted.org/packages/69/84/83439e16197337b8b14b6a5b9c2105fff81d42c2a7c5b58ac7b62ee2c3b1/MarkupSafe-3.0.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0bff5e0ae4ef2e1ae4fdf2dfd5b76c75e5c2fa4132d05fc1b0dabcd20c7e28c4", size = 23306, upload_time = "2024-10-18T15:21:10.185Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/34/a15aa69f01e2181ed8d2b685c0d2f6655d5cca2c4db0ddea775e631918cd/MarkupSafe-3.0.2-cp311-cp311-win32.whl", hash = "sha256:6c89876f41da747c8d3677a2b540fb32ef5715f97b66eeb0c6b66f5e3ef6f59d", size = 15094, upload_time = "2024-10-18T15:21:11.005Z" },
+    { url = "https://files.pythonhosted.org/packages/da/b8/3a3bd761922d416f3dc5d00bfbed11f66b1ab89a0c2b6e887240a30b0f6b/MarkupSafe-3.0.2-cp311-cp311-win_amd64.whl", hash = "sha256:70a87b411535ccad5ef2f1df5136506a10775d267e197e4cf531ced10537bd6b", size = 15521, upload_time = "2024-10-18T15:21:12.911Z" },
+    { url = "https://files.pythonhosted.org/packages/22/09/d1f21434c97fc42f09d290cbb6350d44eb12f09cc62c9476effdb33a18aa/MarkupSafe-3.0.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:9778bd8ab0a994ebf6f84c2b949e65736d5575320a17ae8984a77fab08db94cf", size = 14274, upload_time = "2024-10-18T15:21:13.777Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/b0/18f76bba336fa5aecf79d45dcd6c806c280ec44538b3c13671d49099fdd0/MarkupSafe-3.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:846ade7b71e3536c4e56b386c2a47adf5741d2d8b94ec9dc3e92e5e1ee1e2225", size = 12348, upload_time = "2024-10-18T15:21:14.822Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/25/dd5c0f6ac1311e9b40f4af06c78efde0f3b5cbf02502f8ef9501294c425b/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1c99d261bd2d5f6b59325c92c73df481e05e57f19837bdca8413b9eac4bd8028", size = 24149, upload_time = "2024-10-18T15:21:15.642Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/f0/89e7aadfb3749d0f52234a0c8c7867877876e0a20b60e2188e9850794c17/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e17c96c14e19278594aa4841ec148115f9c7615a47382ecb6b82bd8fea3ab0c8", size = 23118, upload_time = "2024-10-18T15:21:17.133Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/da/f2eeb64c723f5e3777bc081da884b414671982008c47dcc1873d81f625b6/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:88416bd1e65dcea10bc7569faacb2c20ce071dd1f87539ca2ab364bf6231393c", size = 22993, upload_time = "2024-10-18T15:21:18.064Z" },
+    { url = "https://files.pythonhosted.org/packages/da/0e/1f32af846df486dce7c227fe0f2398dc7e2e51d4a370508281f3c1c5cddc/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2181e67807fc2fa785d0592dc2d6206c019b9502410671cc905d132a92866557", size = 24178, upload_time = "2024-10-18T15:21:18.859Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f6/bb3ca0532de8086cbff5f06d137064c8410d10779c4c127e0e47d17c0b71/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:52305740fe773d09cffb16f8ed0427942901f00adedac82ec8b67752f58a1b22", size = 23319, upload_time = "2024-10-18T15:21:19.671Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/82/8be4c96ffee03c5b4a034e60a31294daf481e12c7c43ab8e34a1453ee48b/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ad10d3ded218f1039f11a75f8091880239651b52e9bb592ca27de44eed242a48", size = 23352, upload_time = "2024-10-18T15:21:20.971Z" },
+    { url = "https://files.pythonhosted.org/packages/51/ae/97827349d3fcffee7e184bdf7f41cd6b88d9919c80f0263ba7acd1bbcb18/MarkupSafe-3.0.2-cp312-cp312-win32.whl", hash = "sha256:0f4ca02bea9a23221c0182836703cbf8930c5e9454bacce27e767509fa286a30", size = 15097, upload_time = "2024-10-18T15:21:22.646Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/80/a61f99dc3a936413c3ee4e1eecac96c0da5ed07ad56fd975f1a9da5bc630/MarkupSafe-3.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:8e06879fc22a25ca47312fbe7c8264eb0b662f6db27cb2d3bbbc74b1df4b9b87", size = 15601, upload_time = "2024-10-18T15:21:23.499Z" },
+    { url = "https://files.pythonhosted.org/packages/83/0e/67eb10a7ecc77a0c2bbe2b0235765b98d164d81600746914bebada795e97/MarkupSafe-3.0.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ba9527cdd4c926ed0760bc301f6728ef34d841f405abf9d4f959c478421e4efd", size = 14274, upload_time = "2024-10-18T15:21:24.577Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/6d/9409f3684d3335375d04e5f05744dfe7e9f120062c9857df4ab490a1031a/MarkupSafe-3.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f8b3d067f2e40fe93e1ccdd6b2e1d16c43140e76f02fb1319a05cf2b79d99430", size = 12352, upload_time = "2024-10-18T15:21:25.382Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/f5/6eadfcd3885ea85fe2a7c128315cc1bb7241e1987443d78c8fe712d03091/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:569511d3b58c8791ab4c2e1285575265991e6d8f8700c7be0e88f86cb0672094", size = 24122, upload_time = "2024-10-18T15:21:26.199Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/91/96cf928db8236f1bfab6ce15ad070dfdd02ed88261c2afafd4b43575e9e9/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:15ab75ef81add55874e7ab7055e9c397312385bd9ced94920f2802310c930396", size = 23085, upload_time = "2024-10-18T15:21:27.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/cf/c9d56af24d56ea04daae7ac0940232d31d5a8354f2b457c6d856b2057d69/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f3818cb119498c0678015754eba762e0d61e5b52d34c8b13d770f0719f7b1d79", size = 22978, upload_time = "2024-10-18T15:21:27.846Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/9f/8619835cd6a711d6272d62abb78c033bda638fdc54c4e7f4272cf1c0962b/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cdb82a876c47801bb54a690c5ae105a46b392ac6099881cdfb9f6e95e4014c6a", size = 24208, upload_time = "2024-10-18T15:21:28.744Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/bf/176950a1792b2cd2102b8ffeb5133e1ed984547b75db47c25a67d3359f77/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:cabc348d87e913db6ab4aa100f01b08f481097838bdddf7c7a84b7575b7309ca", size = 23357, upload_time = "2024-10-18T15:21:29.545Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/4f/9a02c1d335caabe5c4efb90e1b6e8ee944aa245c1aaaab8e8a618987d816/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:444dcda765c8a838eaae23112db52f1efaf750daddb2d9ca300bcae1039adc5c", size = 23344, upload_time = "2024-10-18T15:21:30.366Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/55/c271b57db36f748f0e04a759ace9f8f759ccf22b4960c270c78a394f58be/MarkupSafe-3.0.2-cp313-cp313-win32.whl", hash = "sha256:bcf3e58998965654fdaff38e58584d8937aa3096ab5354d493c77d1fdd66d7a1", size = 15101, upload_time = "2024-10-18T15:21:31.207Z" },
+    { url = "https://files.pythonhosted.org/packages/29/88/07df22d2dd4df40aba9f3e402e6dc1b8ee86297dddbad4872bd5e7b0094f/MarkupSafe-3.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:e6a2a455bd412959b57a172ce6328d2dd1f01cb2135efda2e4576e8a23fa3b0f", size = 15603, upload_time = "2024-10-18T15:21:32.032Z" },
+    { url = "https://files.pythonhosted.org/packages/62/6a/8b89d24db2d32d433dffcd6a8779159da109842434f1dd2f6e71f32f738c/MarkupSafe-3.0.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:b5a6b3ada725cea8a5e634536b1b01c30bcdcd7f9c6fff4151548d5bf6b3a36c", size = 14510, upload_time = "2024-10-18T15:21:33.625Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/06/a10f955f70a2e5a9bf78d11a161029d278eeacbd35ef806c3fd17b13060d/MarkupSafe-3.0.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a904af0a6162c73e3edcb969eeeb53a63ceeb5d8cf642fade7d39e7963a22ddb", size = 12486, upload_time = "2024-10-18T15:21:34.611Z" },
+    { url = "https://files.pythonhosted.org/packages/34/cf/65d4a571869a1a9078198ca28f39fba5fbb910f952f9dbc5220afff9f5e6/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4aa4e5faecf353ed117801a068ebab7b7e09ffb6e1d5e412dc852e0da018126c", size = 25480, upload_time = "2024-10-18T15:21:35.398Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/e3/90e9651924c430b885468b56b3d597cabf6d72be4b24a0acd1fa0e12af67/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c0ef13eaeee5b615fb07c9a7dadb38eac06a0608b41570d8ade51c56539e509d", size = 23914, upload_time = "2024-10-18T15:21:36.231Z" },
+    { url = "https://files.pythonhosted.org/packages/66/8c/6c7cf61f95d63bb866db39085150df1f2a5bd3335298f14a66b48e92659c/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d16a81a06776313e817c951135cf7340a3e91e8c1ff2fac444cfd75fffa04afe", size = 23796, upload_time = "2024-10-18T15:21:37.073Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/35/cbe9238ec3f47ac9a7c8b3df7a808e7cb50fe149dc7039f5f454b3fba218/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:6381026f158fdb7c72a168278597a5e3a5222e83ea18f543112b2662a9b699c5", size = 25473, upload_time = "2024-10-18T15:21:37.932Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/32/7621a4382488aa283cc05e8984a9c219abad3bca087be9ec77e89939ded9/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:3d79d162e7be8f996986c064d1c7c817f6df3a77fe3d6859f6f9e7be4b8c213a", size = 24114, upload_time = "2024-10-18T15:21:39.799Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/80/0985960e4b89922cb5a0bac0ed39c5b96cbc1a536a99f30e8c220a996ed9/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:131a3c7689c85f5ad20f9f6fb1b866f402c445b220c19fe4308c0b147ccd2ad9", size = 24098, upload_time = "2024-10-18T15:21:40.813Z" },
+    { url = "https://files.pythonhosted.org/packages/82/78/fedb03c7d5380df2427038ec8d973587e90561b2d90cd472ce9254cf348b/MarkupSafe-3.0.2-cp313-cp313t-win32.whl", hash = "sha256:ba8062ed2cf21c07a9e295d5b8a2a5ce678b913b45fdf68c32d95d6c1291e0b6", size = 15208, upload_time = "2024-10-18T15:21:41.814Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/65/6079a46068dfceaeabb5dcad6d674f5f5c61a6fa5673746f42a9f4c233b3/MarkupSafe-3.0.2-cp313-cp313t-win_amd64.whl", hash = "sha256:e444a31f8db13eb18ada366ab3cf45fd4b31e4db1236a4448f68778c1d1a5a2f", size = 15739, upload_time = "2024-10-18T15:21:42.784Z" },
 ]
 
 [[package]]
 name = "mdurl"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729 }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload_time = "2022-08-14T12:40:10.846Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979 },
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload_time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
 name = "mreg-cli"
-version = "1.2.1.dev6+g2d4a87c.d20241202"
 source = { editable = "." }
 dependencies = [
+    { name = "diskcache" },
     { name = "platformdirs" },
     { name = "prompt-toolkit" },
     { name = "pydantic", extra = ["email"] },
@@ -372,6 +382,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "diskcache", specifier = ">=5.6.3" },
     { name = "platformdirs", specifier = ">=4.3.0" },
     { name = "prompt-toolkit", specifier = ">=3.0.0" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.7.1" },
@@ -412,54 +423,54 @@ dev = [
 name = "mypy-extensions"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/98/a4/1ab47638b92648243faf97a5aeb6ea83059cc3624972ab6b8d2316078d3f/mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782", size = 4433 }
+sdist = { url = "https://files.pythonhosted.org/packages/98/a4/1ab47638b92648243faf97a5aeb6ea83059cc3624972ab6b8d2316078d3f/mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782", size = 4433, upload_time = "2023-02-04T12:11:27.157Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/e2/5d3f6ada4297caebe1a2add3b126fe800c96f56dbe5d1988a2cbe0b267aa/mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d", size = 4695 },
+    { url = "https://files.pythonhosted.org/packages/2a/e2/5d3f6ada4297caebe1a2add3b126fe800c96f56dbe5d1988a2cbe0b267aa/mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d", size = 4695, upload_time = "2023-02-04T12:11:25.002Z" },
 ]
 
 [[package]]
 name = "packaging"
 version = "24.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d0/63/68dbb6eb2de9cb10ee4c9c14a0148804425e13c4fb20d61cce69f53106da/packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f", size = 163950 }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/63/68dbb6eb2de9cb10ee4c9c14a0148804425e13c4fb20d61cce69f53106da/packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f", size = 163950, upload_time = "2024-11-08T09:47:47.202Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759", size = 65451 },
+    { url = "https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759", size = 65451, upload_time = "2024-11-08T09:47:44.722Z" },
 ]
 
 [[package]]
 name = "pathspec"
 version = "0.12.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043 }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043, upload_time = "2023-12-10T22:30:45Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191 },
+    { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191, upload_time = "2023-12-10T22:30:43.14Z" },
 ]
 
 [[package]]
 name = "pefile"
 version = "2023.2.7"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/78/c5/3b3c62223f72e2360737fd2a57c30e5b2adecd85e70276879609a7403334/pefile-2023.2.7.tar.gz", hash = "sha256:82e6114004b3d6911c77c3953e3838654b04511b8b66e8583db70c65998017dc", size = 74854 }
+sdist = { url = "https://files.pythonhosted.org/packages/78/c5/3b3c62223f72e2360737fd2a57c30e5b2adecd85e70276879609a7403334/pefile-2023.2.7.tar.gz", hash = "sha256:82e6114004b3d6911c77c3953e3838654b04511b8b66e8583db70c65998017dc", size = 74854, upload_time = "2023-02-07T12:23:55.958Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/55/26/d0ad8b448476d0a1e8d3ea5622dc77b916db84c6aa3cb1e1c0965af948fc/pefile-2023.2.7-py3-none-any.whl", hash = "sha256:da185cd2af68c08a6cd4481f7325ed600a88f6a813bad9dea07ab3ef73d8d8d6", size = 71791 },
+    { url = "https://files.pythonhosted.org/packages/55/26/d0ad8b448476d0a1e8d3ea5622dc77b916db84c6aa3cb1e1c0965af948fc/pefile-2023.2.7-py3-none-any.whl", hash = "sha256:da185cd2af68c08a6cd4481f7325ed600a88f6a813bad9dea07ab3ef73d8d8d6", size = 71791, upload_time = "2023-02-07T12:28:36.678Z" },
 ]
 
 [[package]]
 name = "platformdirs"
 version = "4.3.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/13/fc/128cc9cb8f03208bdbf93d3aa862e16d376844a14f9a0ce5cf4507372de4/platformdirs-4.3.6.tar.gz", hash = "sha256:357fb2acbc885b0419afd3ce3ed34564c13c9b95c89360cd9563f73aa5e2b907", size = 21302 }
+sdist = { url = "https://files.pythonhosted.org/packages/13/fc/128cc9cb8f03208bdbf93d3aa862e16d376844a14f9a0ce5cf4507372de4/platformdirs-4.3.6.tar.gz", hash = "sha256:357fb2acbc885b0419afd3ce3ed34564c13c9b95c89360cd9563f73aa5e2b907", size = 21302, upload_time = "2024-09-17T19:06:50.688Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3c/a6/bc1012356d8ece4d66dd75c4b9fc6c1f6650ddd5991e421177d9f8f671be/platformdirs-4.3.6-py3-none-any.whl", hash = "sha256:73e575e1408ab8103900836b97580d5307456908a03e92031bab39e4554cc3fb", size = 18439 },
+    { url = "https://files.pythonhosted.org/packages/3c/a6/bc1012356d8ece4d66dd75c4b9fc6c1f6650ddd5991e421177d9f8f671be/platformdirs-4.3.6-py3-none-any.whl", hash = "sha256:73e575e1408ab8103900836b97580d5307456908a03e92031bab39e4554cc3fb", size = 18439, upload_time = "2024-09-17T19:06:49.212Z" },
 ]
 
 [[package]]
 name = "pluggy"
 version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955 }
+sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955, upload_time = "2024-04-20T21:34:42.531Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556 },
+    { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556, upload_time = "2024-04-20T21:34:40.434Z" },
 ]
 
 [[package]]
@@ -469,9 +480,9 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "wcwidth" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2d/4f/feb5e137aff82f7c7f3248267b97451da3644f6cdc218edfe549fb354127/prompt_toolkit-3.0.48.tar.gz", hash = "sha256:d6623ab0477a80df74e646bdbc93621143f5caf104206aa29294d53de1a03d90", size = 424684 }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/4f/feb5e137aff82f7c7f3248267b97451da3644f6cdc218edfe549fb354127/prompt_toolkit-3.0.48.tar.gz", hash = "sha256:d6623ab0477a80df74e646bdbc93621143f5caf104206aa29294d53de1a03d90", size = 424684, upload_time = "2024-09-25T10:20:57.609Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a9/6a/fd08d94654f7e67c52ca30523a178b3f8ccc4237fce4be90d39c938a831a/prompt_toolkit-3.0.48-py3-none-any.whl", hash = "sha256:f49a827f90062e411f1ce1f854f2aedb3c23353244f8108b89283587397ac10e", size = 386595 },
+    { url = "https://files.pythonhosted.org/packages/a9/6a/fd08d94654f7e67c52ca30523a178b3f8ccc4237fce4be90d39c938a831a/prompt_toolkit-3.0.48-py3-none-any.whl", hash = "sha256:f49a827f90062e411f1ce1f854f2aedb3c23353244f8108b89283587397ac10e", size = 386595, upload_time = "2024-09-25T10:20:53.932Z" },
 ]
 
 [[package]]
@@ -483,9 +494,9 @@ dependencies = [
     { name = "pydantic-core" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/b7/d9e3f12af310e1120c21603644a1cd86f59060e040ec5c3a80b8f05fae30/pydantic-2.9.2.tar.gz", hash = "sha256:d155cef71265d1e9807ed1c32b4c8deec042a44a50a4188b25ac67ecd81a9c0f", size = 769917 }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/b7/d9e3f12af310e1120c21603644a1cd86f59060e040ec5c3a80b8f05fae30/pydantic-2.9.2.tar.gz", hash = "sha256:d155cef71265d1e9807ed1c32b4c8deec042a44a50a4188b25ac67ecd81a9c0f", size = 769917, upload_time = "2024-09-17T15:59:54.273Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/e4/ba44652d562cbf0bf320e0f3810206149c8a4e99cdbf66da82e97ab53a15/pydantic-2.9.2-py3-none-any.whl", hash = "sha256:f048cec7b26778210e28a0459867920654d48e5e62db0958433636cde4254f12", size = 434928 },
+    { url = "https://files.pythonhosted.org/packages/df/e4/ba44652d562cbf0bf320e0f3810206149c8a4e99cdbf66da82e97ab53a15/pydantic-2.9.2-py3-none-any.whl", hash = "sha256:f048cec7b26778210e28a0459867920654d48e5e62db0958433636cde4254f12", size = 434928, upload_time = "2024-09-17T15:59:51.827Z" },
 ]
 
 [package.optional-dependencies]
@@ -500,44 +511,44 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/aa/6b6a9b9f8537b872f552ddd46dd3da230367754b6f707b8e1e963f515ea3/pydantic_core-2.23.4.tar.gz", hash = "sha256:2584f7cf844ac4d970fba483a717dbe10c1c1c96a969bf65d61ffe94df1b2863", size = 402156 }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/aa/6b6a9b9f8537b872f552ddd46dd3da230367754b6f707b8e1e963f515ea3/pydantic_core-2.23.4.tar.gz", hash = "sha256:2584f7cf844ac4d970fba483a717dbe10c1c1c96a969bf65d61ffe94df1b2863", size = 402156, upload_time = "2024-09-16T16:06:44.786Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/30/890a583cd3f2be27ecf32b479d5d615710bb926d92da03e3f7838ff3e58b/pydantic_core-2.23.4-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:77733e3892bb0a7fa797826361ce8a9184d25c8dffaec60b7ffe928153680ba8", size = 1865160 },
-    { url = "https://files.pythonhosted.org/packages/1d/9a/b634442e1253bc6889c87afe8bb59447f106ee042140bd57680b3b113ec7/pydantic_core-2.23.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1b84d168f6c48fabd1f2027a3d1bdfe62f92cade1fb273a5d68e621da0e44e6d", size = 1776777 },
-    { url = "https://files.pythonhosted.org/packages/75/9a/7816295124a6b08c24c96f9ce73085032d8bcbaf7e5a781cd41aa910c891/pydantic_core-2.23.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:df49e7a0861a8c36d089c1ed57d308623d60416dab2647a4a17fe050ba85de0e", size = 1799244 },
-    { url = "https://files.pythonhosted.org/packages/a9/8f/89c1405176903e567c5f99ec53387449e62f1121894aa9fc2c4fdc51a59b/pydantic_core-2.23.4-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ff02b6d461a6de369f07ec15e465a88895f3223eb75073ffea56b84d9331f607", size = 1805307 },
-    { url = "https://files.pythonhosted.org/packages/d5/a5/1a194447d0da1ef492e3470680c66048fef56fc1f1a25cafbea4bc1d1c48/pydantic_core-2.23.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:996a38a83508c54c78a5f41456b0103c30508fed9abcad0a59b876d7398f25fd", size = 2000663 },
-    { url = "https://files.pythonhosted.org/packages/13/a5/1df8541651de4455e7d587cf556201b4f7997191e110bca3b589218745a5/pydantic_core-2.23.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d97683ddee4723ae8c95d1eddac7c192e8c552da0c73a925a89fa8649bf13eea", size = 2655941 },
-    { url = "https://files.pythonhosted.org/packages/44/31/a3899b5ce02c4316865e390107f145089876dff7e1dfc770a231d836aed8/pydantic_core-2.23.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:216f9b2d7713eb98cb83c80b9c794de1f6b7e3145eef40400c62e86cee5f4e1e", size = 2052105 },
-    { url = "https://files.pythonhosted.org/packages/1b/aa/98e190f8745d5ec831f6d5449344c48c0627ac5fed4e5340a44b74878f8e/pydantic_core-2.23.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6f783e0ec4803c787bcea93e13e9932edab72068f68ecffdf86a99fd5918878b", size = 1919967 },
-    { url = "https://files.pythonhosted.org/packages/ae/35/b6e00b6abb2acfee3e8f85558c02a0822e9a8b2f2d812ea8b9079b118ba0/pydantic_core-2.23.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:d0776dea117cf5272382634bd2a5c1b6eb16767c223c6a5317cd3e2a757c61a0", size = 1964291 },
-    { url = "https://files.pythonhosted.org/packages/13/46/7bee6d32b69191cd649bbbd2361af79c472d72cb29bb2024f0b6e350ba06/pydantic_core-2.23.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:d5f7a395a8cf1621939692dba2a6b6a830efa6b3cee787d82c7de1ad2930de64", size = 2109666 },
-    { url = "https://files.pythonhosted.org/packages/39/ef/7b34f1b122a81b68ed0a7d0e564da9ccdc9a2924c8d6c6b5b11fa3a56970/pydantic_core-2.23.4-cp311-none-win32.whl", hash = "sha256:74b9127ffea03643e998e0c5ad9bd3811d3dac8c676e47db17b0ee7c3c3bf35f", size = 1732940 },
-    { url = "https://files.pythonhosted.org/packages/2f/76/37b7e76c645843ff46c1d73e046207311ef298d3f7b2f7d8f6ac60113071/pydantic_core-2.23.4-cp311-none-win_amd64.whl", hash = "sha256:98d134c954828488b153d88ba1f34e14259284f256180ce659e8d83e9c05eaa3", size = 1916804 },
-    { url = "https://files.pythonhosted.org/packages/74/7b/8e315f80666194b354966ec84b7d567da77ad927ed6323db4006cf915f3f/pydantic_core-2.23.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:f3e0da4ebaef65158d4dfd7d3678aad692f7666877df0002b8a522cdf088f231", size = 1856459 },
-    { url = "https://files.pythonhosted.org/packages/14/de/866bdce10ed808323d437612aca1ec9971b981e1c52e5e42ad9b8e17a6f6/pydantic_core-2.23.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f69a8e0b033b747bb3e36a44e7732f0c99f7edd5cea723d45bc0d6e95377ffee", size = 1770007 },
-    { url = "https://files.pythonhosted.org/packages/dc/69/8edd5c3cd48bb833a3f7ef9b81d7666ccddd3c9a635225214e044b6e8281/pydantic_core-2.23.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:723314c1d51722ab28bfcd5240d858512ffd3116449c557a1336cbe3919beb87", size = 1790245 },
-    { url = "https://files.pythonhosted.org/packages/80/33/9c24334e3af796ce80d2274940aae38dd4e5676298b4398eff103a79e02d/pydantic_core-2.23.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bb2802e667b7051a1bebbfe93684841cc9351004e2badbd6411bf357ab8d5ac8", size = 1801260 },
-    { url = "https://files.pythonhosted.org/packages/a5/6f/e9567fd90104b79b101ca9d120219644d3314962caa7948dd8b965e9f83e/pydantic_core-2.23.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d18ca8148bebe1b0a382a27a8ee60350091a6ddaf475fa05ef50dc35b5df6327", size = 1996872 },
-    { url = "https://files.pythonhosted.org/packages/2d/ad/b5f0fe9e6cfee915dd144edbd10b6e9c9c9c9d7a56b69256d124b8ac682e/pydantic_core-2.23.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:33e3d65a85a2a4a0dc3b092b938a4062b1a05f3a9abde65ea93b233bca0e03f2", size = 2661617 },
-    { url = "https://files.pythonhosted.org/packages/06/c8/7d4b708f8d05a5cbfda3243aad468052c6e99de7d0937c9146c24d9f12e9/pydantic_core-2.23.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:128585782e5bfa515c590ccee4b727fb76925dd04a98864182b22e89a4e6ed36", size = 2071831 },
-    { url = "https://files.pythonhosted.org/packages/89/4d/3079d00c47f22c9a9a8220db088b309ad6e600a73d7a69473e3a8e5e3ea3/pydantic_core-2.23.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:68665f4c17edcceecc112dfed5dbe6f92261fb9d6054b47d01bf6371a6196126", size = 1917453 },
-    { url = "https://files.pythonhosted.org/packages/e9/88/9df5b7ce880a4703fcc2d76c8c2d8eb9f861f79d0c56f4b8f5f2607ccec8/pydantic_core-2.23.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:20152074317d9bed6b7a95ade3b7d6054845d70584216160860425f4fbd5ee9e", size = 1968793 },
-    { url = "https://files.pythonhosted.org/packages/e3/b9/41f7efe80f6ce2ed3ee3c2dcfe10ab7adc1172f778cc9659509a79518c43/pydantic_core-2.23.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:9261d3ce84fa1d38ed649c3638feefeae23d32ba9182963e465d58d62203bd24", size = 2116872 },
-    { url = "https://files.pythonhosted.org/packages/63/08/b59b7a92e03dd25554b0436554bf23e7c29abae7cce4b1c459cd92746811/pydantic_core-2.23.4-cp312-none-win32.whl", hash = "sha256:4ba762ed58e8d68657fc1281e9bb72e1c3e79cc5d464be146e260c541ec12d84", size = 1738535 },
-    { url = "https://files.pythonhosted.org/packages/88/8d/479293e4d39ab409747926eec4329de5b7129beaedc3786eca070605d07f/pydantic_core-2.23.4-cp312-none-win_amd64.whl", hash = "sha256:97df63000f4fea395b2824da80e169731088656d1818a11b95f3b173747b6cd9", size = 1917992 },
-    { url = "https://files.pythonhosted.org/packages/ad/ef/16ee2df472bf0e419b6bc68c05bf0145c49247a1095e85cee1463c6a44a1/pydantic_core-2.23.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:7530e201d10d7d14abce4fb54cfe5b94a0aefc87da539d0346a484ead376c3cc", size = 1856143 },
-    { url = "https://files.pythonhosted.org/packages/da/fa/bc3dbb83605669a34a93308e297ab22be82dfb9dcf88c6cf4b4f264e0a42/pydantic_core-2.23.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:df933278128ea1cd77772673c73954e53a1c95a4fdf41eef97c2b779271bd0bd", size = 1770063 },
-    { url = "https://files.pythonhosted.org/packages/4e/48/e813f3bbd257a712303ebdf55c8dc46f9589ec74b384c9f652597df3288d/pydantic_core-2.23.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0cb3da3fd1b6a5d0279a01877713dbda118a2a4fc6f0d821a57da2e464793f05", size = 1790013 },
-    { url = "https://files.pythonhosted.org/packages/b4/e0/56eda3a37929a1d297fcab1966db8c339023bcca0b64c5a84896db3fcc5c/pydantic_core-2.23.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:42c6dcb030aefb668a2b7009c85b27f90e51e6a3b4d5c9bc4c57631292015b0d", size = 1801077 },
-    { url = "https://files.pythonhosted.org/packages/04/be/5e49376769bfbf82486da6c5c1683b891809365c20d7c7e52792ce4c71f3/pydantic_core-2.23.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:696dd8d674d6ce621ab9d45b205df149399e4bb9aa34102c970b721554828510", size = 1996782 },
-    { url = "https://files.pythonhosted.org/packages/bc/24/e3ee6c04f1d58cc15f37bcc62f32c7478ff55142b7b3e6d42ea374ea427c/pydantic_core-2.23.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2971bb5ffe72cc0f555c13e19b23c85b654dd2a8f7ab493c262071377bfce9f6", size = 2661375 },
-    { url = "https://files.pythonhosted.org/packages/c1/f8/11a9006de4e89d016b8de74ebb1db727dc100608bb1e6bbe9d56a3cbbcce/pydantic_core-2.23.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8394d940e5d400d04cad4f75c0598665cbb81aecefaca82ca85bd28264af7f9b", size = 2071635 },
-    { url = "https://files.pythonhosted.org/packages/7c/45/bdce5779b59f468bdf262a5bc9eecbae87f271c51aef628d8c073b4b4b4c/pydantic_core-2.23.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:0dff76e0602ca7d4cdaacc1ac4c005e0ce0dcfe095d5b5259163a80d3a10d327", size = 1916994 },
-    { url = "https://files.pythonhosted.org/packages/d8/fa/c648308fe711ee1f88192cad6026ab4f925396d1293e8356de7e55be89b5/pydantic_core-2.23.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:7d32706badfe136888bdea71c0def994644e09fff0bfe47441deaed8e96fdbc6", size = 1968877 },
-    { url = "https://files.pythonhosted.org/packages/16/16/b805c74b35607d24d37103007f899abc4880923b04929547ae68d478b7f4/pydantic_core-2.23.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:ed541d70698978a20eb63d8c5d72f2cc6d7079d9d90f6b50bad07826f1320f5f", size = 2116814 },
-    { url = "https://files.pythonhosted.org/packages/d1/58/5305e723d9fcdf1c5a655e6a4cc2a07128bf644ff4b1d98daf7a9dbf57da/pydantic_core-2.23.4-cp313-none-win32.whl", hash = "sha256:3d5639516376dce1940ea36edf408c554475369f5da2abd45d44621cb616f769", size = 1738360 },
-    { url = "https://files.pythonhosted.org/packages/a5/ae/e14b0ff8b3f48e02394d8acd911376b7b66e164535687ef7dc24ea03072f/pydantic_core-2.23.4-cp313-none-win_amd64.whl", hash = "sha256:5a1504ad17ba4210df3a045132a7baeeba5a200e930f57512ee02909fc5c4cb5", size = 1919411 },
+    { url = "https://files.pythonhosted.org/packages/5d/30/890a583cd3f2be27ecf32b479d5d615710bb926d92da03e3f7838ff3e58b/pydantic_core-2.23.4-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:77733e3892bb0a7fa797826361ce8a9184d25c8dffaec60b7ffe928153680ba8", size = 1865160, upload_time = "2024-09-16T16:04:18.628Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/9a/b634442e1253bc6889c87afe8bb59447f106ee042140bd57680b3b113ec7/pydantic_core-2.23.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1b84d168f6c48fabd1f2027a3d1bdfe62f92cade1fb273a5d68e621da0e44e6d", size = 1776777, upload_time = "2024-09-16T16:04:20.038Z" },
+    { url = "https://files.pythonhosted.org/packages/75/9a/7816295124a6b08c24c96f9ce73085032d8bcbaf7e5a781cd41aa910c891/pydantic_core-2.23.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:df49e7a0861a8c36d089c1ed57d308623d60416dab2647a4a17fe050ba85de0e", size = 1799244, upload_time = "2024-09-16T16:04:21.799Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/8f/89c1405176903e567c5f99ec53387449e62f1121894aa9fc2c4fdc51a59b/pydantic_core-2.23.4-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ff02b6d461a6de369f07ec15e465a88895f3223eb75073ffea56b84d9331f607", size = 1805307, upload_time = "2024-09-16T16:04:23.324Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/a5/1a194447d0da1ef492e3470680c66048fef56fc1f1a25cafbea4bc1d1c48/pydantic_core-2.23.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:996a38a83508c54c78a5f41456b0103c30508fed9abcad0a59b876d7398f25fd", size = 2000663, upload_time = "2024-09-16T16:04:25.203Z" },
+    { url = "https://files.pythonhosted.org/packages/13/a5/1df8541651de4455e7d587cf556201b4f7997191e110bca3b589218745a5/pydantic_core-2.23.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d97683ddee4723ae8c95d1eddac7c192e8c552da0c73a925a89fa8649bf13eea", size = 2655941, upload_time = "2024-09-16T16:04:27.211Z" },
+    { url = "https://files.pythonhosted.org/packages/44/31/a3899b5ce02c4316865e390107f145089876dff7e1dfc770a231d836aed8/pydantic_core-2.23.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:216f9b2d7713eb98cb83c80b9c794de1f6b7e3145eef40400c62e86cee5f4e1e", size = 2052105, upload_time = "2024-09-16T16:04:28.611Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/aa/98e190f8745d5ec831f6d5449344c48c0627ac5fed4e5340a44b74878f8e/pydantic_core-2.23.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6f783e0ec4803c787bcea93e13e9932edab72068f68ecffdf86a99fd5918878b", size = 1919967, upload_time = "2024-09-16T16:04:30.045Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/35/b6e00b6abb2acfee3e8f85558c02a0822e9a8b2f2d812ea8b9079b118ba0/pydantic_core-2.23.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:d0776dea117cf5272382634bd2a5c1b6eb16767c223c6a5317cd3e2a757c61a0", size = 1964291, upload_time = "2024-09-16T16:04:32.376Z" },
+    { url = "https://files.pythonhosted.org/packages/13/46/7bee6d32b69191cd649bbbd2361af79c472d72cb29bb2024f0b6e350ba06/pydantic_core-2.23.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:d5f7a395a8cf1621939692dba2a6b6a830efa6b3cee787d82c7de1ad2930de64", size = 2109666, upload_time = "2024-09-16T16:04:33.923Z" },
+    { url = "https://files.pythonhosted.org/packages/39/ef/7b34f1b122a81b68ed0a7d0e564da9ccdc9a2924c8d6c6b5b11fa3a56970/pydantic_core-2.23.4-cp311-none-win32.whl", hash = "sha256:74b9127ffea03643e998e0c5ad9bd3811d3dac8c676e47db17b0ee7c3c3bf35f", size = 1732940, upload_time = "2024-09-16T16:04:35.467Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/76/37b7e76c645843ff46c1d73e046207311ef298d3f7b2f7d8f6ac60113071/pydantic_core-2.23.4-cp311-none-win_amd64.whl", hash = "sha256:98d134c954828488b153d88ba1f34e14259284f256180ce659e8d83e9c05eaa3", size = 1916804, upload_time = "2024-09-16T16:04:37.06Z" },
+    { url = "https://files.pythonhosted.org/packages/74/7b/8e315f80666194b354966ec84b7d567da77ad927ed6323db4006cf915f3f/pydantic_core-2.23.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:f3e0da4ebaef65158d4dfd7d3678aad692f7666877df0002b8a522cdf088f231", size = 1856459, upload_time = "2024-09-16T16:04:38.438Z" },
+    { url = "https://files.pythonhosted.org/packages/14/de/866bdce10ed808323d437612aca1ec9971b981e1c52e5e42ad9b8e17a6f6/pydantic_core-2.23.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f69a8e0b033b747bb3e36a44e7732f0c99f7edd5cea723d45bc0d6e95377ffee", size = 1770007, upload_time = "2024-09-16T16:04:40.229Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/69/8edd5c3cd48bb833a3f7ef9b81d7666ccddd3c9a635225214e044b6e8281/pydantic_core-2.23.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:723314c1d51722ab28bfcd5240d858512ffd3116449c557a1336cbe3919beb87", size = 1790245, upload_time = "2024-09-16T16:04:41.794Z" },
+    { url = "https://files.pythonhosted.org/packages/80/33/9c24334e3af796ce80d2274940aae38dd4e5676298b4398eff103a79e02d/pydantic_core-2.23.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bb2802e667b7051a1bebbfe93684841cc9351004e2badbd6411bf357ab8d5ac8", size = 1801260, upload_time = "2024-09-16T16:04:43.991Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/6f/e9567fd90104b79b101ca9d120219644d3314962caa7948dd8b965e9f83e/pydantic_core-2.23.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d18ca8148bebe1b0a382a27a8ee60350091a6ddaf475fa05ef50dc35b5df6327", size = 1996872, upload_time = "2024-09-16T16:04:45.593Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/ad/b5f0fe9e6cfee915dd144edbd10b6e9c9c9c9d7a56b69256d124b8ac682e/pydantic_core-2.23.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:33e3d65a85a2a4a0dc3b092b938a4062b1a05f3a9abde65ea93b233bca0e03f2", size = 2661617, upload_time = "2024-09-16T16:04:47.3Z" },
+    { url = "https://files.pythonhosted.org/packages/06/c8/7d4b708f8d05a5cbfda3243aad468052c6e99de7d0937c9146c24d9f12e9/pydantic_core-2.23.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:128585782e5bfa515c590ccee4b727fb76925dd04a98864182b22e89a4e6ed36", size = 2071831, upload_time = "2024-09-16T16:04:48.893Z" },
+    { url = "https://files.pythonhosted.org/packages/89/4d/3079d00c47f22c9a9a8220db088b309ad6e600a73d7a69473e3a8e5e3ea3/pydantic_core-2.23.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:68665f4c17edcceecc112dfed5dbe6f92261fb9d6054b47d01bf6371a6196126", size = 1917453, upload_time = "2024-09-16T16:04:51.099Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/88/9df5b7ce880a4703fcc2d76c8c2d8eb9f861f79d0c56f4b8f5f2607ccec8/pydantic_core-2.23.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:20152074317d9bed6b7a95ade3b7d6054845d70584216160860425f4fbd5ee9e", size = 1968793, upload_time = "2024-09-16T16:04:52.604Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/b9/41f7efe80f6ce2ed3ee3c2dcfe10ab7adc1172f778cc9659509a79518c43/pydantic_core-2.23.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:9261d3ce84fa1d38ed649c3638feefeae23d32ba9182963e465d58d62203bd24", size = 2116872, upload_time = "2024-09-16T16:04:54.41Z" },
+    { url = "https://files.pythonhosted.org/packages/63/08/b59b7a92e03dd25554b0436554bf23e7c29abae7cce4b1c459cd92746811/pydantic_core-2.23.4-cp312-none-win32.whl", hash = "sha256:4ba762ed58e8d68657fc1281e9bb72e1c3e79cc5d464be146e260c541ec12d84", size = 1738535, upload_time = "2024-09-16T16:04:55.828Z" },
+    { url = "https://files.pythonhosted.org/packages/88/8d/479293e4d39ab409747926eec4329de5b7129beaedc3786eca070605d07f/pydantic_core-2.23.4-cp312-none-win_amd64.whl", hash = "sha256:97df63000f4fea395b2824da80e169731088656d1818a11b95f3b173747b6cd9", size = 1917992, upload_time = "2024-09-16T16:04:57.395Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/ef/16ee2df472bf0e419b6bc68c05bf0145c49247a1095e85cee1463c6a44a1/pydantic_core-2.23.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:7530e201d10d7d14abce4fb54cfe5b94a0aefc87da539d0346a484ead376c3cc", size = 1856143, upload_time = "2024-09-16T16:04:59.062Z" },
+    { url = "https://files.pythonhosted.org/packages/da/fa/bc3dbb83605669a34a93308e297ab22be82dfb9dcf88c6cf4b4f264e0a42/pydantic_core-2.23.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:df933278128ea1cd77772673c73954e53a1c95a4fdf41eef97c2b779271bd0bd", size = 1770063, upload_time = "2024-09-16T16:05:00.522Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/48/e813f3bbd257a712303ebdf55c8dc46f9589ec74b384c9f652597df3288d/pydantic_core-2.23.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0cb3da3fd1b6a5d0279a01877713dbda118a2a4fc6f0d821a57da2e464793f05", size = 1790013, upload_time = "2024-09-16T16:05:02.619Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/e0/56eda3a37929a1d297fcab1966db8c339023bcca0b64c5a84896db3fcc5c/pydantic_core-2.23.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:42c6dcb030aefb668a2b7009c85b27f90e51e6a3b4d5c9bc4c57631292015b0d", size = 1801077, upload_time = "2024-09-16T16:05:04.154Z" },
+    { url = "https://files.pythonhosted.org/packages/04/be/5e49376769bfbf82486da6c5c1683b891809365c20d7c7e52792ce4c71f3/pydantic_core-2.23.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:696dd8d674d6ce621ab9d45b205df149399e4bb9aa34102c970b721554828510", size = 1996782, upload_time = "2024-09-16T16:05:06.931Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/24/e3ee6c04f1d58cc15f37bcc62f32c7478ff55142b7b3e6d42ea374ea427c/pydantic_core-2.23.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2971bb5ffe72cc0f555c13e19b23c85b654dd2a8f7ab493c262071377bfce9f6", size = 2661375, upload_time = "2024-09-16T16:05:08.773Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/f8/11a9006de4e89d016b8de74ebb1db727dc100608bb1e6bbe9d56a3cbbcce/pydantic_core-2.23.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8394d940e5d400d04cad4f75c0598665cbb81aecefaca82ca85bd28264af7f9b", size = 2071635, upload_time = "2024-09-16T16:05:10.456Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/45/bdce5779b59f468bdf262a5bc9eecbae87f271c51aef628d8c073b4b4b4c/pydantic_core-2.23.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:0dff76e0602ca7d4cdaacc1ac4c005e0ce0dcfe095d5b5259163a80d3a10d327", size = 1916994, upload_time = "2024-09-16T16:05:12.051Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/fa/c648308fe711ee1f88192cad6026ab4f925396d1293e8356de7e55be89b5/pydantic_core-2.23.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:7d32706badfe136888bdea71c0def994644e09fff0bfe47441deaed8e96fdbc6", size = 1968877, upload_time = "2024-09-16T16:05:14.021Z" },
+    { url = "https://files.pythonhosted.org/packages/16/16/b805c74b35607d24d37103007f899abc4880923b04929547ae68d478b7f4/pydantic_core-2.23.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:ed541d70698978a20eb63d8c5d72f2cc6d7079d9d90f6b50bad07826f1320f5f", size = 2116814, upload_time = "2024-09-16T16:05:15.684Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/58/5305e723d9fcdf1c5a655e6a4cc2a07128bf644ff4b1d98daf7a9dbf57da/pydantic_core-2.23.4-cp313-none-win32.whl", hash = "sha256:3d5639516376dce1940ea36edf408c554475369f5da2abd45d44621cb616f769", size = 1738360, upload_time = "2024-09-16T16:05:17.258Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ae/e14b0ff8b3f48e02394d8acd911376b7b66e164535687ef7dc24ea03072f/pydantic_core-2.23.4-cp313-none-win_amd64.whl", hash = "sha256:5a1504ad17ba4210df3a045132a7baeeba5a200e930f57512ee02909fc5c4cb5", size = 1919411, upload_time = "2024-09-16T16:05:18.934Z" },
 ]
 
 [[package]]
@@ -548,18 +559,18 @@ dependencies = [
     { name = "pydantic" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f4/92/8542f406466d11bf348b795d498906034f9bb9016f09e906ff7fee6444be/pydantic_extra_types-2.10.0.tar.gz", hash = "sha256:552c47dd18fe1d00cfed75d9981162a2f3203cf7e77e55a3d3e70936f59587b9", size = 44559 }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/92/8542f406466d11bf348b795d498906034f9bb9016f09e906ff7fee6444be/pydantic_extra_types-2.10.0.tar.gz", hash = "sha256:552c47dd18fe1d00cfed75d9981162a2f3203cf7e77e55a3d3e70936f59587b9", size = 44559, upload_time = "2024-11-04T17:31:08.939Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/41/0b0cc8b59c31a04bdfde2ae71fccbb13c11fadafc8bd41a2af3e76db7e44/pydantic_extra_types-2.10.0-py3-none-any.whl", hash = "sha256:b19943914e6286548254f5079d1da094e9c0583ee91a8e611e9df24bfd07dbcd", size = 34185 },
+    { url = "https://files.pythonhosted.org/packages/38/41/0b0cc8b59c31a04bdfde2ae71fccbb13c11fadafc8bd41a2af3e76db7e44/pydantic_extra_types-2.10.0-py3-none-any.whl", hash = "sha256:b19943914e6286548254f5079d1da094e9c0583ee91a8e611e9df24bfd07dbcd", size = 34185, upload_time = "2024-11-04T17:31:07.567Z" },
 ]
 
 [[package]]
 name = "pygments"
 version = "2.18.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8e/62/8336eff65bcbc8e4cb5d05b55faf041285951b6e80f33e2bff2024788f31/pygments-2.18.0.tar.gz", hash = "sha256:786ff802f32e91311bff3889f6e9a86e81505fe99f2735bb6d60ae0c5004f199", size = 4891905 }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/62/8336eff65bcbc8e4cb5d05b55faf041285951b6e80f33e2bff2024788f31/pygments-2.18.0.tar.gz", hash = "sha256:786ff802f32e91311bff3889f6e9a86e81505fe99f2735bb6d60ae0c5004f199", size = 4891905, upload_time = "2024-05-04T13:42:02.013Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f7/3f/01c8b82017c199075f8f788d0d906b9ffbbc5a47dc9918a945e13d5a2bda/pygments-2.18.0-py3-none-any.whl", hash = "sha256:b8e6aca0523f3ab76fee51799c488e38782ac06eafcf95e7ba832985c8e7b13a", size = 1205513 },
+    { url = "https://files.pythonhosted.org/packages/f7/3f/01c8b82017c199075f8f788d0d906b9ffbbc5a47dc9918a945e13d5a2bda/pygments-2.18.0-py3-none-any.whl", hash = "sha256:b8e6aca0523f3ab76fee51799c488e38782ac06eafcf95e7ba832985c8e7b13a", size = 1205513, upload_time = "2024-05-04T13:41:57.345Z" },
 ]
 
 [[package]]
@@ -575,19 +586,19 @@ dependencies = [
     { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
     { name = "setuptools" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/55/d4/54f5f5c73b803e6256ea97ffc6ba8a305d9a5f57f85f9b00b282512bf18a/pyinstaller-6.11.1.tar.gz", hash = "sha256:491dfb4d9d5d1d9650d9507daec1ff6829527a254d8e396badd60a0affcb72ef", size = 4249772 }
+sdist = { url = "https://files.pythonhosted.org/packages/55/d4/54f5f5c73b803e6256ea97ffc6ba8a305d9a5f57f85f9b00b282512bf18a/pyinstaller-6.11.1.tar.gz", hash = "sha256:491dfb4d9d5d1d9650d9507daec1ff6829527a254d8e396badd60a0affcb72ef", size = 4249772, upload_time = "2024-11-10T17:01:25.415Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/96/15/b0f1c0985ee32fcd2f6ad9a486ef94e4db3fef9af025a3655e76cb708009/pyinstaller-6.11.1-py3-none-macosx_10_13_universal2.whl", hash = "sha256:44e36172de326af6d4e7663b12f71dbd34e2e3e02233e181e457394423daaf03", size = 991780 },
-    { url = "https://files.pythonhosted.org/packages/fd/0f/9f54cb18abe2b1d89051bc9214c0cb40d7b5f4049c151c315dacc067f4a2/pyinstaller-6.11.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:6d12c45a29add78039066a53fb05967afaa09a672426072b13816fe7676abfc4", size = 711739 },
-    { url = "https://files.pythonhosted.org/packages/32/f7/79d10830780eff8339bfa793eece1df4b2459e35a712fc81983e8536cc29/pyinstaller-6.11.1-py3-none-manylinux2014_i686.whl", hash = "sha256:ddc0fddd75f07f7e423da1f0822e389a42af011f9589e0269b87e0d89aa48c1f", size = 714053 },
-    { url = "https://files.pythonhosted.org/packages/25/f7/9961ef02cdbd2dbb1b1a215292656bd0ea72a83aafd8fb6373513849711e/pyinstaller-6.11.1-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:0d6475559c4939f0735122989611d7f739ed3bf02f666ce31022928f7a7e4fda", size = 719133 },
-    { url = "https://files.pythonhosted.org/packages/6f/4d/7f854842a1ce798de762a0b0bc5d5a4fc26ad06164a98575dc3c54abed1f/pyinstaller-6.11.1-py3-none-manylinux2014_s390x.whl", hash = "sha256:e21c7806e34f40181e7606926a14579f848bfb1dc52cbca7eea66eccccbfe977", size = 709591 },
-    { url = "https://files.pythonhosted.org/packages/7f/e0/00d29fc90c3ba50620c61554e26ebb4d764569507be7cd1c8794aa696f9a/pyinstaller-6.11.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:32c742a24fe65d0702958fadf4040f76de85859c26bec0008766e5dbabc5b68f", size = 710068 },
-    { url = "https://files.pythonhosted.org/packages/3e/57/d14b44a69f068d2caaee49d15e45f9fa0f37c6a2d2ad778c953c1722a1ca/pyinstaller-6.11.1-py3-none-musllinux_1_1_aarch64.whl", hash = "sha256:208c0ef6dab0837a0a273ea32d1a3619a208e3d1fe3fec3785eea71a77fd00ce", size = 714439 },
-    { url = "https://files.pythonhosted.org/packages/88/01/256824bb57ca208099c86c2fb289f888ca7732580e91ced48fa14e5903b2/pyinstaller-6.11.1-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:ad84abf465bcda363c1d54eafa76745d77b6a8a713778348377dc98d12a452f7", size = 710457 },
-    { url = "https://files.pythonhosted.org/packages/7c/f0/98c9138f5f0ff17462f1ad6d712dcfa643b9a283d6238d464d8145bc139d/pyinstaller-6.11.1-py3-none-win32.whl", hash = "sha256:2e8365276c5131c9bef98e358fbc305e4022db8bedc9df479629d6414021956a", size = 1280261 },
-    { url = "https://files.pythonhosted.org/packages/7d/08/f43080614b3e8bce481d4dfd580e579497c7dcdaf87656d9d2ad912e5796/pyinstaller-6.11.1-py3-none-win_amd64.whl", hash = "sha256:7ac83c0dc0e04357dab98c487e74ad2adb30e7eb186b58157a8faf46f1fa796f", size = 1340482 },
-    { url = "https://files.pythonhosted.org/packages/ed/56/953c6594cb66e249563854c9cc04ac5a055c6c99d1614298feeaeaa9b87e/pyinstaller-6.11.1-py3-none-win_arm64.whl", hash = "sha256:35e6b8077d240600bb309ed68bb0b1453fd2b7ab740b66d000db7abae6244423", size = 1267519 },
+    { url = "https://files.pythonhosted.org/packages/96/15/b0f1c0985ee32fcd2f6ad9a486ef94e4db3fef9af025a3655e76cb708009/pyinstaller-6.11.1-py3-none-macosx_10_13_universal2.whl", hash = "sha256:44e36172de326af6d4e7663b12f71dbd34e2e3e02233e181e457394423daaf03", size = 991780, upload_time = "2024-11-10T17:00:17.242Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/0f/9f54cb18abe2b1d89051bc9214c0cb40d7b5f4049c151c315dacc067f4a2/pyinstaller-6.11.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:6d12c45a29add78039066a53fb05967afaa09a672426072b13816fe7676abfc4", size = 711739, upload_time = "2024-11-10T17:00:21.734Z" },
+    { url = "https://files.pythonhosted.org/packages/32/f7/79d10830780eff8339bfa793eece1df4b2459e35a712fc81983e8536cc29/pyinstaller-6.11.1-py3-none-manylinux2014_i686.whl", hash = "sha256:ddc0fddd75f07f7e423da1f0822e389a42af011f9589e0269b87e0d89aa48c1f", size = 714053, upload_time = "2024-11-10T17:00:25.773Z" },
+    { url = "https://files.pythonhosted.org/packages/25/f7/9961ef02cdbd2dbb1b1a215292656bd0ea72a83aafd8fb6373513849711e/pyinstaller-6.11.1-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:0d6475559c4939f0735122989611d7f739ed3bf02f666ce31022928f7a7e4fda", size = 719133, upload_time = "2024-11-10T17:00:30.342Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/4d/7f854842a1ce798de762a0b0bc5d5a4fc26ad06164a98575dc3c54abed1f/pyinstaller-6.11.1-py3-none-manylinux2014_s390x.whl", hash = "sha256:e21c7806e34f40181e7606926a14579f848bfb1dc52cbca7eea66eccccbfe977", size = 709591, upload_time = "2024-11-10T17:00:34.932Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/e0/00d29fc90c3ba50620c61554e26ebb4d764569507be7cd1c8794aa696f9a/pyinstaller-6.11.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:32c742a24fe65d0702958fadf4040f76de85859c26bec0008766e5dbabc5b68f", size = 710068, upload_time = "2024-11-10T17:00:39.655Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/57/d14b44a69f068d2caaee49d15e45f9fa0f37c6a2d2ad778c953c1722a1ca/pyinstaller-6.11.1-py3-none-musllinux_1_1_aarch64.whl", hash = "sha256:208c0ef6dab0837a0a273ea32d1a3619a208e3d1fe3fec3785eea71a77fd00ce", size = 714439, upload_time = "2024-11-10T17:00:43.838Z" },
+    { url = "https://files.pythonhosted.org/packages/88/01/256824bb57ca208099c86c2fb289f888ca7732580e91ced48fa14e5903b2/pyinstaller-6.11.1-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:ad84abf465bcda363c1d54eafa76745d77b6a8a713778348377dc98d12a452f7", size = 710457, upload_time = "2024-11-10T17:00:47.89Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f0/98c9138f5f0ff17462f1ad6d712dcfa643b9a283d6238d464d8145bc139d/pyinstaller-6.11.1-py3-none-win32.whl", hash = "sha256:2e8365276c5131c9bef98e358fbc305e4022db8bedc9df479629d6414021956a", size = 1280261, upload_time = "2024-11-10T17:00:54.688Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/08/f43080614b3e8bce481d4dfd580e579497c7dcdaf87656d9d2ad912e5796/pyinstaller-6.11.1-py3-none-win_amd64.whl", hash = "sha256:7ac83c0dc0e04357dab98c487e74ad2adb30e7eb186b58157a8faf46f1fa796f", size = 1340482, upload_time = "2024-11-10T17:01:01.62Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/56/953c6594cb66e249563854c9cc04ac5a055c6c99d1614298feeaeaa9b87e/pyinstaller-6.11.1-py3-none-win_arm64.whl", hash = "sha256:35e6b8077d240600bb309ed68bb0b1453fd2b7ab740b66d000db7abae6244423", size = 1267519, upload_time = "2024-11-10T17:01:08.525Z" },
 ]
 
 [[package]]
@@ -598,9 +609,9 @@ dependencies = [
     { name = "packaging" },
     { name = "setuptools" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/73/6a/9d0057e312b85fbd17a79e1c1955d115fd9bbc78b85bab757777c8ef2307/pyinstaller_hooks_contrib-2024.10.tar.gz", hash = "sha256:8a46655e5c5b0186b5e527399118a9b342f10513eb1425c483fa4f6d02e8800c", size = 140592 }
+sdist = { url = "https://files.pythonhosted.org/packages/73/6a/9d0057e312b85fbd17a79e1c1955d115fd9bbc78b85bab757777c8ef2307/pyinstaller_hooks_contrib-2024.10.tar.gz", hash = "sha256:8a46655e5c5b0186b5e527399118a9b342f10513eb1425c483fa4f6d02e8800c", size = 140592, upload_time = "2024-11-10T17:57:44.795Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a9/64/445861ee7a5fd32874c0f6cfe8222aacc8feda22539332e0d8ff50dadec6/pyinstaller_hooks_contrib-2024.10-py3-none-any.whl", hash = "sha256:ad47db0e153683b4151e10d231cb91f2d93c85079e78d76d9e0f57ac6c8a5e10", size = 338417 },
+    { url = "https://files.pythonhosted.org/packages/a9/64/445861ee7a5fd32874c0f6cfe8222aacc8feda22539332e0d8ff50dadec6/pyinstaller_hooks_contrib-2024.10-py3-none-any.whl", hash = "sha256:ad47db0e153683b4151e10d231cb91f2d93c85079e78d76d9e0f57ac6c8a5e10", size = 338417, upload_time = "2024-11-10T17:57:42.706Z" },
 ]
 
 [[package]]
@@ -610,27 +621,27 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "packaging" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bb/19/441e0624a8afedd15bbcce96df1b80479dd0ff0d965f5ce8fde4f2f6ffad/pyproject_api-1.8.0.tar.gz", hash = "sha256:77b8049f2feb5d33eefcc21b57f1e279636277a8ac8ad6b5871037b243778496", size = 22340 }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/19/441e0624a8afedd15bbcce96df1b80479dd0ff0d965f5ce8fde4f2f6ffad/pyproject_api-1.8.0.tar.gz", hash = "sha256:77b8049f2feb5d33eefcc21b57f1e279636277a8ac8ad6b5871037b243778496", size = 22340, upload_time = "2024-09-18T23:18:37.805Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ba/f4/3c4ddfcc0c19c217c6de513842d286de8021af2f2ab79bbb86c00342d778/pyproject_api-1.8.0-py3-none-any.whl", hash = "sha256:3d7d347a047afe796fd5d1885b1e391ba29be7169bd2f102fcd378f04273d228", size = 13100 },
+    { url = "https://files.pythonhosted.org/packages/ba/f4/3c4ddfcc0c19c217c6de513842d286de8021af2f2ab79bbb86c00342d778/pyproject_api-1.8.0-py3-none-any.whl", hash = "sha256:3d7d347a047afe796fd5d1885b1e391ba29be7169bd2f102fcd378f04273d228", size = 13100, upload_time = "2024-09-18T23:18:35.927Z" },
 ]
 
 [[package]]
 name = "pyproject-hooks"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/82/28175b2414effca1cdac8dc99f76d660e7a4fb0ceefa4b4ab8f5f6742925/pyproject_hooks-1.2.0.tar.gz", hash = "sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8", size = 19228 }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/82/28175b2414effca1cdac8dc99f76d660e7a4fb0ceefa4b4ab8f5f6742925/pyproject_hooks-1.2.0.tar.gz", hash = "sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8", size = 19228, upload_time = "2024-09-29T09:24:13.293Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl", hash = "sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913", size = 10216 },
+    { url = "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl", hash = "sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913", size = 10216, upload_time = "2024-09-29T09:24:11.978Z" },
 ]
 
 [[package]]
 name = "pysocks"
 version = "1.7.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bd/11/293dd436aea955d45fc4e8a35b6ae7270f5b8e00b53cf6c024c83b657a11/PySocks-1.7.1.tar.gz", hash = "sha256:3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0", size = 284429 }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/11/293dd436aea955d45fc4e8a35b6ae7270f5b8e00b53cf6c024c83b657a11/PySocks-1.7.1.tar.gz", hash = "sha256:3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0", size = 284429, upload_time = "2019-09-20T02:07:35.714Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/59/b4572118e098ac8e46e399a1dd0f2d85403ce8bbaad9ec79373ed6badaf9/PySocks-1.7.1-py3-none-any.whl", hash = "sha256:2725bd0a9925919b9b51739eea5f9e2bae91e83288108a9ad338b2e3a4435ee5", size = 16725 },
+    { url = "https://files.pythonhosted.org/packages/8d/59/b4572118e098ac8e46e399a1dd0f2d85403ce8bbaad9ec79373ed6badaf9/PySocks-1.7.1-py3-none-any.whl", hash = "sha256:2725bd0a9925919b9b51739eea5f9e2bae91e83288108a9ad338b2e3a4435ee5", size = 16725, upload_time = "2019-09-20T02:06:22.938Z" },
 ]
 
 [[package]]
@@ -643,9 +654,9 @@ dependencies = [
     { name = "packaging" },
     { name = "pluggy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/6c/62bbd536103af674e227c41a8f3dcd022d591f6eed5facb5a0f31ee33bbc/pytest-8.3.3.tar.gz", hash = "sha256:70b98107bd648308a7952b06e6ca9a50bc660be218d53c257cc1fc94fda10181", size = 1442487 }
+sdist = { url = "https://files.pythonhosted.org/packages/8b/6c/62bbd536103af674e227c41a8f3dcd022d591f6eed5facb5a0f31ee33bbc/pytest-8.3.3.tar.gz", hash = "sha256:70b98107bd648308a7952b06e6ca9a50bc660be218d53c257cc1fc94fda10181", size = 1442487, upload_time = "2024-09-10T10:52:15.003Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6b/77/7440a06a8ead44c7757a64362dd22df5760f9b12dc5f11b6188cd2fc27a0/pytest-8.3.3-py3-none-any.whl", hash = "sha256:a6853c7375b2663155079443d2e45de913a911a11d669df02a50814944db57b2", size = 342341 },
+    { url = "https://files.pythonhosted.org/packages/6b/77/7440a06a8ead44c7757a64362dd22df5760f9b12dc5f11b6188cd2fc27a0/pytest-8.3.3-py3-none-any.whl", hash = "sha256:a6853c7375b2663155079443d2e45de913a911a11d669df02a50814944db57b2", size = 342341, upload_time = "2024-09-10T10:52:12.54Z" },
 ]
 
 [[package]]
@@ -655,9 +666,9 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "werkzeug" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/12/53/aa5aa8518246848251243a21440f167b812bd40896546061c1fda814c10c/pytest_httpserver-1.1.0.tar.gz", hash = "sha256:6b1cb0199e2ed551b1b94d43f096863bbf6ae5bcd7c75c2c06845e5ce2dc8701", size = 67210 }
+sdist = { url = "https://files.pythonhosted.org/packages/12/53/aa5aa8518246848251243a21440f167b812bd40896546061c1fda814c10c/pytest_httpserver-1.1.0.tar.gz", hash = "sha256:6b1cb0199e2ed551b1b94d43f096863bbf6ae5bcd7c75c2c06845e5ce2dc8701", size = 67210, upload_time = "2024-08-11T21:48:30.774Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/29/c5dfce47d5f575e46e2d4a4257cd43cc199a8014f506d14d808e03d6f8cd/pytest_httpserver-1.1.0-py3-none-any.whl", hash = "sha256:7ef88be8ed3354b6784daa3daa75a422370327c634053cefb124903fa8d73a41", size = 20671 },
+    { url = "https://files.pythonhosted.org/packages/1d/29/c5dfce47d5f575e46e2d4a4257cd43cc199a8014f506d14d808e03d6f8cd/pytest_httpserver-1.1.0-py3-none-any.whl", hash = "sha256:7ef88be8ed3354b6784daa3daa75a422370327c634053cefb124903fa8d73a41", size = 20671, upload_time = "2024-08-11T21:48:28.67Z" },
 ]
 
 [[package]]
@@ -667,18 +678,18 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "six" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432 }
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload_time = "2024-03-01T18:36:20.211Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892 },
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload_time = "2024-03-01T18:36:18.57Z" },
 ]
 
 [[package]]
 name = "pywin32-ctypes"
 version = "0.2.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471 }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload_time = "2024-08-14T10:15:34.626Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756 },
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload_time = "2024-08-14T10:15:33.187Z" },
 ]
 
 [[package]]
@@ -691,9 +702,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/63/70/2bf7780ad2d390a8d301ad0b550f1581eadbd9a20f896afe06353c2a2913/requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760", size = 131218 }
+sdist = { url = "https://files.pythonhosted.org/packages/63/70/2bf7780ad2d390a8d301ad0b550f1581eadbd9a20f896afe06353c2a2913/requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760", size = 131218, upload_time = "2024-05-29T15:37:49.536Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl", hash = "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6", size = 64928 },
+    { url = "https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl", hash = "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6", size = 64928, upload_time = "2024-05-29T15:37:47.027Z" },
 ]
 
 [package.optional-dependencies]
@@ -709,43 +720,43 @@ dependencies = [
     { name = "markdown-it-py" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ab/3a/0316b28d0761c6734d6bc14e770d85506c986c85ffb239e688eeaab2c2bc/rich-13.9.4.tar.gz", hash = "sha256:439594978a49a09530cff7ebc4b5c7103ef57baf48d5ea3184f21d9a2befa098", size = 223149 }
+sdist = { url = "https://files.pythonhosted.org/packages/ab/3a/0316b28d0761c6734d6bc14e770d85506c986c85ffb239e688eeaab2c2bc/rich-13.9.4.tar.gz", hash = "sha256:439594978a49a09530cff7ebc4b5c7103ef57baf48d5ea3184f21d9a2befa098", size = 223149, upload_time = "2024-11-01T16:43:57.873Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/71/39c7c0d87f8d4e6c020a393182060eaefeeae6c01dab6a84ec346f2567df/rich-13.9.4-py3-none-any.whl", hash = "sha256:6049d5e6ec054bf2779ab3358186963bac2ea89175919d699e378b99738c2a90", size = 242424 },
+    { url = "https://files.pythonhosted.org/packages/19/71/39c7c0d87f8d4e6c020a393182060eaefeeae6c01dab6a84ec346f2567df/rich-13.9.4-py3-none-any.whl", hash = "sha256:6049d5e6ec054bf2779ab3358186963bac2ea89175919d699e378b99738c2a90", size = 242424, upload_time = "2024-11-01T16:43:55.817Z" },
 ]
 
 [[package]]
 name = "ruff"
 version = "0.7.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0b/8b/bc4e0dfa1245b07cf14300e10319b98e958a53ff074c1dd86b35253a8c2a/ruff-0.7.4.tar.gz", hash = "sha256:cd12e35031f5af6b9b93715d8c4f40360070b2041f81273d0527683d5708fce2", size = 3275547 }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/8b/bc4e0dfa1245b07cf14300e10319b98e958a53ff074c1dd86b35253a8c2a/ruff-0.7.4.tar.gz", hash = "sha256:cd12e35031f5af6b9b93715d8c4f40360070b2041f81273d0527683d5708fce2", size = 3275547, upload_time = "2024-11-15T11:33:11.853Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/4b/f5094719e254829766b807dadb766841124daba75a37da83e292ae5ad12f/ruff-0.7.4-py3-none-linux_armv6l.whl", hash = "sha256:a4919925e7684a3f18e18243cd6bea7cfb8e968a6eaa8437971f681b7ec51478", size = 10447512 },
-    { url = "https://files.pythonhosted.org/packages/9e/1d/3d2d2c9f601cf6044799c5349ff5267467224cefed9b35edf5f1f36486e9/ruff-0.7.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:cfb365c135b830778dda8c04fb7d4280ed0b984e1aec27f574445231e20d6c63", size = 10235436 },
-    { url = "https://files.pythonhosted.org/packages/62/83/42a6ec6216ded30b354b13e0e9327ef75a3c147751aaf10443756cb690e9/ruff-0.7.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:63a569b36bc66fbadec5beaa539dd81e0527cb258b94e29e0531ce41bacc1f20", size = 9888936 },
-    { url = "https://files.pythonhosted.org/packages/4d/26/e1e54893b13046a6ad05ee9b89ee6f71542ba250f72b4c7a7d17c3dbf73d/ruff-0.7.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d06218747d361d06fd2fdac734e7fa92df36df93035db3dc2ad7aa9852cb109", size = 10697353 },
-    { url = "https://files.pythonhosted.org/packages/21/24/98d2e109c4efc02bfef144ec6ea2c3e1217e7ce0cfddda8361d268dfd499/ruff-0.7.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e0cea28d0944f74ebc33e9f934238f15c758841f9f5edd180b5315c203293452", size = 10228078 },
-    { url = "https://files.pythonhosted.org/packages/ad/b7/964c75be9bc2945fc3172241b371197bb6d948cc69e28bc4518448c368f3/ruff-0.7.4-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:80094ecd4793c68b2571b128f91754d60f692d64bc0d7272ec9197fdd09bf9ea", size = 11264823 },
-    { url = "https://files.pythonhosted.org/packages/12/8d/20abdbf705969914ce40988fe71a554a918deaab62c38ec07483e77866f6/ruff-0.7.4-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:997512325c6620d1c4c2b15db49ef59543ef9cd0f4aa8065ec2ae5103cedc7e7", size = 11951855 },
-    { url = "https://files.pythonhosted.org/packages/b8/fc/6519ce58c57b4edafcdf40920b7273dfbba64fc6ebcaae7b88e4dc1bf0a8/ruff-0.7.4-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:00b4cf3a6b5fad6d1a66e7574d78956bbd09abfd6c8a997798f01f5da3d46a05", size = 11516580 },
-    { url = "https://files.pythonhosted.org/packages/37/1a/5ec1844e993e376a86eb2456496831ed91b4398c434d8244f89094758940/ruff-0.7.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7dbdc7d8274e1422722933d1edddfdc65b4336abf0b16dfcb9dedd6e6a517d06", size = 12692057 },
-    { url = "https://files.pythonhosted.org/packages/50/90/76867152b0d3c05df29a74bb028413e90f704f0f6701c4801174ba47f959/ruff-0.7.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0e92dfb5f00eaedb1501b2f906ccabfd67b2355bdf117fea9719fc99ac2145bc", size = 11085137 },
-    { url = "https://files.pythonhosted.org/packages/c8/eb/0a7cb6059ac3555243bd026bb21785bbc812f7bbfa95a36c101bd72b47ae/ruff-0.7.4-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:3bd726099f277d735dc38900b6a8d6cf070f80828877941983a57bca1cd92172", size = 10681243 },
-    { url = "https://files.pythonhosted.org/packages/5e/76/2270719dbee0fd35780b05c08a07b7a726c3da9f67d9ae89ef21fc18e2e5/ruff-0.7.4-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:2e32829c429dd081ee5ba39aef436603e5b22335c3d3fff013cd585806a6486a", size = 10319187 },
-    { url = "https://files.pythonhosted.org/packages/9f/e5/39100f72f8ba70bec1bd329efc880dea8b6c1765ea1cb9d0c1c5f18b8d7f/ruff-0.7.4-py3-none-musllinux_1_2_i686.whl", hash = "sha256:662a63b4971807623f6f90c1fb664613f67cc182dc4d991471c23c541fee62dd", size = 10803715 },
-    { url = "https://files.pythonhosted.org/packages/a5/89/40e904784f305fb56850063f70a998a64ebba68796d823dde67e89a24691/ruff-0.7.4-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:876f5e09eaae3eb76814c1d3b68879891d6fde4824c015d48e7a7da4cf066a3a", size = 11162912 },
-    { url = "https://files.pythonhosted.org/packages/8d/1b/dd77503b3875c51e3dbc053fd8367b845ab8b01c9ca6d0c237082732856c/ruff-0.7.4-py3-none-win32.whl", hash = "sha256:75c53f54904be42dd52a548728a5b572344b50d9b2873d13a3f8c5e3b91f5cac", size = 8702767 },
-    { url = "https://files.pythonhosted.org/packages/63/76/253ddc3e89e70165bba952ecca424b980b8d3c2598ceb4fc47904f424953/ruff-0.7.4-py3-none-win_amd64.whl", hash = "sha256:745775c7b39f914238ed1f1b0bebed0b9155a17cd8bc0b08d3c87e4703b990d6", size = 9497534 },
-    { url = "https://files.pythonhosted.org/packages/aa/70/f8724f31abc0b329ca98b33d73c14020168babcf71b0cba3cded5d9d0e66/ruff-0.7.4-py3-none-win_arm64.whl", hash = "sha256:11bff065102c3ae9d3ea4dc9ecdfe5a5171349cdd0787c1fc64761212fc9cf1f", size = 8851590 },
+    { url = "https://files.pythonhosted.org/packages/e6/4b/f5094719e254829766b807dadb766841124daba75a37da83e292ae5ad12f/ruff-0.7.4-py3-none-linux_armv6l.whl", hash = "sha256:a4919925e7684a3f18e18243cd6bea7cfb8e968a6eaa8437971f681b7ec51478", size = 10447512, upload_time = "2024-11-15T11:32:27.812Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/1d/3d2d2c9f601cf6044799c5349ff5267467224cefed9b35edf5f1f36486e9/ruff-0.7.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:cfb365c135b830778dda8c04fb7d4280ed0b984e1aec27f574445231e20d6c63", size = 10235436, upload_time = "2024-11-15T11:32:30.6Z" },
+    { url = "https://files.pythonhosted.org/packages/62/83/42a6ec6216ded30b354b13e0e9327ef75a3c147751aaf10443756cb690e9/ruff-0.7.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:63a569b36bc66fbadec5beaa539dd81e0527cb258b94e29e0531ce41bacc1f20", size = 9888936, upload_time = "2024-11-15T11:32:33.287Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/26/e1e54893b13046a6ad05ee9b89ee6f71542ba250f72b4c7a7d17c3dbf73d/ruff-0.7.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d06218747d361d06fd2fdac734e7fa92df36df93035db3dc2ad7aa9852cb109", size = 10697353, upload_time = "2024-11-15T11:32:35.895Z" },
+    { url = "https://files.pythonhosted.org/packages/21/24/98d2e109c4efc02bfef144ec6ea2c3e1217e7ce0cfddda8361d268dfd499/ruff-0.7.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e0cea28d0944f74ebc33e9f934238f15c758841f9f5edd180b5315c203293452", size = 10228078, upload_time = "2024-11-15T11:32:40.929Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/b7/964c75be9bc2945fc3172241b371197bb6d948cc69e28bc4518448c368f3/ruff-0.7.4-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:80094ecd4793c68b2571b128f91754d60f692d64bc0d7272ec9197fdd09bf9ea", size = 11264823, upload_time = "2024-11-15T11:32:43.31Z" },
+    { url = "https://files.pythonhosted.org/packages/12/8d/20abdbf705969914ce40988fe71a554a918deaab62c38ec07483e77866f6/ruff-0.7.4-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:997512325c6620d1c4c2b15db49ef59543ef9cd0f4aa8065ec2ae5103cedc7e7", size = 11951855, upload_time = "2024-11-15T11:32:46.038Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/fc/6519ce58c57b4edafcdf40920b7273dfbba64fc6ebcaae7b88e4dc1bf0a8/ruff-0.7.4-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:00b4cf3a6b5fad6d1a66e7574d78956bbd09abfd6c8a997798f01f5da3d46a05", size = 11516580, upload_time = "2024-11-15T11:32:48.17Z" },
+    { url = "https://files.pythonhosted.org/packages/37/1a/5ec1844e993e376a86eb2456496831ed91b4398c434d8244f89094758940/ruff-0.7.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7dbdc7d8274e1422722933d1edddfdc65b4336abf0b16dfcb9dedd6e6a517d06", size = 12692057, upload_time = "2024-11-15T11:32:50.623Z" },
+    { url = "https://files.pythonhosted.org/packages/50/90/76867152b0d3c05df29a74bb028413e90f704f0f6701c4801174ba47f959/ruff-0.7.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0e92dfb5f00eaedb1501b2f906ccabfd67b2355bdf117fea9719fc99ac2145bc", size = 11085137, upload_time = "2024-11-15T11:32:52.819Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/eb/0a7cb6059ac3555243bd026bb21785bbc812f7bbfa95a36c101bd72b47ae/ruff-0.7.4-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:3bd726099f277d735dc38900b6a8d6cf070f80828877941983a57bca1cd92172", size = 10681243, upload_time = "2024-11-15T11:32:55.902Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/76/2270719dbee0fd35780b05c08a07b7a726c3da9f67d9ae89ef21fc18e2e5/ruff-0.7.4-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:2e32829c429dd081ee5ba39aef436603e5b22335c3d3fff013cd585806a6486a", size = 10319187, upload_time = "2024-11-15T11:32:58.255Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/e5/39100f72f8ba70bec1bd329efc880dea8b6c1765ea1cb9d0c1c5f18b8d7f/ruff-0.7.4-py3-none-musllinux_1_2_i686.whl", hash = "sha256:662a63b4971807623f6f90c1fb664613f67cc182dc4d991471c23c541fee62dd", size = 10803715, upload_time = "2024-11-15T11:33:00.88Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/89/40e904784f305fb56850063f70a998a64ebba68796d823dde67e89a24691/ruff-0.7.4-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:876f5e09eaae3eb76814c1d3b68879891d6fde4824c015d48e7a7da4cf066a3a", size = 11162912, upload_time = "2024-11-15T11:33:03.097Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/1b/dd77503b3875c51e3dbc053fd8367b845ab8b01c9ca6d0c237082732856c/ruff-0.7.4-py3-none-win32.whl", hash = "sha256:75c53f54904be42dd52a548728a5b572344b50d9b2873d13a3f8c5e3b91f5cac", size = 8702767, upload_time = "2024-11-15T11:33:05.15Z" },
+    { url = "https://files.pythonhosted.org/packages/63/76/253ddc3e89e70165bba952ecca424b980b8d3c2598ceb4fc47904f424953/ruff-0.7.4-py3-none-win_amd64.whl", hash = "sha256:745775c7b39f914238ed1f1b0bebed0b9155a17cd8bc0b08d3c87e4703b990d6", size = 9497534, upload_time = "2024-11-15T11:33:07.359Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/70/f8724f31abc0b329ca98b33d73c14020168babcf71b0cba3cded5d9d0e66/ruff-0.7.4-py3-none-win_arm64.whl", hash = "sha256:11bff065102c3ae9d3ea4dc9ecdfe5a5171349cdd0787c1fc64761212fc9cf1f", size = 8851590, upload_time = "2024-11-15T11:33:09.664Z" },
 ]
 
 [[package]]
 name = "setuptools"
 version = "75.5.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c8/db/722a42ffdc226e950c4757b3da7b56ff5c090bb265dccd707f7b8a3c6fee/setuptools-75.5.0.tar.gz", hash = "sha256:5c4ccb41111392671f02bb5f8436dfc5a9a7185e80500531b133f5775c4163ef", size = 1336032 }
+sdist = { url = "https://files.pythonhosted.org/packages/c8/db/722a42ffdc226e950c4757b3da7b56ff5c090bb265dccd707f7b8a3c6fee/setuptools-75.5.0.tar.gz", hash = "sha256:5c4ccb41111392671f02bb5f8436dfc5a9a7185e80500531b133f5775c4163ef", size = 1336032, upload_time = "2024-11-13T11:22:07.199Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fe/df/88ccbee85aefbca071db004fdc8f8d2507d55d5a9dc27ebb93c92edb1bd8/setuptools-75.5.0-py3-none-any.whl", hash = "sha256:87cb777c3b96d638ca02031192d40390e0ad97737e27b6b4fa831bea86f2f829", size = 1222710 },
+    { url = "https://files.pythonhosted.org/packages/fe/df/88ccbee85aefbca071db004fdc8f8d2507d55d5a9dc27ebb93c92edb1bd8/setuptools-75.5.0-py3-none-any.whl", hash = "sha256:87cb777c3b96d638ca02031192d40390e0ad97737e27b6b4fa831bea86f2f829", size = 1222710, upload_time = "2024-11-13T11:22:04.978Z" },
 ]
 
 [[package]]
@@ -756,18 +767,18 @@ dependencies = [
     { name = "packaging" },
     { name = "setuptools" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4f/a4/00a9ac1b555294710d4a68d2ce8dfdf39d72aa4d769a7395d05218d88a42/setuptools_scm-8.1.0.tar.gz", hash = "sha256:42dea1b65771cba93b7a515d65a65d8246e560768a66b9106a592c8e7f26c8a7", size = 76465 }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/a4/00a9ac1b555294710d4a68d2ce8dfdf39d72aa4d769a7395d05218d88a42/setuptools_scm-8.1.0.tar.gz", hash = "sha256:42dea1b65771cba93b7a515d65a65d8246e560768a66b9106a592c8e7f26c8a7", size = 76465, upload_time = "2024-05-06T15:07:56.934Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/b9/1906bfeb30f2fc13bb39bf7ddb8749784c05faadbd18a21cf141ba37bff2/setuptools_scm-8.1.0-py3-none-any.whl", hash = "sha256:897a3226a6fd4a6eb2f068745e49733261a21f70b1bb28fce0339feb978d9af3", size = 43666 },
+    { url = "https://files.pythonhosted.org/packages/a0/b9/1906bfeb30f2fc13bb39bf7ddb8749784c05faadbd18a21cf141ba37bff2/setuptools_scm-8.1.0-py3-none-any.whl", hash = "sha256:897a3226a6fd4a6eb2f068745e49733261a21f70b1bb28fce0339feb978d9af3", size = 43666, upload_time = "2024-05-06T15:07:55.071Z" },
 ]
 
 [[package]]
 name = "six"
 version = "1.16.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/71/39/171f1c67cd00715f190ba0b100d606d440a28c93c7714febeca8b79af85e/six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926", size = 34041 }
+sdist = { url = "https://files.pythonhosted.org/packages/71/39/171f1c67cd00715f190ba0b100d606d440a28c93c7714febeca8b79af85e/six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926", size = 34041, upload_time = "2021-05-05T14:18:18.379Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254", size = 11053 },
+    { url = "https://files.pythonhosted.org/packages/d9/5a/e7c31adbe875f2abbb91bd84cf2dc52d792b5a01506781dbcf25c91daf11/six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254", size = 11053, upload_time = "2021-05-05T14:18:17.237Z" },
 ]
 
 [[package]]
@@ -785,9 +796,9 @@ dependencies = [
     { name = "pyproject-api" },
     { name = "virtualenv" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1f/86/32b10f91b4b975a37ac402b0f9fa016775088e0565c93602ba0b3c729ce8/tox-4.23.2.tar.gz", hash = "sha256:86075e00e555df6e82e74cfc333917f91ecb47ffbc868dcafbd2672e332f4a2c", size = 189998 }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/86/32b10f91b4b975a37ac402b0f9fa016775088e0565c93602ba0b3c729ce8/tox-4.23.2.tar.gz", hash = "sha256:86075e00e555df6e82e74cfc333917f91ecb47ffbc868dcafbd2672e332f4a2c", size = 189998, upload_time = "2024-10-22T14:29:04.46Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/af/c0/124b73d01c120e917383bc6c53ebc34efdf7243faa9fca64d105c94cf2ab/tox-4.23.2-py3-none-any.whl", hash = "sha256:452bc32bb031f2282881a2118923176445bac783ab97c874b8770ab4c3b76c38", size = 166758 },
+    { url = "https://files.pythonhosted.org/packages/af/c0/124b73d01c120e917383bc6c53ebc34efdf7243faa9fca64d105c94cf2ab/tox-4.23.2-py3-none-any.whl", hash = "sha256:452bc32bb031f2282881a2118923176445bac783ab97c874b8770ab4c3b76c38", size = 166758, upload_time = "2024-10-22T14:29:02.087Z" },
 ]
 
 [[package]]
@@ -797,9 +808,9 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "tox" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5b/a1/3e7b3185031f905ddfc0c65dfd85949dae612a4387cbacb286b9f2931314/tox-gh-actions-3.2.0.tar.gz", hash = "sha256:ac6fa3b8da51bc90dd77985fd55f09e746c6558c55910c0a93d643045a2b0ccc", size = 18834 }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/a1/3e7b3185031f905ddfc0c65dfd85949dae612a4387cbacb286b9f2931314/tox-gh-actions-3.2.0.tar.gz", hash = "sha256:ac6fa3b8da51bc90dd77985fd55f09e746c6558c55910c0a93d643045a2b0ccc", size = 18834, upload_time = "2024-01-03T13:58:36.114Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/7a/d59f4eb08d156787af19fb44371586fd8b25580a1837ce92ae203a847c49/tox_gh_actions-3.2.0-py2.py3-none-any.whl", hash = "sha256:821b66a4751a788fa3e9617bd796d696507b08c6e1d929ee4faefba06b73b694", size = 9951 },
+    { url = "https://files.pythonhosted.org/packages/b9/7a/d59f4eb08d156787af19fb44371586fd8b25580a1837ce92ae203a847c49/tox_gh_actions-3.2.0-py2.py3-none-any.whl", hash = "sha256:821b66a4751a788fa3e9617bd796d696507b08c6e1d929ee4faefba06b73b694", size = 9951, upload_time = "2024-01-03T13:58:33.77Z" },
 ]
 
 [[package]]
@@ -811,52 +822,52 @@ dependencies = [
     { name = "tox" },
     { name = "uv" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ed/5e/c3d2a45ab5465dddbbc267a589c9cfce23b91750d49af10738a08c98534e/tox_uv-1.16.0.tar.gz", hash = "sha256:71b2e2fa6c35c1360b91a302df1d65b3e5a1f656b321c5ebf7b84545804c9f01", size = 16337 }
+sdist = { url = "https://files.pythonhosted.org/packages/ed/5e/c3d2a45ab5465dddbbc267a589c9cfce23b91750d49af10738a08c98534e/tox_uv-1.16.0.tar.gz", hash = "sha256:71b2e2fa6c35c1360b91a302df1d65b3e5a1f656b321c5ebf7b84545804c9f01", size = 16337, upload_time = "2024-10-30T17:47:56.39Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ad/8d/1baa9f725ddd4824708759cf7b74bc43379f5f7feb079fde0629d7b32b3e/tox_uv-1.16.0-py3-none-any.whl", hash = "sha256:e6f0b525a687e745ab878d07cbf5c7e85d582028d4a7c8935f95e84350651432", size = 13661 },
+    { url = "https://files.pythonhosted.org/packages/ad/8d/1baa9f725ddd4824708759cf7b74bc43379f5f7feb079fde0629d7b32b3e/tox_uv-1.16.0-py3-none-any.whl", hash = "sha256:e6f0b525a687e745ab878d07cbf5c7e85d582028d4a7c8935f95e84350651432", size = 13661, upload_time = "2024-10-30T17:47:54.893Z" },
 ]
 
 [[package]]
 name = "typing-extensions"
 version = "4.12.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/df/db/f35a00659bc03fec321ba8bce9420de607a1d37f8342eee1863174c69557/typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8", size = 85321 }
+sdist = { url = "https://files.pythonhosted.org/packages/df/db/f35a00659bc03fec321ba8bce9420de607a1d37f8342eee1863174c69557/typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8", size = 85321, upload_time = "2024-06-07T18:52:15.995Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d", size = 37438 },
+    { url = "https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d", size = 37438, upload_time = "2024-06-07T18:52:13.582Z" },
 ]
 
 [[package]]
 name = "urllib3"
 version = "2.2.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ed/63/22ba4ebfe7430b76388e7cd448d5478814d3032121827c12a2cc287e2260/urllib3-2.2.3.tar.gz", hash = "sha256:e7d814a81dad81e6caf2ec9fdedb284ecc9c73076b62654547cc64ccdcae26e9", size = 300677 }
+sdist = { url = "https://files.pythonhosted.org/packages/ed/63/22ba4ebfe7430b76388e7cd448d5478814d3032121827c12a2cc287e2260/urllib3-2.2.3.tar.gz", hash = "sha256:e7d814a81dad81e6caf2ec9fdedb284ecc9c73076b62654547cc64ccdcae26e9", size = 300677, upload_time = "2024-09-12T10:52:18.401Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/d9/5f4c13cecde62396b0d3fe530a50ccea91e7dfc1ccf0e09c228841bb5ba8/urllib3-2.2.3-py3-none-any.whl", hash = "sha256:ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac", size = 126338 },
+    { url = "https://files.pythonhosted.org/packages/ce/d9/5f4c13cecde62396b0d3fe530a50ccea91e7dfc1ccf0e09c228841bb5ba8/urllib3-2.2.3-py3-none-any.whl", hash = "sha256:ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac", size = 126338, upload_time = "2024-09-12T10:52:16.589Z" },
 ]
 
 [[package]]
 name = "uv"
 version = "0.5.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/13/51/985549772d9c76d18b99ab188afe2aaa7a9afd948b97a03d7061e4716798/uv-0.5.2.tar.gz", hash = "sha256:89e60ad9601f35f187326de84f35e7517c6eb1438359da42ec85cfd9c1895957", size = 2174112 }
+sdist = { url = "https://files.pythonhosted.org/packages/13/51/985549772d9c76d18b99ab188afe2aaa7a9afd948b97a03d7061e4716798/uv-0.5.2.tar.gz", hash = "sha256:89e60ad9601f35f187326de84f35e7517c6eb1438359da42ec85cfd9c1895957", size = 2174112, upload_time = "2024-11-14T22:22:29.299Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/59/e8/542ef2ce56366f550f1cb93c1d4fd75bdfda440be56e8e99303f694193ce/uv-0.5.2-py3-none-linux_armv6l.whl", hash = "sha256:7bde66f13571e437fd45f32f5742ab53d5e011b4edb1c74cb74cb8b1cbb828b5", size = 13639242 },
-    { url = "https://files.pythonhosted.org/packages/f7/5e/dfa65e7e0dd0db9e7b258b15e2cc5109a89c5a61939cff8a4772e1dd8478/uv-0.5.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:d0834c6b37750c045bbea80600d3ae3e95becc4db148f5c0d0bc3ec6a7924e8f", size = 13610178 },
-    { url = "https://files.pythonhosted.org/packages/24/e0/f468ea89d85fb4c7a442b999d6fc1a5ef32e6fa3c872e471f0a1ba856069/uv-0.5.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a8a9897dd7657258c53f41aecdbe787da99f4fc0775f19826ab65cc0a7136cbf", size = 12658718 },
-    { url = "https://files.pythonhosted.org/packages/12/46/4239d5dc97d6d292256baef0750c69f19ef427febcbbb4ab20b4b5a1a49b/uv-0.5.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:15c7ffa08ae21abd221dbdf9ba25c8969235f587cec6df8035552434e5ca1cc5", size = 12938603 },
-    { url = "https://files.pythonhosted.org/packages/7c/c5/71d05e9ca73ddbf83fb320105bdf966bab9e5d04d3708f58f8daea8d94a0/uv-0.5.2-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d1fe4e025dbb9ec5c9250bfc1231847b8487706538f94d10c769f0a54db3e0af", size = 13438355 },
-    { url = "https://files.pythonhosted.org/packages/76/ec/d6811c51f02f8426610468639d7c0f7bce50854e22491e6fd43dc6197003/uv-0.5.2-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cfba5b0070652da4174083b78852f3ab3d262ba1c8b63a4d5ae497263b02b834", size = 13997533 },
-    { url = "https://files.pythonhosted.org/packages/03/b5/bafafe3132e2fdfde3a0931f5fbb0116fbd761bf813cc260a4672ff6fa2e/uv-0.5.2-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:dfcd8275ff8cb59d5f26f826a44270b2fe8f38aa7188d7355c48d3e9b759d0c0", size = 14586163 },
-    { url = "https://files.pythonhosted.org/packages/8d/69/685fdaa80434d680248e588e339bce08251167fcdd008ee384669cd7e507/uv-0.5.2-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:71467545d51883d1af7094c8f6da69b55e7d49b742c2dc707d644676dcb66515", size = 14481327 },
-    { url = "https://files.pythonhosted.org/packages/67/84/525f395051bf753a92509a0b19b8410017417e96705645a00b3554da3aa6/uv-0.5.2-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5052758d374dd769efd0c70b4789ffb08439567eb114ad8fe728536bb5cc5299", size = 18609412 },
-    { url = "https://files.pythonhosted.org/packages/82/ce/11fe4448173570b9a4ac09a5b21b6b2d90d455ce454c3e344e5fcd8b3430/uv-0.5.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:374e9498e155fcaa8728a6770b84f03781106d705332f4ec059e1cc93c8f4d8a", size = 14156364 },
-    { url = "https://files.pythonhosted.org/packages/44/4f/27fb79bf0300d110e9d9bf6ae31ffad516f6af9fca8a518208c9b71d1093/uv-0.5.2-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:675ca34829ceca3e9de395cf05e8f881334a24488f97dd923c463830270d52a7", size = 13132200 },
-    { url = "https://files.pythonhosted.org/packages/a3/ff/a25a9619201857cd3f6a2012d5d49ef9cfc76cd8b426f941b3c709c124c0/uv-0.5.2-py3-none-musllinux_1_1_armv7l.whl", hash = "sha256:c9795b990fb0b2a18d3a8cef8822e13c6a6f438bc16d34ccf01d931c76cfd5da", size = 13421241 },
-    { url = "https://files.pythonhosted.org/packages/fc/ea/e3b6fe349a63069f2724a8f5992e3d7da0eade867f9b5f6470afd8512046/uv-0.5.2-py3-none-musllinux_1_1_i686.whl", hash = "sha256:27d666da8fbb0f87d9df67abf9feea0da4ee1336730f2c4be29a11f3feaa0a29", size = 13787663 },
-    { url = "https://files.pythonhosted.org/packages/b9/ed/6bf3b02e5672b9e4f4c9acfc9d92cd114572ce7d5ae458c423ab849e3738/uv-0.5.2-py3-none-musllinux_1_1_ppc64le.whl", hash = "sha256:67776d34cba359c63919c5ad50331171261d2ec7a83fd07f032eb8cc22e22b8e", size = 15529195 },
-    { url = "https://files.pythonhosted.org/packages/19/29/41fd2928e79d343d7009b92028df868d13307f365949a9649d5fff9c11d7/uv-0.5.2-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:772b32d157ec8f27c0099ecac94cf5cd298bce72f1a1f512205591de4e9f0c5c", size = 14277293 },
-    { url = "https://files.pythonhosted.org/packages/3b/ba/bf58db3f3520c18fd7dc43cc302432bd49dc4a20a612cda587756f9fb035/uv-0.5.2-py3-none-win32.whl", hash = "sha256:2597e91be45b3f4458d0d16a5a1cda7e93af7d6dbfddf251aae5377f9187fa88", size = 13541309 },
-    { url = "https://files.pythonhosted.org/packages/55/84/ab10b46e0523aa8ea290798ec7ca4dde339601697d2319d19564c3552b34/uv-0.5.2-py3-none-win_amd64.whl", hash = "sha256:a4d4fdad03e6dc3e8216192b8a12bcf2c71c8b12046e755575c7f262cbb61924", size = 15323473 },
+    { url = "https://files.pythonhosted.org/packages/59/e8/542ef2ce56366f550f1cb93c1d4fd75bdfda440be56e8e99303f694193ce/uv-0.5.2-py3-none-linux_armv6l.whl", hash = "sha256:7bde66f13571e437fd45f32f5742ab53d5e011b4edb1c74cb74cb8b1cbb828b5", size = 13639242, upload_time = "2024-11-14T22:21:36.826Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/5e/dfa65e7e0dd0db9e7b258b15e2cc5109a89c5a61939cff8a4772e1dd8478/uv-0.5.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:d0834c6b37750c045bbea80600d3ae3e95becc4db148f5c0d0bc3ec6a7924e8f", size = 13610178, upload_time = "2024-11-14T22:21:40.059Z" },
+    { url = "https://files.pythonhosted.org/packages/24/e0/f468ea89d85fb4c7a442b999d6fc1a5ef32e6fa3c872e471f0a1ba856069/uv-0.5.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a8a9897dd7657258c53f41aecdbe787da99f4fc0775f19826ab65cc0a7136cbf", size = 12658718, upload_time = "2024-11-14T22:21:43.07Z" },
+    { url = "https://files.pythonhosted.org/packages/12/46/4239d5dc97d6d292256baef0750c69f19ef427febcbbb4ab20b4b5a1a49b/uv-0.5.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:15c7ffa08ae21abd221dbdf9ba25c8969235f587cec6df8035552434e5ca1cc5", size = 12938603, upload_time = "2024-11-14T22:21:46.345Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/c5/71d05e9ca73ddbf83fb320105bdf966bab9e5d04d3708f58f8daea8d94a0/uv-0.5.2-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d1fe4e025dbb9ec5c9250bfc1231847b8487706538f94d10c769f0a54db3e0af", size = 13438355, upload_time = "2024-11-14T22:21:49.13Z" },
+    { url = "https://files.pythonhosted.org/packages/76/ec/d6811c51f02f8426610468639d7c0f7bce50854e22491e6fd43dc6197003/uv-0.5.2-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cfba5b0070652da4174083b78852f3ab3d262ba1c8b63a4d5ae497263b02b834", size = 13997533, upload_time = "2024-11-14T22:21:52.32Z" },
+    { url = "https://files.pythonhosted.org/packages/03/b5/bafafe3132e2fdfde3a0931f5fbb0116fbd761bf813cc260a4672ff6fa2e/uv-0.5.2-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:dfcd8275ff8cb59d5f26f826a44270b2fe8f38aa7188d7355c48d3e9b759d0c0", size = 14586163, upload_time = "2024-11-14T22:21:55.01Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/69/685fdaa80434d680248e588e339bce08251167fcdd008ee384669cd7e507/uv-0.5.2-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:71467545d51883d1af7094c8f6da69b55e7d49b742c2dc707d644676dcb66515", size = 14481327, upload_time = "2024-11-14T22:21:57.685Z" },
+    { url = "https://files.pythonhosted.org/packages/67/84/525f395051bf753a92509a0b19b8410017417e96705645a00b3554da3aa6/uv-0.5.2-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5052758d374dd769efd0c70b4789ffb08439567eb114ad8fe728536bb5cc5299", size = 18609412, upload_time = "2024-11-14T22:22:01.652Z" },
+    { url = "https://files.pythonhosted.org/packages/82/ce/11fe4448173570b9a4ac09a5b21b6b2d90d455ce454c3e344e5fcd8b3430/uv-0.5.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:374e9498e155fcaa8728a6770b84f03781106d705332f4ec059e1cc93c8f4d8a", size = 14156364, upload_time = "2024-11-14T22:22:04.266Z" },
+    { url = "https://files.pythonhosted.org/packages/44/4f/27fb79bf0300d110e9d9bf6ae31ffad516f6af9fca8a518208c9b71d1093/uv-0.5.2-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:675ca34829ceca3e9de395cf05e8f881334a24488f97dd923c463830270d52a7", size = 13132200, upload_time = "2024-11-14T22:22:07.55Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ff/a25a9619201857cd3f6a2012d5d49ef9cfc76cd8b426f941b3c709c124c0/uv-0.5.2-py3-none-musllinux_1_1_armv7l.whl", hash = "sha256:c9795b990fb0b2a18d3a8cef8822e13c6a6f438bc16d34ccf01d931c76cfd5da", size = 13421241, upload_time = "2024-11-14T22:22:11.335Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/ea/e3b6fe349a63069f2724a8f5992e3d7da0eade867f9b5f6470afd8512046/uv-0.5.2-py3-none-musllinux_1_1_i686.whl", hash = "sha256:27d666da8fbb0f87d9df67abf9feea0da4ee1336730f2c4be29a11f3feaa0a29", size = 13787663, upload_time = "2024-11-14T22:22:14.094Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/ed/6bf3b02e5672b9e4f4c9acfc9d92cd114572ce7d5ae458c423ab849e3738/uv-0.5.2-py3-none-musllinux_1_1_ppc64le.whl", hash = "sha256:67776d34cba359c63919c5ad50331171261d2ec7a83fd07f032eb8cc22e22b8e", size = 15529195, upload_time = "2024-11-14T22:22:17.407Z" },
+    { url = "https://files.pythonhosted.org/packages/19/29/41fd2928e79d343d7009b92028df868d13307f365949a9649d5fff9c11d7/uv-0.5.2-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:772b32d157ec8f27c0099ecac94cf5cd298bce72f1a1f512205591de4e9f0c5c", size = 14277293, upload_time = "2024-11-14T22:22:20.807Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/ba/bf58db3f3520c18fd7dc43cc302432bd49dc4a20a612cda587756f9fb035/uv-0.5.2-py3-none-win32.whl", hash = "sha256:2597e91be45b3f4458d0d16a5a1cda7e93af7d6dbfddf251aae5377f9187fa88", size = 13541309, upload_time = "2024-11-14T22:22:23.419Z" },
+    { url = "https://files.pythonhosted.org/packages/55/84/ab10b46e0523aa8ea290798ec7ca4dde339601697d2319d19564c3552b34/uv-0.5.2-py3-none-win_amd64.whl", hash = "sha256:a4d4fdad03e6dc3e8216192b8a12bcf2c71c8b12046e755575c7f262cbb61924", size = 15323473, upload_time = "2024-11-14T22:22:26.534Z" },
 ]
 
 [[package]]
@@ -868,18 +879,18 @@ dependencies = [
     { name = "filelock" },
     { name = "platformdirs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8c/b3/7b6a79c5c8cf6d90ea681310e169cf2db2884f4d583d16c6e1d5a75a4e04/virtualenv-20.27.1.tar.gz", hash = "sha256:142c6be10212543b32c6c45d3d3893dff89112cc588b7d0879ae5a1ec03a47ba", size = 6491145 }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/b3/7b6a79c5c8cf6d90ea681310e169cf2db2884f4d583d16c6e1d5a75a4e04/virtualenv-20.27.1.tar.gz", hash = "sha256:142c6be10212543b32c6c45d3d3893dff89112cc588b7d0879ae5a1ec03a47ba", size = 6491145, upload_time = "2024-10-28T18:00:22.706Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/92/78324ff89391e00c8f4cf6b8526c41c6ef36b4ea2d2c132250b1a6fc2b8d/virtualenv-20.27.1-py3-none-any.whl", hash = "sha256:f11f1b8a29525562925f745563bfd48b189450f61fb34c4f9cc79dd5aa32a1f4", size = 3117838 },
+    { url = "https://files.pythonhosted.org/packages/ae/92/78324ff89391e00c8f4cf6b8526c41c6ef36b4ea2d2c132250b1a6fc2b8d/virtualenv-20.27.1-py3-none-any.whl", hash = "sha256:f11f1b8a29525562925f745563bfd48b189450f61fb34c4f9cc79dd5aa32a1f4", size = 3117838, upload_time = "2024-10-28T18:00:19.994Z" },
 ]
 
 [[package]]
 name = "wcwidth"
 version = "0.2.13"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6c/63/53559446a878410fc5a5974feb13d31d78d752eb18aeba59c7fef1af7598/wcwidth-0.2.13.tar.gz", hash = "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5", size = 101301 }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/63/53559446a878410fc5a5974feb13d31d78d752eb18aeba59c7fef1af7598/wcwidth-0.2.13.tar.gz", hash = "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5", size = 101301, upload_time = "2024-01-06T02:10:57.829Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/84/fd2ba7aafacbad3c4201d395674fc6348826569da3c0937e75505ead3528/wcwidth-0.2.13-py2.py3-none-any.whl", hash = "sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859", size = 34166 },
+    { url = "https://files.pythonhosted.org/packages/fd/84/fd2ba7aafacbad3c4201d395674fc6348826569da3c0937e75505ead3528/wcwidth-0.2.13-py2.py3-none-any.whl", hash = "sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859", size = 34166, upload_time = "2024-01-06T02:10:55.763Z" },
 ]
 
 [[package]]
@@ -889,7 +900,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9f/69/83029f1f6300c5fb2471d621ab06f6ec6b3324685a2ce0f9777fd4a8b71e/werkzeug-3.1.3.tar.gz", hash = "sha256:60723ce945c19328679790e3282cc758aa4a6040e4bb330f53d30fa546d44746", size = 806925 }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/69/83029f1f6300c5fb2471d621ab06f6ec6b3324685a2ce0f9777fd4a8b71e/werkzeug-3.1.3.tar.gz", hash = "sha256:60723ce945c19328679790e3282cc758aa4a6040e4bb330f53d30fa546d44746", size = 806925, upload_time = "2024-11-08T15:52:18.093Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/52/24/ab44c871b0f07f491e5d2ad12c9bd7358e527510618cb1b803a88e986db1/werkzeug-3.1.3-py3-none-any.whl", hash = "sha256:54b78bf3716d19a65be4fceccc0d1d7b89e608834989dfae50ea87564639213e", size = 224498 },
+    { url = "https://files.pythonhosted.org/packages/52/24/ab44c871b0f07f491e5d2ad12c9bd7358e527510618cb1b803a88e986db1/werkzeug-3.1.3-py3-none-any.whl", hash = "sha256:54b78bf3716d19a65be4fceccc0d1d7b89e608834989dfae50ea87564639213e", size = 224498, upload_time = "2024-11-08T15:52:16.132Z" },
 ]


### PR DESCRIPTION
This PR adds simple disk-based caching using [diskcache](https://pypi.org/project/diskcache/). 

## Implementation

It is implemented as a transparent layer over the `mreg_cli.utils.api.get()` method, with an expiration time of 300 seconds. Results from `get()` are memoized and stored in the cache for a maximum of 300 seconds. Each time the user performs a write operation (i.e. POST, PUT, PATCH, DELETE), the cache is cleared. There is no granularity in the way items are stored in cache; all items are flushed if the user performs a write operation.

## Robustness

In case the cache cannot be initialized (lack of write privileges, sqlite errors, etc.), a dummy cache is instantiated, whose `memoize()` decorator simply returns the unmodified `get()` function. The most common cache methods (currently unused), are implemented as dummy methods with deterministic behavior compatible with the corresponding `diskcache.Cache` methods.

## Notes

Due to the relatively low frequency of writes compared to reads we witness, I deemed it acceptable to implement the cache in this all-or-nothing way. Trying to tag, set and delete cache items based on API operations would be a huge undertaking, while in practice yielding very few improvements over the current implementation. It would very likely also make the API code entangled with the cache code in a way that the current decorator-based approach does not.