### PR TITLE
Format and lint snapshots with ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,9 @@ include = ["mreg_cli*"]
 [tool.black]
 max-line-length = 99
 
+[tool.inline-snapshot]
+format-command = "ruff check --fix-only --stdin-filename {filename} | ruff format --stdin-filename {filename}"
+
 [tool.isort]
 profile = "black"
 line_length = 99


### PR DESCRIPTION
Adds formatting and linting of snapshots with Ruff, per the recipe in the [inline-snapshot docs](https://15r10nk.github.io/inline-snapshot/latest/configuration/#__tabbed_1_2).

I already used this configuration locally for these snapshots:

https://github.com/unioslo/mreg-cli/blob/d74f1a1780e1eaf23eff2bb25aa4633d93bec6e3/tests/test_cache.py#L118-L127
https://github.com/unioslo/mreg-cli/blob/d74f1a1780e1eaf23eff2bb25aa4633d93bec6e3/tests/test_cache.py#L135-L144