### PR TITLE
Add `@disable_cache` decorator, don't cache `help` commands

### DIFF
--- a/mreg_cli/commands/help.py
+++ b/mreg_cli/commands/help.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from mreg_cli.__about__ import __version__ as mreg_cli_version
 from mreg_cli.api.models import HealthInfo, ServerLibraries, ServerVersion, UserInfo
+from mreg_cli.cache import disable_cache
 from mreg_cli.commands.base import BaseCommand
 from mreg_cli.commands.registry import CommandRegistry
 from mreg_cli.config import MregCliConfig
@@ -91,6 +92,7 @@ def configuration_help(_: argparse.Namespace) -> None:
     description="Show versions of client and server as much as possible",
     short_desc="Show versions",
 )
+@disable_cache
 def versions_help(_: argparse.Namespace) -> None:
     """Show versions of client and server as much as possible."""
     output_manager = OutputManager()
@@ -108,6 +110,7 @@ def versions_help(_: argparse.Namespace) -> None:
         Flag("-django", action="store_true", description="Show Django internal roles"),
     ],
 )
+@disable_cache
 def whoami_help(args: argparse.Namespace) -> None:
     """Show information about the current user."""
     try:
@@ -127,6 +130,7 @@ def whoami_help(args: argparse.Namespace) -> None:
         Flag("-django", action="store_true", description="Show Django internal roles"),
     ],
 )
+@disable_cache
 def whois_help(args: argparse.Namespace) -> None:
     """Show information about a user."""
     try:
@@ -140,6 +144,7 @@ def whois_help(args: argparse.Namespace) -> None:
     description="Show information about the health of the server",
     short_desc="Show health info",
 )
+@disable_cache
 def meta_health(_: argparse.Namespace) -> None:
     """Show information about the health of the server."""
     try:


### PR DESCRIPTION
This PR adds a `@disable_cache` decorator which can be added to functions to temporarily disable the program-wide cache when calling the function. The decorator has been applied to all `help` commands that make API calls to ensure these always return fresh data.

## Implementation

It works by unpatching all patched functions (but without clearing the cache!), and then re-patching the functions once the decorated function has executed. This was the simplest implementation that I could come up with, as diskcache does not expose an API for toggling caching on/off for memoized functions. However, the good news is that this implementation has _very_ minimal overhead:

```
super@mreg-dev.uio.no> help health
Took 0.080041 ms to disable cache
Health Information:
  Uptime: 18 days, 3:06:56
  LDAP: OK
super@mreg-dev.uio.no> help health
Took 0.031417 ms to disable cache
Health Information:
  Uptime: 18 days, 3:07:04
  LDAP: OK
super@mreg-dev.uio.no> help health
Took 0.042958 ms to disable cache
Health Information:
  Uptime: 18 days, 3:07:06
  LDAP: OK
```

<details>
  <summary>Modified code with <code>time.perf_counter_ns</code></summary>
  
  ```python
def disable_cache(func: Callable[P, T]) -> Callable[P, T]:
    """Disable cache for the duration of the decorated function."""

    @functools.wraps(func)
    def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
        cache = get_cache()
        try:
            start_time = time.perf_counter_ns()
            cache.disable(clear=False)
            stop_time = time.perf_counter_ns()
            print(f"Took {(stop_time - start_time) / 1_000_000} ms to disable cache")
            return func(*args, **kwargs)
        finally:
            cache.enable()

    return wrapper
```

</details>