### PR TITLE
Upgrade mreg-api to 0.2.0

### DIFF
--- a/mreg_cli/commands/group.py
+++ b/mreg_cli/commands/group.py
@@ -41,7 +41,7 @@ def create(args: argparse.Namespace) -> None:
     :param args: argparse.Namespace (name, description)
     """
     HostGroup.get_by_field_and_raise("name", args.name)
-    newgroup = HostGroup.create(params={"name": args.name, "description": args.description})
+    newgroup = HostGroup.create(data={"name": args.name, "description": args.description})
     if not newgroup:
         raise CreateError("Failed to create new group '{args.name}'")
 

--- a/mreg_cli/commands/host_submodules/a_aaaa.py
+++ b/mreg_cli/commands/host_submodules/a_aaaa.py
@@ -141,7 +141,7 @@ def _ip_change(name: str, old: str, new: str, force: bool, ipversion: IP_Version
 
     check_ip_constraints(new_ip, network, host, IPOperation.CHANGE, force)
 
-    host_ip.patch(fields={"ipaddress": str(new_ip)})
+    host_ip.patch(data={"ipaddress": str(new_ip)})
 
     OutputManager().add_ok(f"changed ip {old} to {new_ip} for {host}")
 
@@ -171,13 +171,13 @@ def _ip_move(ipaddr: str, fromhost: str, tohost: str, ipversion: IP_Version) -> 
 
     msg = ""
     if host_ip:
-        host_ip.patch(fields={"host": to_host.id})
+        host_ip.patch(data={"host": to_host.id})
         msg = f"Moved ipaddress {ipaddr}"
     else:
         msg += "No ipaddresses matched. "
 
     if ptr:
-        ptr.patch(fields={"host": to_host.id})
+        ptr.patch(data={"host": to_host.id})
         msg += "Moved PTR override."
 
     OutputManager().add_line(msg)

--- a/mreg_cli/commands/host_submodules/bacnet.py
+++ b/mreg_cli/commands/host_submodules/bacnet.py
@@ -52,7 +52,7 @@ def bacnetid_add(args: argparse.Namespace) -> None:
             f"BACnet ID {existing.id} is already in use by {existing.hostname}."
         )
 
-    BacnetID.create(params={"hostname": host.name, "id": args.id})
+    BacnetID.create(data={"hostname": host.name, "id": args.id})
 
     validator = BacnetID.get(args.id)
     if validator and validator.hostname == host.name:

--- a/mreg_cli/commands/host_submodules/cname.py
+++ b/mreg_cli/commands/host_submodules/cname.py
@@ -66,7 +66,7 @@ def cname_add(args: argparse.Namespace) -> None:
     if not zone:
         raise EntityNotFound(f"Could not find a zone for the alias {alias}.")
 
-    CNAME.create(params={"host": str(host.id), "name": alias})
+    CNAME.create(data={"host": str(host.id), "name": alias})
     cname = CNAME.get_by_host_and_name(host.name, alias)
 
     if cname:

--- a/mreg_cli/commands/host_submodules/rr.py
+++ b/mreg_cli/commands/host_submodules/rr.py
@@ -363,7 +363,7 @@ def naptr_add(args: argparse.Namespace) -> None:
     existing_naptr = NAPTR.get_by_query_unique(params)
     if existing_naptr:
         raise EntityAlreadyExists(f"{host} already has that NAPTR defined.")
-    NAPTR.create(params=params)
+    NAPTR.create(data=params)
     OutputManager().add_ok(f"Added NAPTR record to {host.name}.")
 
 

--- a/mreg_cli/commands/permission.py
+++ b/mreg_cli/commands/permission.py
@@ -117,7 +117,7 @@ def network_add(args: argparse.Namespace) -> None:
     }
 
     Permission.get_by_query_unique_and_raise(query)
-    Permission.create(params=query)
+    Permission.create(data=query)
     OutputManager().add_ok(f"Added permission to {args.range}")
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "platformdirs>=4.3.0",
     "pydantic-settings>=2.10.1",
     "rich>=13.9.4",
-    "mreg-api>=0.1.5",
+    "mreg-api>=0.2.0,<0.3.0",      # prevent breaking changes in pre-1.0.0 minor versions
 ]
 dynamic = ["version"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -263,7 +263,7 @@ wheels = [
 
 [[package]]
 name = "mreg-api"
-version = "0.1.5"
+version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "diskcache" },
@@ -273,9 +273,9 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/46/87/512138ecc3b32c90b50acfb2a804f13f744f78daf57648b04e42e194fe40/mreg_api-0.1.5.tar.gz", hash = "sha256:da34d26b9b381e7890833bc81c2660db0a4d6bf88fdbf0fa17ad3a2ddec8b64e", size = 153605, upload-time = "2026-03-26T13:10:11.978Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5d/e8/2577d1d9b37fe6da434ce0341d4ee9c9ef89fa9b1c86619d8ad8210f8ad2/mreg_api-0.2.0.tar.gz", hash = "sha256:4bbfcca6eaff604407a1c593aff54a840dfab49eb0597926ff24eb03b6185c81", size = 154556, upload-time = "2026-04-16T10:40:58.927Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/13/7d2ef5a6c4ab7bea3e693ccce9f1c18eba065a14c2147502c1d1a443936e/mreg_api-0.1.5-py3-none-any.whl", hash = "sha256:22e34c9377ad55843dad7d6dea412d81ff7a6065d478d1f6399906dfc4c9f151", size = 84182, upload-time = "2026-03-26T13:10:10.245Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/6f/e9bd687a8b99aa3636278926ad15924b8f8ff84306788a45861bde301078/mreg_api-0.2.0-py3-none-any.whl", hash = "sha256:1266cfdb2460616a9ed7b5e8b39bbaa038f89e253a400b7f28bbd18efa66543c", size = 84334, upload-time = "2026-04-16T10:40:57.365Z" },
 ]
 
 [[package]]
@@ -318,7 +318,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mreg-api", specifier = ">=0.1.5" },
+    { name = "mreg-api", specifier = ">=0.2.0,<0.3.0" },
     { name = "platformdirs", specifier = ">=4.3.0" },
     { name = "prompt-toolkit", specifier = ">=3.0.0" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.7.1" },


### PR DESCRIPTION
Upgrades to the new more consistent `params` and `data` parameter names for `APIMixin` methods introduced in mreg-api 0.2.0.