### PR TITLE
Add IP output to `host find`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- `host find` now shows IP address(es) for each host.
 
 ## [1.9.0](https://github.com/unioslo/mreg-cli/releases/tag/1.9.0) - 2026-04-14
 

--- a/ci/testsuite-result.json
+++ b/ci/testsuite-result.json
@@ -23251,8 +23251,8 @@
     "warning": [],
     "error": [],
     "output": [
-      "Name                 Contact              Comment",
-      "foo.example.org      hi@ho.com            meh"
+      "Name                 Contact              IP                   Comment",
+      "foo.example.org      hi@ho.com            10.0.0.10            meh"
     ],
     "api_requests": [
       {
@@ -23269,8 +23269,8 @@
               "ipaddresses": [
                 {
                   "macaddress": "11:22:33:aa:bb:cc",
-                  "created_at": "2025-12-18T11:57:42.249661+01:00",
-                  "updated_at": "2025-12-18T11:57:42.329996+01:00",
+                  "created_at": "2026-04-20T16:03:33.608920+02:00",
+                  "updated_at": "2026-04-20T16:03:34.121446+02:00",
                   "ipaddress": "10.0.0.10",
                   "host": 19
                 }
@@ -23279,8 +23279,8 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2025-12-18T11:57:42.230049+01:00",
-                  "updated_at": "2025-12-18T11:57:42.230056+01:00",
+                  "created_at": "2026-04-20T16:03:33.351245+02:00",
+                  "updated_at": "2026-04-20T16:03:33.351281+02:00",
                   "txt": "v=spf1 -all",
                   "host": 19
                 }
@@ -23298,12 +23298,12 @@
               "contacts": [
                 {
                   "email": "hi@ho.com",
-                  "created_at": "2025-12-18T11:57:42.232796+01:00",
-                  "updated_at": "2025-12-18T11:57:42.232806+01:00"
+                  "created_at": "2026-04-20T16:03:33.379144+02:00",
+                  "updated_at": "2026-04-20T16:03:33.379164+02:00"
                 }
               ],
-              "created_at": "2025-12-18T11:57:42.227827+01:00",
-              "updated_at": "2025-12-18T11:57:42.227837+01:00",
+              "created_at": "2026-04-20T16:03:33.328134+02:00",
+              "updated_at": "2026-04-20T16:03:33.328152+02:00",
               "name": "foo.example.org",
               "ttl": null,
               "comment": "meh",
@@ -23325,8 +23325,8 @@
     "warning": [],
     "error": [],
     "output": [
-      "Name                 Contact              Comment",
-      "foo.example.org      hi@ho.com            meh"
+      "Name                 Contact              IP                   Comment",
+      "foo.example.org      hi@ho.com            10.0.0.10            meh"
     ],
     "api_requests": [
       {
@@ -23343,8 +23343,8 @@
               "ipaddresses": [
                 {
                   "macaddress": "11:22:33:aa:bb:cc",
-                  "created_at": "2025-12-18T11:57:42.249661+01:00",
-                  "updated_at": "2025-12-18T11:57:42.329996+01:00",
+                  "created_at": "2026-04-20T16:03:33.608920+02:00",
+                  "updated_at": "2026-04-20T16:03:34.121446+02:00",
                   "ipaddress": "10.0.0.10",
                   "host": 19
                 }
@@ -23353,8 +23353,8 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2025-12-18T11:57:42.230049+01:00",
-                  "updated_at": "2025-12-18T11:57:42.230056+01:00",
+                  "created_at": "2026-04-20T16:03:33.351245+02:00",
+                  "updated_at": "2026-04-20T16:03:33.351281+02:00",
                   "txt": "v=spf1 -all",
                   "host": 19
                 }
@@ -23372,12 +23372,12 @@
               "contacts": [
                 {
                   "email": "hi@ho.com",
-                  "created_at": "2025-12-18T11:57:42.232796+01:00",
-                  "updated_at": "2025-12-18T11:57:42.232806+01:00"
+                  "created_at": "2026-04-20T16:03:33.379144+02:00",
+                  "updated_at": "2026-04-20T16:03:33.379164+02:00"
                 }
               ],
-              "created_at": "2025-12-18T11:57:42.227827+01:00",
-              "updated_at": "2025-12-18T11:57:42.227837+01:00",
+              "created_at": "2026-04-20T16:03:33.328134+02:00",
+              "updated_at": "2026-04-20T16:03:33.328152+02:00",
               "name": "foo.example.org",
               "ttl": null,
               "comment": "meh",
@@ -23399,8 +23399,8 @@
     "warning": [],
     "error": [],
     "output": [
-      "Name                 Contact              Comment",
-      "foo.example.org      hi@ho.com            meh"
+      "Name                 Contact              IP                   Comment",
+      "foo.example.org      hi@ho.com            10.0.0.10            meh"
     ],
     "api_requests": [
       {
@@ -23417,8 +23417,8 @@
               "ipaddresses": [
                 {
                   "macaddress": "11:22:33:aa:bb:cc",
-                  "created_at": "2025-12-18T11:57:42.249661+01:00",
-                  "updated_at": "2025-12-18T11:57:42.329996+01:00",
+                  "created_at": "2026-04-20T16:03:33.608920+02:00",
+                  "updated_at": "2026-04-20T16:03:34.121446+02:00",
                   "ipaddress": "10.0.0.10",
                   "host": 19
                 }
@@ -23427,8 +23427,8 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2025-12-18T11:57:42.230049+01:00",
-                  "updated_at": "2025-12-18T11:57:42.230056+01:00",
+                  "created_at": "2026-04-20T16:03:33.351245+02:00",
+                  "updated_at": "2026-04-20T16:03:33.351281+02:00",
                   "txt": "v=spf1 -all",
                   "host": 19
                 }
@@ -23446,12 +23446,12 @@
               "contacts": [
                 {
                   "email": "hi@ho.com",
-                  "created_at": "2025-12-18T11:57:42.232796+01:00",
-                  "updated_at": "2025-12-18T11:57:42.232806+01:00"
+                  "created_at": "2026-04-20T16:03:33.379144+02:00",
+                  "updated_at": "2026-04-20T16:03:33.379164+02:00"
                 }
               ],
-              "created_at": "2025-12-18T11:57:42.227827+01:00",
-              "updated_at": "2025-12-18T11:57:42.227837+01:00",
+              "created_at": "2026-04-20T16:03:33.328134+02:00",
+              "updated_at": "2026-04-20T16:03:33.328152+02:00",
               "name": "foo.example.org",
               "ttl": null,
               "comment": "meh",
@@ -23473,8 +23473,8 @@
     "warning": [],
     "error": [],
     "output": [
-      "Name                 Contact              Comment",
-      "foo.example.org      hi@ho.com            meh"
+      "Name                 Contact              IP                   Comment",
+      "foo.example.org      hi@ho.com            10.0.0.10            meh"
     ],
     "api_requests": [
       {
@@ -23491,8 +23491,8 @@
               "ipaddresses": [
                 {
                   "macaddress": "11:22:33:aa:bb:cc",
-                  "created_at": "2025-12-18T11:57:42.249661+01:00",
-                  "updated_at": "2025-12-18T11:57:42.329996+01:00",
+                  "created_at": "2026-04-20T16:03:33.608920+02:00",
+                  "updated_at": "2026-04-20T16:03:34.121446+02:00",
                   "ipaddress": "10.0.0.10",
                   "host": 19
                 }
@@ -23501,8 +23501,8 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2025-12-18T11:57:42.230049+01:00",
-                  "updated_at": "2025-12-18T11:57:42.230056+01:00",
+                  "created_at": "2026-04-20T16:03:33.351245+02:00",
+                  "updated_at": "2026-04-20T16:03:33.351281+02:00",
                   "txt": "v=spf1 -all",
                   "host": 19
                 }
@@ -23520,12 +23520,12 @@
               "contacts": [
                 {
                   "email": "hi@ho.com",
-                  "created_at": "2025-12-18T11:57:42.232796+01:00",
-                  "updated_at": "2025-12-18T11:57:42.232806+01:00"
+                  "created_at": "2026-04-20T16:03:33.379144+02:00",
+                  "updated_at": "2026-04-20T16:03:33.379164+02:00"
                 }
               ],
-              "created_at": "2025-12-18T11:57:42.227827+01:00",
-              "updated_at": "2025-12-18T11:57:42.227837+01:00",
+              "created_at": "2026-04-20T16:03:33.328134+02:00",
+              "updated_at": "2026-04-20T16:03:33.328152+02:00",
               "name": "foo.example.org",
               "ttl": null,
               "comment": "meh",

--- a/mreg_cli/output/host.py
+++ b/mreg_cli/output/host.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import Literal
+from typing import Literal, NamedTuple
 
 from mreg_api import MregClient
 from mreg_api.endpoints import Endpoint
@@ -118,19 +118,42 @@ def output_hostlist(hostlist: HostList) -> None:
     if not hostlist.results:
         raise EntityNotFound("No hosts found.")
 
-    max_name = max_contact = 20
-    for i in hostlist.results:
-        max_name = max(max_name, len(str(i.name)))
-        max_contact = max(max_contact, max((len(c) for c in i.contact_emails), default=0))
+    max_name = max_contacts = max_ips = 20
 
-    def _format(name: str, contact: str, comment: str) -> None:
+    class HostOutput(NamedTuple):
+        name: str
+        contacts: str
+        comment: str
+        ips: str
+
+    hosts = [
+        HostOutput(
+            name=str(i.name),
+            contacts=", ".join(i.contact_emails),
+            comment=i.comment or "",
+            ips=", ".join(str(ip.ipaddress) for ip in i.ipaddresses),
+        )
+        for i in hostlist.results
+    ]
+    max_name = max(max_name, max(len(host.name) for host in hosts))
+    max_contacts = max(max_contacts, max(len(host.contacts) for host in hosts))
+    max_ips = max(max_ips, max(len(host.ips) for host in hosts))
+
+    def _format(name: str, contact: str, ips: str, comment: str) -> None:
         OutputManager().add_line(
-            "{0:<{1}} {2:<{3}} {4}".format(name, max_name, contact, max_contact, comment)
+            "{0:<{1}} {2:<{3}} {4:<{5}} {6}".format(
+                name, max_name, contact, max_contacts, ips, max_ips, comment
+            )
         )
 
-    _format("Name", "Contact", "Comment")
-    for i in hostlist.results:
-        _format(str(i.name), ", ".join(i.contact_emails), i.comment)
+    _format("Name", "Contact", "IP", "Comment")
+    for host in hosts:
+        _format(
+            name=host.name,
+            contact=host.contacts,
+            ips=host.ips,
+            comment=host.comment,
+        )
 
 
 def output_host_networks(


### PR DESCRIPTION
Closes #408 

```
test@127.0.0.1> host find -name "testhost12(3|4)"
Name                 Contact                           IP                         Comment
testhost123.uio.no   user@example.com, alt@example.com 192.0.2.123, 2001:db8::123 A long comment goes here!
testhost124.uio.no   user@example.com                  192.0.2.124                
```

Standardizes on a consistent format for multiple values (contacts, ips), also fixes existing max contact length calculation for hosts with multiple contacts.