### PR TITLE
CI: Increase health check start period

### DIFF
--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       interval: 5s
       timeout: 5s
       retries: 10
-      start_period: 5s
+      start_period: 30s
 
   # The purpose of the dummy container is to depend on the mreg container,
   # so the "docker compose" command won't return until mreg is up and running.


### PR DESCRIPTION
After switching to Docker VMM for virtualization on my M1 mac, the test suite started terminating itself before it could begin, because of increased startup time of containers. This PR adds a longer grace-period before we start measuring retries for the health check.