### PR TITLE
Fix host add contact argument ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `host find` now shows IP address(es) for each host.
+- `host add -contact` is now repeatable, with one contact per flag, so options can be placed before or after the hostname.
 
 ## [1.9.0](https://github.com/unioslo/mreg-cli/releases/tag/1.9.0) - 2026-04-14
 

--- a/README.md
+++ b/README.md
@@ -221,10 +221,10 @@ location_tags=default,oslo,bergen,stavanger
 Commands in `mreg-cli` take on the form of a fairly standard command line interface:
 
 ```sh
-host add myhost.example.com 192.168.1.1 me@example.con -hinfo Linux -comment "My host"
+host add myhost.example.com -ip 192.168.1.1 -contact me@example.com -comment "My host"
 ```
 
-Here we are using the `host add` command to add a new host. The command takes a number of arguments, which are positional. The arguments in this case is a name and an ip address, followed by a contact and some optional arguments. The optional arguments are specified with a flag, followed by the value. The optional arguments can be specified in any order, but the positional arguments must be specified in the order they are defined in the command.
+Here we are using the `host add` command to add a new host. The command takes the hostname as a positional argument, while IP address, contact, and comment are specified with flags. Multiple contacts can be added by repeating `-contact`.
 
 ### Filtering
 
@@ -262,9 +262,8 @@ As an example, you may add a host to a network unknown to mreg, or a frozen netw
 ### Host
 
 ```cli
-   host add <name> <ip/net> <contact> [-hinfo <hinfo>] [-comment <comment>]
-       Add a new host with the given name, ip or subnet and contact. hinfo and comment
-       are optional.
+   host add <name> [-ip <ip/net>] [-contact <contact>]... [-comment <comment>]
+       Add a new host with the given name, optional ip or subnet, contact(s), and comment.
 ```
 
 !!!note

--- a/mreg_cli/cli.py
+++ b/mreg_cli/cli.py
@@ -267,12 +267,12 @@ class Command(Completer):
             return
 
         # complete flags which aren't already used
-        for name in self.flags:
-            if ("-" + name) not in words:
+        for name, flag in self.flags.items():
+            if flag.action == "append" or ("-" + name) not in words:
                 if name.startswith(cur):
                     yield Completion(
                         name,
-                        display_meta=self.flags[name].short_desc,
+                        display_meta=flag.short_desc,
                         start_position=-len(cur),
                     )
 

--- a/mreg_cli/commands/host_submodules/core.py
+++ b/mreg_cli/commands/host_submodules/core.py
@@ -126,11 +126,7 @@ def add(args: argparse.Namespace) -> None:
     if "*" in hname and not force:
         raise ForceMissing("Wildcards must be forced.")
 
-    data: JsonMapping = {
-        "name": hname,
-        "contacts": contact,
-        "comment": args.comment or None,
-    }
+    data = _host_create_payload(hname, contact, args.comment)
 
     if network_or_ip:
         autodetect = False
@@ -211,6 +207,17 @@ def add(args: argparse.Namespace) -> None:
                 )
 
     output_host(host)
+
+
+def _host_create_payload(hname: HostName, contact: list[str], comment: str | None) -> JsonMapping:
+    """Build the API payload for creating a host."""
+    data: JsonMapping = {
+        "name": hname,
+        "comment": comment or None,
+    }
+    if contact:
+        data["contacts"] = contact
+    return data
 
 
 class Override(str, Enum):

--- a/mreg_cli/commands/host_submodules/core.py
+++ b/mreg_cli/commands/host_submodules/core.py
@@ -48,7 +48,7 @@ from mreg_cli.exceptions import (
 from mreg_cli.output import output_host, output_hostlist, output_hosts
 from mreg_cli.output.history import output_host_history
 from mreg_cli.outputmanager import OutputManager
-from mreg_cli.types import Flag, JsonMapping, QueryParams
+from mreg_cli.types import Flag, Json, JsonMapping, QueryParams
 from mreg_cli.utilities.shared import convert_wildcard_to_regex
 
 
@@ -211,12 +211,14 @@ def add(args: argparse.Namespace) -> None:
 
 def _host_create_payload(hname: HostName, contact: list[str], comment: str | None) -> JsonMapping:
     """Build the API payload for creating a host."""
-    data: JsonMapping = {
+    # Note: The JSON test results relies on the order of these keys to produce consistent diffs.
+    data: dict[str, Json] = {
         "name": hname,
-        "comment": comment or None,
     }
     if contact:
         data["contacts"] = contact
+    data["comment"] = comment or None
+
     return data
 
 

--- a/mreg_cli/commands/host_submodules/core.py
+++ b/mreg_cli/commands/host_submodules/core.py
@@ -79,7 +79,7 @@ from mreg_cli.utilities.shared import convert_wildcard_to_regex
             "-contact",
             short_desc="Contact mail(s) for the host",
             description="Contact mail(s) for the host",
-            nargs="+",
+            action="append",
             metavar="CONTACT",
         ),
         Flag("-force", action="store_true", description="Enable force."),
@@ -104,7 +104,7 @@ def add(args: argparse.Namespace) -> None:
     network_or_ip: str = args.ip
     macaddress: str | None = args.macaddress
     force: bool = args.force
-    contact: list[str] = args.contact
+    contact: list[str] = args.contact or []
 
     if macaddress is not None:
         macaddress = MacAddress.parse_or_raise(macaddress)

--- a/tests/commands/test_host.py
+++ b/tests/commands/test_host.py
@@ -6,9 +6,14 @@ from ipaddress import IPv4Address, IPv6Address
 import pytest
 from inline_snapshot import snapshot
 from mreg_api.models import NAPTR, PTR_override, Srv
+from mreg_api.models.fields import HostName
 
 from mreg_cli.cli import _top_parser
-from mreg_cli.commands.host_submodules.core import Override, get_record_identifier
+from mreg_cli.commands.host_submodules.core import (
+    Override,
+    _host_create_payload,
+    get_record_identifier,
+)
 from mreg_cli.exceptions import InputFailure
 
 
@@ -159,3 +164,28 @@ def test_host_add_contact_rejects_multiple_values_per_flag() -> None:
         _top_parser.parse_args(
             ["host", "add", "foo.example.org", "-contact", "foo@example.org", "bar@example.org"]
         )
+
+
+def test_host_add_payload_omits_empty_contacts() -> None:
+    """Empty contacts should not be sent in the host create payload."""
+    payload = _host_create_payload(HostName("foo.example.org"), [], None)
+
+    assert payload == {
+        "name": "foo.example.org",
+        "comment": None,
+    }
+
+
+def test_host_add_payload_includes_supplied_contacts() -> None:
+    """Supplied contacts should be sent in the host create payload."""
+    payload = _host_create_payload(
+        HostName("foo.example.org"),
+        ["foo@example.org", "bar@example.org"],
+        None,
+    )
+
+    assert payload == {
+        "name": "foo.example.org",
+        "comment": None,
+        "contacts": ["foo@example.org", "bar@example.org"],
+    }

--- a/tests/commands/test_host.py
+++ b/tests/commands/test_host.py
@@ -7,6 +7,7 @@ import pytest
 from inline_snapshot import snapshot
 from mreg_api.models import NAPTR, PTR_override, Srv
 
+from mreg_cli.cli import _top_parser
 from mreg_cli.commands.host_submodules.core import Override, get_record_identifier
 from mreg_cli.exceptions import InputFailure
 
@@ -122,3 +123,39 @@ def test_override_from_string() -> None:
 def test_get_record_identifier(record: NAPTR | PTR_override | Srv, expected: str) -> None:
     """Test get_record_identifier with different record types."""
     assert get_record_identifier(record) == expected
+
+
+def test_host_add_contact_before_hostname() -> None:
+    """Ensure -contact does not consume a following hostname."""
+    parsed = _top_parser.parse_args(
+        ["host", "add", "-contact", "foo@example.org", "foo.example.org"]
+    )
+
+    assert parsed.name == "foo.example.org"
+    assert parsed.contact == ["foo@example.org"]
+
+
+def test_host_add_contact_is_repeatable() -> None:
+    """Ensure multiple contacts are passed as repeated -contact flags."""
+    parsed = _top_parser.parse_args(
+        [
+            "host",
+            "add",
+            "-contact",
+            "foo@example.org",
+            "-contact",
+            "bar@example.org",
+            "foo.example.org",
+        ]
+    )
+
+    assert parsed.name == "foo.example.org"
+    assert parsed.contact == ["foo@example.org", "bar@example.org"]
+
+
+def test_host_add_contact_rejects_multiple_values_per_flag() -> None:
+    """The repeatable -contact option accepts one contact per flag."""
+    with pytest.raises(SystemExit):
+        _top_parser.parse_args(
+            ["host", "add", "foo.example.org", "-contact", "foo@example.org", "bar@example.org"]
+        )


### PR DESCRIPTION
Fixes the regression where hostnames have to come first in the list due to the use of `nargs="+"` by making `-contact` a repeatable flag.