### PR TITLE
Change default cache TTL to 60 seconds.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Cache TTL now defaults to 60 seconds.
 
 ## [1.10.0](https://github.com/unioslo/mreg-cli/releases/tag/1.10.0) - 2026-05-22
 

--- a/README.md
+++ b/README.md
@@ -169,11 +169,11 @@ cache=true
 
 ### Cache TTL
 
-Time-to-live for cached API results, in seconds. Defaults to 300 seconds (5 minutes).
+Time-to-live for cached API results, in seconds. Defaults to 60 seconds (1 minute).
 
 ```ini
 [mreg]
-cache_ttl=300
+cache_ttl=60
 ```
 
 ### History

--- a/data/mreg-cli.conf
+++ b/data/mreg-cli.conf
@@ -8,4 +8,4 @@
 category_tags=cat1,cat2,cat3
 location_tags=loc1,loc2,loc3
 cache=true
-cache_ttl=300
+cache_ttl=60

--- a/mreg_cli/config.py
+++ b/mreg_cli/config.py
@@ -179,7 +179,7 @@ class MregCliConfig(BaseSettings):
     category_tags: list[str] = []
     location_tags: list[str] = []
     cache: bool = True
-    cache_ttl: int = Field(default=300, ge=0)
+    cache_ttl: int = Field(default=60, ge=0)
     http_timeout: int = Field(default=20, ge=0)
     record_traffic: ResolvedPath | None = None
     record_traffic_without_timestamps: bool = False

--- a/mreg_cli/main.py
+++ b/mreg_cli/main.py
@@ -95,7 +95,7 @@ def main():
         dest="cache_ttl",
         help="Maximum time to live for cache entries in seconds.",
         type=int,
-        default=300,
+        default=60,
     )
 
     output_args = parser.add_argument_group("output settings")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -34,7 +34,7 @@ def test_get_default_config() -> None:
             "category_tags": [],
             "location_tags": [],
             "cache": True,
-            "cache_ttl": 300,
+            "cache_ttl": 60,
             "http_timeout": 20,
             "record_traffic": None,
             "record_traffic_without_timestamps": False,


### PR DESCRIPTION
Now that host prefetching has been "fixed", there is less of a reason to cache so aggressively. A minute duration allows repeated lookup on the same resource type to feel snappy, while reducing the chance people run into stale results.