### PR TITLE
Upgrade mreg api to 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 
 - `policy atom_create -created` option. This option is now hidden and will be removed in a future release.
+- `policy role_create -created` option. This option is now hidden and will be removed in a future release.
 
 ## [1.9.0](https://github.com/unioslo/mreg-cli/releases/tag/1.9.0) - 2026-04-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `naptr_remove` removing all records regardless of the provided options. Now requires all options to match for a record to be removed.
 
+### Deprecated
+
+- `policy atom_create -created` option. This option is now hidden and will be removed in a future release.
+
 ## [1.9.0](https://github.com/unioslo/mreg-cli/releases/tag/1.9.0) - 2026-04-14
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ def zone_info(args):
 
 - `output_host(host, names=False, traverse_hostgroups=False)` - Single host
 - `output_hosts(hosts, names=False, traverse_hostgroups=False)` - Multiple hosts
-- `output_hostlist(hostlist)` - HostList result
+- `output_hostlist(hosts)` - table of hosts
 - `output_ipaddresses(ips, padding=14, names=False)` - IP addresses
 - `output_cnames(cnames, host=None, padding=14)` - CNAME records
 - `output_mxs(mxs, padding=14)` - MX records

--- a/ci/testsuite
+++ b/ci/testsuite
@@ -180,7 +180,7 @@ zone delegation_delete example.org wut.example.org
 #   - rename
 #   - set description
 policy atom_create apple "Here's the description"
-policy atom_create -created 2018-07-07 orange "Round and orange"
+policy atom_create orange "Round and orange"
 policy list_atoms *
 policy list_atoms ppl
 policy role_create fruit "5 a day"

--- a/ci/testsuite-result.json
+++ b/ci/testsuite-result.json
@@ -18051,10 +18051,10 @@
     "time": null
   },
   {
-    "command": "policy atom_create -created 2018-07-07 orange \"Round and orange\"",
+    "command": "policy atom_create orange \"Round and orange\"",
     "command_filter": null,
     "command_filter_negate": false,
-    "command_issued": "policy atom_create -created 2018-07-07 orange \"Round and orange\"",
+    "command_issued": "policy atom_create orange \"Round and orange\"",
     "ok": [
       "Created new atom orange"
     ],

--- a/ci/testsuite-result.json
+++ b/ci/testsuite-result.json
@@ -39738,8 +39738,8 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2026-07-02T16:49:11.562623+02:00",
-              "updated_at": "2026-07-02T16:49:11.809411+02:00",
+              "created_at": "2026-07-08T14:48:47.160018+02:00",
+              "updated_at": "2026-07-08T14:48:47.412577+02:00",
               "ipaddress": "10.0.2.4",
               "host": 30
             }
@@ -39748,8 +39748,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2026-07-02T16:49:11.425658+02:00",
-              "updated_at": "2026-07-02T16:49:11.425712+02:00",
+              "created_at": "2026-07-08T14:48:47.029922+02:00",
+              "updated_at": "2026-07-08T14:48:47.029974+02:00",
               "txt": "v=spf1 -all",
               "host": 30
             }
@@ -39774,20 +39774,20 @@
                   "tinyhost.example.org"
                 ],
                 "global_name": "community02",
-                "created_at": "2026-07-02T16:49:12.288892+02:00",
-                "updated_at": "2026-07-02T16:49:16.146442+02:00"
+                "created_at": "2026-07-08T14:48:47.903755+02:00",
+                "updated_at": "2026-07-08T14:48:51.727084+02:00"
               }
             }
           ],
           "contacts": [
             {
               "email": "tinyhost@example.org",
-              "created_at": "2026-07-02T16:49:11.444548+02:00",
-              "updated_at": "2026-07-02T16:49:11.444608+02:00"
+              "created_at": "2026-07-08T14:48:47.048448+02:00",
+              "updated_at": "2026-07-08T14:48:47.048510+02:00"
             }
           ],
-          "created_at": "2026-07-02T16:49:11.413648+02:00",
-          "updated_at": "2026-07-02T16:49:11.413704+02:00",
+          "created_at": "2026-07-08T14:48:47.017385+02:00",
+          "updated_at": "2026-07-08T14:48:47.017444+02:00",
           "name": "tinyhost.example.org",
           "ttl": null,
           "comment": "",
@@ -39812,8 +39812,8 @@
               }
             ],
             "community_template_pattern": null,
-            "created_at": "2026-07-02T16:49:04.917311+02:00",
-            "updated_at": "2026-07-02T16:49:10.522449+02:00"
+            "created_at": "2026-07-08T14:48:40.484680+02:00",
+            "updated_at": "2026-07-08T14:48:46.084497+02:00"
           },
           "communities": [
             {
@@ -39822,8 +39822,8 @@
               "network": 10,
               "hosts": [],
               "global_name": "community01",
-              "created_at": "2026-07-02T16:49:12.150363+02:00",
-              "updated_at": "2026-07-02T16:49:12.150450+02:00"
+              "created_at": "2026-07-08T14:48:47.744667+02:00",
+              "updated_at": "2026-07-08T14:48:47.744734+02:00"
             },
             {
               "name": "labequipment",
@@ -39833,12 +39833,12 @@
                 "tinyhost.example.org"
               ],
               "global_name": "community02",
-              "created_at": "2026-07-02T16:49:12.288892+02:00",
-              "updated_at": "2026-07-02T16:49:16.146442+02:00"
+              "created_at": "2026-07-08T14:48:47.903755+02:00",
+              "updated_at": "2026-07-08T14:48:51.727084+02:00"
             }
           ],
-          "created_at": "2026-07-02T16:49:03.924028+02:00",
-          "updated_at": "2026-07-02T16:49:08.694317+02:00",
+          "created_at": "2026-07-08T14:48:39.347142+02:00",
+          "updated_at": "2026-07-08T14:48:44.116104+02:00",
           "network": "10.0.2.0/28",
           "description": "TinyNet",
           "vlan": null,
@@ -39851,42 +39851,11 @@
         }
       },
       {
-        "method": "GET",
-        "url": "/api/v1/networks/10.0.2.0/28/communities/",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 2,
-          "next": null,
-          "previous": null,
-          "results": [
-            {
-              "name": "guests",
-              "description": "Guest hosts.",
-              "network": 10,
-              "hosts": [],
-              "global_name": "community01",
-              "created_at": "2026-07-02T16:49:12.150363+02:00",
-              "updated_at": "2026-07-02T16:49:12.150450+02:00"
-            },
-            {
-              "name": "labequipment",
-              "description": "Lab equipment (expensive)",
-              "network": 10,
-              "hosts": [
-                "tinyhost.example.org"
-              ],
-              "global_name": "community02",
-              "created_at": "2026-07-02T16:49:12.288892+02:00",
-              "updated_at": "2026-07-02T16:49:16.146442+02:00"
-            }
-          ]
-        }
-      },
-      {
         "method": "DELETE",
         "url": "/api/v1/networks/10.0.2.0/28/communities/2/hosts/30",
-        "data": {},
+        "data": {
+          "ipaddress": "10.0.2.4"
+        },
         "status": 204
       }
     ],

--- a/ci/testsuite-result.json
+++ b/ci/testsuite-result.json
@@ -11347,80 +11347,73 @@
         "url": "/api/v1/ipaddresses/",
         "data": {
           "ipaddress": "10.0.1.5",
-          "host": "4"
+          "host": 4
         },
         "status": 201,
         "response": {
           "macaddress": "",
-          "created_at": "2025-12-18T11:57:31.705513+01:00",
-          "updated_at": "2025-12-18T11:57:31.705521+01:00",
+          "created_at": "2026-07-02T15:42:00.090778+02:00",
+          "updated_at": "2026-07-02T15:42:00.090841+02:00",
           "ipaddress": "10.0.1.5",
           "host": 4
         }
       },
       {
         "method": "GET",
-        "url": "/api/v1/hosts/?id=4",
+        "url": "/api/v1/hosts/somehost.example.org",
         "data": {},
         "status": 200,
         "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
+          "ipaddresses": [
             {
-              "ipaddresses": [
-                {
-                  "macaddress": "",
-                  "created_at": "2025-12-18T11:57:30.870728+01:00",
-                  "updated_at": "2025-12-18T11:57:30.870733+01:00",
-                  "ipaddress": "10.0.1.4",
-                  "host": 4
-                },
-                {
-                  "macaddress": "",
-                  "created_at": "2025-12-18T11:57:31.705513+01:00",
-                  "updated_at": "2025-12-18T11:57:31.705521+01:00",
-                  "ipaddress": "10.0.1.5",
-                  "host": 4
-                }
-              ],
-              "cnames": [],
-              "mxs": [],
-              "txts": [
-                {
-                  "created_at": "2025-12-18T11:57:30.851592+01:00",
-                  "updated_at": "2025-12-18T11:57:30.851598+01:00",
-                  "txt": "v=spf1 -all",
-                  "host": 4
-                }
-              ],
-              "ptr_overrides": [],
-              "srvs": [],
-              "naptrs": [],
-              "sshfps": [],
-              "hostgroups": [],
-              "roles": [],
-              "hinfo": null,
-              "loc": null,
-              "bacnetid": null,
-              "communities": [],
-              "contacts": [
-                {
-                  "email": "new-support@example.org",
-                  "created_at": "2025-12-18T11:57:31.482448+01:00",
-                  "updated_at": "2025-12-18T11:57:31.482456+01:00"
-                }
-              ],
-              "created_at": "2025-12-18T11:57:30.849901+01:00",
-              "updated_at": "2025-12-18T11:57:31.490965+01:00",
-              "name": "somehost.example.org",
-              "ttl": null,
-              "comment": "",
-              "zone": 1,
-              "contact": "new-support@example.org"
+              "macaddress": "",
+              "created_at": "2026-07-02T15:41:56.749017+02:00",
+              "updated_at": "2026-07-02T15:41:56.749075+02:00",
+              "ipaddress": "10.0.1.4",
+              "host": 4
+            },
+            {
+              "macaddress": "",
+              "created_at": "2026-07-02T15:42:00.090778+02:00",
+              "updated_at": "2026-07-02T15:42:00.090841+02:00",
+              "ipaddress": "10.0.1.5",
+              "host": 4
             }
-          ]
+          ],
+          "cnames": [],
+          "mxs": [],
+          "txts": [
+            {
+              "created_at": "2026-07-02T15:41:56.600470+02:00",
+              "updated_at": "2026-07-02T15:41:56.600524+02:00",
+              "txt": "v=spf1 -all",
+              "host": 4
+            }
+          ],
+          "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "hostgroups": [],
+          "roles": [],
+          "hinfo": null,
+          "loc": null,
+          "bacnetid": null,
+          "communities": [],
+          "contacts": [
+            {
+              "email": "new-support@example.org",
+              "created_at": "2026-07-02T15:41:59.000990+02:00",
+              "updated_at": "2026-07-02T15:41:59.001088+02:00"
+            }
+          ],
+          "created_at": "2026-07-02T15:41:56.588156+02:00",
+          "updated_at": "2026-07-02T15:41:58.973635+02:00",
+          "name": "somehost.example.org",
+          "ttl": null,
+          "comment": "",
+          "zone": 1,
+          "contact": "new-support@example.org"
         }
       }
     ],
@@ -11440,72 +11433,14 @@
     "api_requests": [
       {
         "method": "GET",
-        "url": "/api/v1/hosts/somehost.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "",
-              "created_at": "2025-12-18T11:57:30.870728+01:00",
-              "updated_at": "2025-12-18T11:57:30.870733+01:00",
-              "ipaddress": "10.0.1.4",
-              "host": 4
-            },
-            {
-              "macaddress": "",
-              "created_at": "2025-12-18T11:57:31.705513+01:00",
-              "updated_at": "2025-12-18T11:57:31.705521+01:00",
-              "ipaddress": "10.0.1.5",
-              "host": 4
-            }
-          ],
-          "cnames": [],
-          "mxs": [],
-          "txts": [
-            {
-              "created_at": "2025-12-18T11:57:30.851592+01:00",
-              "updated_at": "2025-12-18T11:57:30.851598+01:00",
-              "txt": "v=spf1 -all",
-              "host": 4
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "contacts": [
-            {
-              "email": "new-support@example.org",
-              "created_at": "2025-12-18T11:57:31.482448+01:00",
-              "updated_at": "2025-12-18T11:57:31.482456+01:00"
-            }
-          ],
-          "created_at": "2025-12-18T11:57:30.849901+01:00",
-          "updated_at": "2025-12-18T11:57:31.490965+01:00",
-          "name": "somehost.example.org",
-          "ttl": null,
-          "comment": "",
-          "zone": 1,
-          "contact": "new-support@example.org"
-        }
-      },
-      {
-        "method": "GET",
         "url": "/api/v1/networks/ip/10.0.1.4",
         "data": {},
         "status": 200,
         "response": {
           "excluded_ranges": [
             {
-              "created_at": "2025-12-18T11:57:30.680328+01:00",
-              "updated_at": "2025-12-18T11:57:30.680341+01:00",
+              "created_at": "2026-07-01T13:13:27.760597+02:00",
+              "updated_at": "2026-07-01T13:13:27.760730+02:00",
               "start_ip": "10.0.1.20",
               "end_ip": "10.0.1.30",
               "network": 3
@@ -11513,8 +11448,8 @@
           ],
           "policy": null,
           "communities": [],
-          "created_at": "2025-12-18T11:57:30.463627+01:00",
-          "updated_at": "2025-12-18T11:57:31.234874+01:00",
+          "created_at": "2026-07-01T13:13:27.052825+02:00",
+          "updated_at": "2026-07-01T13:13:29.873966+02:00",
           "network": "10.0.1.0/24",
           "description": "Frozen but has one host",
           "vlan": 1234,
@@ -11534,8 +11469,8 @@
         "response": {
           "excluded_ranges": [
             {
-              "created_at": "2025-12-18T11:57:30.680328+01:00",
-              "updated_at": "2025-12-18T11:57:30.680341+01:00",
+              "created_at": "2026-07-01T13:13:27.760597+02:00",
+              "updated_at": "2026-07-01T13:13:27.760730+02:00",
               "start_ip": "10.0.1.20",
               "end_ip": "10.0.1.30",
               "network": 3
@@ -11543,8 +11478,8 @@
           ],
           "policy": null,
           "communities": [],
-          "created_at": "2025-12-18T11:57:30.463627+01:00",
-          "updated_at": "2025-12-18T11:57:31.234874+01:00",
+          "created_at": "2026-07-01T13:13:27.052825+02:00",
+          "updated_at": "2026-07-01T13:13:29.873966+02:00",
           "network": "10.0.1.0/24",
           "description": "Frozen but has one host",
           "vlan": 1234,
@@ -12937,80 +12872,73 @@
         "url": "/api/v1/ipaddresses/",
         "data": {
           "ipaddress": "2001:db8::5",
-          "host": "8"
+          "host": 8
         },
         "status": 201,
         "response": {
           "macaddress": "",
-          "created_at": "2025-12-18T11:57:33.108677+01:00",
-          "updated_at": "2025-12-18T11:57:33.108685+01:00",
+          "created_at": "2026-07-02T15:42:05.567673+02:00",
+          "updated_at": "2026-07-02T15:42:05.568088+02:00",
           "ipaddress": "2001:db8::5",
           "host": 8
         }
       },
       {
         "method": "GET",
-        "url": "/api/v1/hosts/?id=8",
+        "url": "/api/v1/hosts/somehost.example.org",
         "data": {},
         "status": 200,
         "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
+          "ipaddresses": [
             {
-              "ipaddresses": [
-                {
-                  "macaddress": "",
-                  "created_at": "2025-12-18T11:57:32.819472+01:00",
-                  "updated_at": "2025-12-18T11:57:32.819492+01:00",
-                  "ipaddress": "2001:db8::4",
-                  "host": 8
-                },
-                {
-                  "macaddress": "",
-                  "created_at": "2025-12-18T11:57:33.108677+01:00",
-                  "updated_at": "2025-12-18T11:57:33.108685+01:00",
-                  "ipaddress": "2001:db8::5",
-                  "host": 8
-                }
-              ],
-              "cnames": [],
-              "mxs": [],
-              "txts": [
-                {
-                  "created_at": "2025-12-18T11:57:32.797522+01:00",
-                  "updated_at": "2025-12-18T11:57:32.797528+01:00",
-                  "txt": "v=spf1 -all",
-                  "host": 8
-                }
-              ],
-              "ptr_overrides": [],
-              "srvs": [],
-              "naptrs": [],
-              "sshfps": [],
-              "hostgroups": [],
-              "roles": [],
-              "hinfo": null,
-              "loc": null,
-              "bacnetid": null,
-              "communities": [],
-              "contacts": [
-                {
-                  "email": "support@example.org",
-                  "created_at": "2025-12-18T11:57:30.853644+01:00",
-                  "updated_at": "2025-12-18T11:57:30.853650+01:00"
-                }
-              ],
-              "created_at": "2025-12-18T11:57:32.795806+01:00",
-              "updated_at": "2025-12-18T11:57:32.795813+01:00",
-              "name": "somehost.example.org",
-              "ttl": null,
-              "comment": "",
-              "zone": 1,
-              "contact": "support@example.org"
+              "macaddress": "",
+              "created_at": "2026-07-02T15:42:04.379869+02:00",
+              "updated_at": "2026-07-02T15:42:04.379943+02:00",
+              "ipaddress": "2001:db8::4",
+              "host": 8
+            },
+            {
+              "macaddress": "",
+              "created_at": "2026-07-02T15:42:05.567673+02:00",
+              "updated_at": "2026-07-02T15:42:05.568088+02:00",
+              "ipaddress": "2001:db8::5",
+              "host": 8
             }
-          ]
+          ],
+          "cnames": [],
+          "mxs": [],
+          "txts": [
+            {
+              "created_at": "2026-07-02T15:42:03.663005+02:00",
+              "updated_at": "2026-07-02T15:42:03.663063+02:00",
+              "txt": "v=spf1 -all",
+              "host": 8
+            }
+          ],
+          "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "hostgroups": [],
+          "roles": [],
+          "hinfo": null,
+          "loc": null,
+          "bacnetid": null,
+          "communities": [],
+          "contacts": [
+            {
+              "email": "support@example.org",
+              "created_at": "2026-07-02T15:42:04.238374+02:00",
+              "updated_at": "2026-07-02T15:42:04.238484+02:00"
+            }
+          ],
+          "created_at": "2026-07-02T15:42:03.647469+02:00",
+          "updated_at": "2026-07-02T15:42:03.647534+02:00",
+          "name": "somehost.example.org",
+          "ttl": null,
+          "comment": "",
+          "zone": 1,
+          "contact": "support@example.org"
         }
       }
     ],
@@ -13030,72 +12958,14 @@
     "api_requests": [
       {
         "method": "GET",
-        "url": "/api/v1/hosts/somehost.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "",
-              "created_at": "2025-12-18T11:57:32.819472+01:00",
-              "updated_at": "2025-12-18T11:57:32.819492+01:00",
-              "ipaddress": "2001:db8::4",
-              "host": 8
-            },
-            {
-              "macaddress": "",
-              "created_at": "2025-12-18T11:57:33.108677+01:00",
-              "updated_at": "2025-12-18T11:57:33.108685+01:00",
-              "ipaddress": "2001:db8::5",
-              "host": 8
-            }
-          ],
-          "cnames": [],
-          "mxs": [],
-          "txts": [
-            {
-              "created_at": "2025-12-18T11:57:32.797522+01:00",
-              "updated_at": "2025-12-18T11:57:32.797528+01:00",
-              "txt": "v=spf1 -all",
-              "host": 8
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "contacts": [
-            {
-              "email": "support@example.org",
-              "created_at": "2025-12-18T11:57:30.853644+01:00",
-              "updated_at": "2025-12-18T11:57:30.853650+01:00"
-            }
-          ],
-          "created_at": "2025-12-18T11:57:32.795806+01:00",
-          "updated_at": "2025-12-18T11:57:32.795813+01:00",
-          "name": "somehost.example.org",
-          "ttl": null,
-          "comment": "",
-          "zone": 1,
-          "contact": "support@example.org"
-        }
-      },
-      {
-        "method": "GET",
         "url": "/api/v1/networks/ip/2001%3Adb8%3A%3A4",
         "data": {},
         "status": 200,
         "response": {
           "excluded_ranges": [
             {
-              "created_at": "2025-12-18T11:57:32.628919+01:00",
-              "updated_at": "2025-12-18T11:57:32.628927+01:00",
+              "created_at": "2026-07-01T13:13:36.852343+02:00",
+              "updated_at": "2026-07-01T13:13:36.852427+02:00",
               "start_ip": "2001:db8::20",
               "end_ip": "2001:db8::30",
               "network": 4
@@ -13103,8 +12973,8 @@
           ],
           "policy": null,
           "communities": [],
-          "created_at": "2025-12-18T11:57:32.430735+01:00",
-          "updated_at": "2025-12-18T11:57:32.925774+01:00",
+          "created_at": "2026-07-01T13:13:36.075543+02:00",
+          "updated_at": "2026-07-01T13:13:38.109667+02:00",
           "network": "2001:db8::/64",
           "description": "Frozen but has one host",
           "vlan": null,
@@ -13124,8 +12994,8 @@
         "response": {
           "excluded_ranges": [
             {
-              "created_at": "2025-12-18T11:57:32.628919+01:00",
-              "updated_at": "2025-12-18T11:57:32.628927+01:00",
+              "created_at": "2026-07-01T13:13:36.852343+02:00",
+              "updated_at": "2026-07-01T13:13:36.852427+02:00",
               "start_ip": "2001:db8::20",
               "end_ip": "2001:db8::30",
               "network": 4
@@ -13133,8 +13003,8 @@
           ],
           "policy": null,
           "communities": [],
-          "created_at": "2025-12-18T11:57:32.430735+01:00",
-          "updated_at": "2025-12-18T11:57:32.925774+01:00",
+          "created_at": "2026-07-01T13:13:36.075543+02:00",
+          "updated_at": "2026-07-01T13:13:38.109667+02:00",
           "network": "2001:db8::/64",
           "description": "Frozen but has one host",
           "vlan": null,
@@ -13480,90 +13350,17 @@
         "url": "/api/v1/ipaddresses/",
         "data": {
           "ipaddress": "10.0.1.0",
-          "host": "9"
+          "host": 9
         },
         "status": 201,
         "response": {
           "macaddress": "",
-          "created_at": "2025-12-18T11:57:33.555733+01:00",
-          "updated_at": "2025-12-18T11:57:33.555739+01:00",
+          "created_at": "2026-07-02T15:42:07.240006+02:00",
+          "updated_at": "2026-07-02T15:42:07.240060+02:00",
           "ipaddress": "10.0.1.0",
           "host": 9
         }
       },
-      {
-        "method": "GET",
-        "url": "/api/v1/hosts/?id=9",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
-            {
-              "ipaddresses": [
-                {
-                  "macaddress": "",
-                  "created_at": "2025-12-18T11:57:33.555733+01:00",
-                  "updated_at": "2025-12-18T11:57:33.555739+01:00",
-                  "ipaddress": "10.0.1.0",
-                  "host": 9
-                }
-              ],
-              "cnames": [],
-              "mxs": [],
-              "txts": [
-                {
-                  "created_at": "2025-12-18T11:57:33.443378+01:00",
-                  "updated_at": "2025-12-18T11:57:33.443384+01:00",
-                  "txt": "v=spf1 -all",
-                  "host": 9
-                }
-              ],
-              "ptr_overrides": [],
-              "srvs": [],
-              "naptrs": [],
-              "sshfps": [],
-              "hostgroups": [],
-              "roles": [],
-              "hinfo": null,
-              "loc": null,
-              "bacnetid": null,
-              "communities": [],
-              "contacts": [
-                {
-                  "email": "support@example.org",
-                  "created_at": "2025-12-18T11:57:30.853644+01:00",
-                  "updated_at": "2025-12-18T11:57:30.853650+01:00"
-                }
-              ],
-              "created_at": "2025-12-18T11:57:33.441682+01:00",
-              "updated_at": "2025-12-18T11:57:33.441689+01:00",
-              "name": "somehost.example.org",
-              "ttl": null,
-              "comment": "",
-              "zone": 1,
-              "contact": "support@example.org"
-            }
-          ]
-        }
-      }
-    ],
-    "time": null
-  },
-  {
-    "command": "host a_remove somehost 10.0.1.0",
-    "command_filter": null,
-    "command_filter_negate": false,
-    "command_issued": "host a_remove somehost 10.0.1.0 # force not required for removal",
-    "ok": [
-      "Removed ipaddress 10.0.1.0 from somehost.example.org"
-    ],
-    "warning": [],
-    "error": [],
-    "output": [],
-    "api_requests": [
       {
         "method": "GET",
         "url": "/api/v1/hosts/somehost.example.org",
@@ -13573,8 +13370,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-12-18T11:57:33.555733+01:00",
-              "updated_at": "2025-12-18T11:57:33.555739+01:00",
+              "created_at": "2026-07-02T15:42:07.240006+02:00",
+              "updated_at": "2026-07-02T15:42:07.240060+02:00",
               "ipaddress": "10.0.1.0",
               "host": 9
             }
@@ -13583,8 +13380,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-12-18T11:57:33.443378+01:00",
-              "updated_at": "2025-12-18T11:57:33.443384+01:00",
+              "created_at": "2026-07-02T15:42:06.741414+02:00",
+              "updated_at": "2026-07-02T15:42:06.741486+02:00",
               "txt": "v=spf1 -all",
               "host": 9
             }
@@ -13602,19 +13399,34 @@
           "contacts": [
             {
               "email": "support@example.org",
-              "created_at": "2025-12-18T11:57:30.853644+01:00",
-              "updated_at": "2025-12-18T11:57:30.853650+01:00"
+              "created_at": "2026-07-02T15:42:06.764612+02:00",
+              "updated_at": "2026-07-02T15:42:06.764684+02:00"
             }
           ],
-          "created_at": "2025-12-18T11:57:33.441682+01:00",
-          "updated_at": "2025-12-18T11:57:33.441689+01:00",
+          "created_at": "2026-07-02T15:42:06.726781+02:00",
+          "updated_at": "2026-07-02T15:42:06.726846+02:00",
           "name": "somehost.example.org",
           "ttl": null,
           "comment": "",
           "zone": 1,
           "contact": "support@example.org"
         }
-      },
+      }
+    ],
+    "time": null
+  },
+  {
+    "command": "host a_remove somehost 10.0.1.0",
+    "command_filter": null,
+    "command_filter_negate": false,
+    "command_issued": "host a_remove somehost 10.0.1.0 # force not required for removal",
+    "ok": [
+      "Removed ipaddress 10.0.1.0 from somehost.example.org"
+    ],
+    "warning": [],
+    "error": [],
+    "output": [],
+    "api_requests": [
       {
         "method": "DELETE",
         "url": "/api/v1/ipaddresses/8",
@@ -13721,73 +13533,66 @@
         "url": "/api/v1/ipaddresses/",
         "data": {
           "ipaddress": "10.0.1.255",
-          "host": "9"
+          "host": 9
         },
         "status": 201,
         "response": {
           "macaddress": "",
-          "created_at": "2025-12-18T11:57:33.747206+01:00",
-          "updated_at": "2025-12-18T11:57:33.747216+01:00",
+          "created_at": "2026-07-02T15:42:07.706481+02:00",
+          "updated_at": "2026-07-02T15:42:07.706540+02:00",
           "ipaddress": "10.0.1.255",
           "host": 9
         }
       },
       {
         "method": "GET",
-        "url": "/api/v1/hosts/?id=9",
+        "url": "/api/v1/hosts/somehost.example.org",
         "data": {},
         "status": 200,
         "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
+          "ipaddresses": [
             {
-              "ipaddresses": [
-                {
-                  "macaddress": "",
-                  "created_at": "2025-12-18T11:57:33.747206+01:00",
-                  "updated_at": "2025-12-18T11:57:33.747216+01:00",
-                  "ipaddress": "10.0.1.255",
-                  "host": 9
-                }
-              ],
-              "cnames": [],
-              "mxs": [],
-              "txts": [
-                {
-                  "created_at": "2025-12-18T11:57:33.443378+01:00",
-                  "updated_at": "2025-12-18T11:57:33.443384+01:00",
-                  "txt": "v=spf1 -all",
-                  "host": 9
-                }
-              ],
-              "ptr_overrides": [],
-              "srvs": [],
-              "naptrs": [],
-              "sshfps": [],
-              "hostgroups": [],
-              "roles": [],
-              "hinfo": null,
-              "loc": null,
-              "bacnetid": null,
-              "communities": [],
-              "contacts": [
-                {
-                  "email": "support@example.org",
-                  "created_at": "2025-12-18T11:57:30.853644+01:00",
-                  "updated_at": "2025-12-18T11:57:30.853650+01:00"
-                }
-              ],
-              "created_at": "2025-12-18T11:57:33.441682+01:00",
-              "updated_at": "2025-12-18T11:57:33.441689+01:00",
-              "name": "somehost.example.org",
-              "ttl": null,
-              "comment": "",
-              "zone": 1,
-              "contact": "support@example.org"
+              "macaddress": "",
+              "created_at": "2026-07-02T15:42:07.706481+02:00",
+              "updated_at": "2026-07-02T15:42:07.706540+02:00",
+              "ipaddress": "10.0.1.255",
+              "host": 9
             }
-          ]
+          ],
+          "cnames": [],
+          "mxs": [],
+          "txts": [
+            {
+              "created_at": "2026-07-02T15:42:06.741414+02:00",
+              "updated_at": "2026-07-02T15:42:06.741486+02:00",
+              "txt": "v=spf1 -all",
+              "host": 9
+            }
+          ],
+          "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "hostgroups": [],
+          "roles": [],
+          "hinfo": null,
+          "loc": null,
+          "bacnetid": null,
+          "communities": [],
+          "contacts": [
+            {
+              "email": "support@example.org",
+              "created_at": "2026-07-02T15:42:06.764612+02:00",
+              "updated_at": "2026-07-02T15:42:06.764684+02:00"
+            }
+          ],
+          "created_at": "2026-07-02T15:42:06.726781+02:00",
+          "updated_at": "2026-07-02T15:42:06.726846+02:00",
+          "name": "somehost.example.org",
+          "ttl": null,
+          "comment": "",
+          "zone": 1,
+          "contact": "support@example.org"
         }
       }
     ],
@@ -13814,8 +13619,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-12-18T11:57:30.463627+01:00",
-          "updated_at": "2025-12-18T11:57:31.925080+01:00",
+          "created_at": "2026-07-01T13:13:27.052825+02:00",
+          "updated_at": "2026-07-01T13:13:33.564842+02:00",
           "network": "10.0.1.0/24",
           "description": "Frozen but has one host",
           "vlan": 1234,
@@ -13825,57 +13630,6 @@
           "frozen": false,
           "reserved": 3,
           "max_communities": null
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hosts/somehost.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "",
-              "created_at": "2025-12-18T11:57:33.747206+01:00",
-              "updated_at": "2025-12-18T11:57:33.747216+01:00",
-              "ipaddress": "10.0.1.255",
-              "host": 9
-            }
-          ],
-          "cnames": [],
-          "mxs": [],
-          "txts": [
-            {
-              "created_at": "2025-12-18T11:57:33.443378+01:00",
-              "updated_at": "2025-12-18T11:57:33.443384+01:00",
-              "txt": "v=spf1 -all",
-              "host": 9
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "contacts": [
-            {
-              "email": "support@example.org",
-              "created_at": "2025-12-18T11:57:30.853644+01:00",
-              "updated_at": "2025-12-18T11:57:30.853650+01:00"
-            }
-          ],
-          "created_at": "2025-12-18T11:57:33.441682+01:00",
-          "updated_at": "2025-12-18T11:57:33.441689+01:00",
-          "name": "somehost.example.org",
-          "ttl": null,
-          "comment": "",
-          "zone": 1,
-          "contact": "support@example.org"
         }
       }
     ],
@@ -14642,67 +14396,60 @@
         "url": "/api/v1/ipaddresses/",
         "data": {
           "ipaddress": "2001:db8::",
-          "host": "11"
+          "host": 11
         },
         "status": 201,
         "response": {
           "macaddress": "",
-          "created_at": "2025-12-18T11:57:34.547183+01:00",
-          "updated_at": "2025-12-18T11:57:34.547189+01:00",
+          "created_at": "2026-07-02T15:42:10.535483+02:00",
+          "updated_at": "2026-07-02T15:42:10.535564+02:00",
           "ipaddress": "2001:db8::",
           "host": 11
         }
       },
       {
         "method": "GET",
-        "url": "/api/v1/hosts/?id=11",
+        "url": "/api/v1/hosts/somehost.example.org",
         "data": {},
         "status": 200,
         "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
+          "ipaddresses": [
             {
-              "ipaddresses": [
-                {
-                  "macaddress": "",
-                  "created_at": "2025-12-18T11:57:34.547183+01:00",
-                  "updated_at": "2025-12-18T11:57:34.547189+01:00",
-                  "ipaddress": "2001:db8::",
-                  "host": 11
-                }
-              ],
-              "cnames": [],
-              "mxs": [],
-              "txts": [
-                {
-                  "created_at": "2025-12-18T11:57:34.361344+01:00",
-                  "updated_at": "2025-12-18T11:57:34.361355+01:00",
-                  "txt": "v=spf1 -all",
-                  "host": 11
-                }
-              ],
-              "ptr_overrides": [],
-              "srvs": [],
-              "naptrs": [],
-              "sshfps": [],
-              "hostgroups": [],
-              "roles": [],
-              "hinfo": null,
-              "loc": null,
-              "bacnetid": null,
-              "communities": [],
-              "contacts": [],
-              "created_at": "2025-12-18T11:57:34.359390+01:00",
-              "updated_at": "2025-12-18T11:57:34.359397+01:00",
-              "name": "somehost.example.org",
-              "ttl": null,
-              "comment": "",
-              "zone": 1,
-              "contact": ""
+              "macaddress": "",
+              "created_at": "2026-07-02T15:42:10.535483+02:00",
+              "updated_at": "2026-07-02T15:42:10.535564+02:00",
+              "ipaddress": "2001:db8::",
+              "host": 11
             }
-          ]
+          ],
+          "cnames": [],
+          "mxs": [],
+          "txts": [
+            {
+              "created_at": "2026-07-02T15:42:09.834143+02:00",
+              "updated_at": "2026-07-02T15:42:09.834206+02:00",
+              "txt": "v=spf1 -all",
+              "host": 11
+            }
+          ],
+          "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "hostgroups": [],
+          "roles": [],
+          "hinfo": null,
+          "loc": null,
+          "bacnetid": null,
+          "communities": [],
+          "contacts": [],
+          "created_at": "2026-07-02T15:42:09.813639+02:00",
+          "updated_at": "2026-07-02T15:42:09.813712+02:00",
+          "name": "somehost.example.org",
+          "ttl": null,
+          "comment": "",
+          "zone": 1,
+          "contact": ""
         }
       }
     ],
@@ -14720,51 +14467,6 @@
     "error": [],
     "output": [],
     "api_requests": [
-      {
-        "method": "GET",
-        "url": "/api/v1/hosts/somehost.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "",
-              "created_at": "2025-12-18T11:57:34.547183+01:00",
-              "updated_at": "2025-12-18T11:57:34.547189+01:00",
-              "ipaddress": "2001:db8::",
-              "host": 11
-            }
-          ],
-          "cnames": [],
-          "mxs": [],
-          "txts": [
-            {
-              "created_at": "2025-12-18T11:57:34.361344+01:00",
-              "updated_at": "2025-12-18T11:57:34.361355+01:00",
-              "txt": "v=spf1 -all",
-              "host": 11
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "contacts": [],
-          "created_at": "2025-12-18T11:57:34.359390+01:00",
-          "updated_at": "2025-12-18T11:57:34.359397+01:00",
-          "name": "somehost.example.org",
-          "ttl": null,
-          "comment": "",
-          "zone": 1,
-          "contact": ""
-        }
-      },
       {
         "method": "DELETE",
         "url": "/api/v1/ipaddresses/12",
@@ -14873,67 +14575,60 @@
         "url": "/api/v1/ipaddresses/",
         "data": {
           "ipaddress": "2001:db8::ffff:ffff:ffff:ffff",
-          "host": "11"
+          "host": 11
         },
         "status": 201,
         "response": {
           "macaddress": "",
-          "created_at": "2025-12-18T11:57:34.716209+01:00",
-          "updated_at": "2025-12-18T11:57:34.716216+01:00",
+          "created_at": "2026-07-02T15:42:11.007534+02:00",
+          "updated_at": "2026-07-02T15:42:11.007592+02:00",
           "ipaddress": "2001:db8::ffff:ffff:ffff:ffff",
           "host": 11
         }
       },
       {
         "method": "GET",
-        "url": "/api/v1/hosts/?id=11",
+        "url": "/api/v1/hosts/somehost.example.org",
         "data": {},
         "status": 200,
         "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
+          "ipaddresses": [
             {
-              "ipaddresses": [
-                {
-                  "macaddress": "",
-                  "created_at": "2025-12-18T11:57:34.716209+01:00",
-                  "updated_at": "2025-12-18T11:57:34.716216+01:00",
-                  "ipaddress": "2001:db8::ffff:ffff:ffff:ffff",
-                  "host": 11
-                }
-              ],
-              "cnames": [],
-              "mxs": [],
-              "txts": [
-                {
-                  "created_at": "2025-12-18T11:57:34.361344+01:00",
-                  "updated_at": "2025-12-18T11:57:34.361355+01:00",
-                  "txt": "v=spf1 -all",
-                  "host": 11
-                }
-              ],
-              "ptr_overrides": [],
-              "srvs": [],
-              "naptrs": [],
-              "sshfps": [],
-              "hostgroups": [],
-              "roles": [],
-              "hinfo": null,
-              "loc": null,
-              "bacnetid": null,
-              "communities": [],
-              "contacts": [],
-              "created_at": "2025-12-18T11:57:34.359390+01:00",
-              "updated_at": "2025-12-18T11:57:34.359397+01:00",
-              "name": "somehost.example.org",
-              "ttl": null,
-              "comment": "",
-              "zone": 1,
-              "contact": ""
+              "macaddress": "",
+              "created_at": "2026-07-02T15:42:11.007534+02:00",
+              "updated_at": "2026-07-02T15:42:11.007592+02:00",
+              "ipaddress": "2001:db8::ffff:ffff:ffff:ffff",
+              "host": 11
             }
-          ]
+          ],
+          "cnames": [],
+          "mxs": [],
+          "txts": [
+            {
+              "created_at": "2026-07-02T15:42:09.834143+02:00",
+              "updated_at": "2026-07-02T15:42:09.834206+02:00",
+              "txt": "v=spf1 -all",
+              "host": 11
+            }
+          ],
+          "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "hostgroups": [],
+          "roles": [],
+          "hinfo": null,
+          "loc": null,
+          "bacnetid": null,
+          "communities": [],
+          "contacts": [],
+          "created_at": "2026-07-02T15:42:09.813639+02:00",
+          "updated_at": "2026-07-02T15:42:09.813712+02:00",
+          "name": "somehost.example.org",
+          "ttl": null,
+          "comment": "",
+          "zone": 1,
+          "contact": ""
         }
       }
     ],
@@ -14959,8 +14654,8 @@
         "response": {
           "excluded_ranges": [
             {
-              "created_at": "2025-12-18T11:57:32.628919+01:00",
-              "updated_at": "2025-12-18T11:57:32.628927+01:00",
+              "created_at": "2026-07-01T13:38:38.640708+02:00",
+              "updated_at": "2026-07-01T13:38:38.640783+02:00",
               "start_ip": "2001:db8::20",
               "end_ip": "2001:db8::30",
               "network": 4
@@ -14968,8 +14663,8 @@
           ],
           "policy": null,
           "communities": [],
-          "created_at": "2025-12-18T11:57:32.430735+01:00",
-          "updated_at": "2025-12-18T11:57:33.336342+01:00",
+          "created_at": "2026-07-01T13:38:38.109905+02:00",
+          "updated_at": "2026-07-01T13:38:41.281527+02:00",
           "network": "2001:db8::/64",
           "description": "Frozen but has one host",
           "vlan": null,
@@ -14979,51 +14674,6 @@
           "frozen": false,
           "reserved": 3,
           "max_communities": null
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hosts/somehost.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "",
-              "created_at": "2025-12-18T11:57:34.716209+01:00",
-              "updated_at": "2025-12-18T11:57:34.716216+01:00",
-              "ipaddress": "2001:db8::ffff:ffff:ffff:ffff",
-              "host": 11
-            }
-          ],
-          "cnames": [],
-          "mxs": [],
-          "txts": [
-            {
-              "created_at": "2025-12-18T11:57:34.361344+01:00",
-              "updated_at": "2025-12-18T11:57:34.361355+01:00",
-              "txt": "v=spf1 -all",
-              "host": 11
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "contacts": [],
-          "created_at": "2025-12-18T11:57:34.359390+01:00",
-          "updated_at": "2025-12-18T11:57:34.359397+01:00",
-          "name": "somehost.example.org",
-          "ttl": null,
-          "comment": "",
-          "zone": 1,
-          "contact": ""
         }
       }
     ],
@@ -17807,56 +17457,24 @@
         "response": {
           "nameservers": [
             {
-              "created_at": "2025-05-19T10:27:38.778680+02:00",
-              "updated_at": "2025-05-19T10:27:38.778705+02:00",
+              "created_at": "2026-07-01T13:38:22.454153+02:00",
+              "updated_at": "2026-07-01T13:38:22.454239+02:00",
               "name": "ns2.example.org",
               "ttl": null
             }
           ],
-          "created_at": "2025-05-19T10:27:38.232774+02:00",
-          "updated_at": "2025-05-19T10:27:47.465803+02:00",
+          "created_at": "2026-07-01T13:38:21.914790+02:00",
+          "updated_at": "2026-07-01T13:38:54.901821+02:00",
           "updated": true,
           "primary_ns": "ns2.example.org",
           "email": "hostperson@example.org",
-          "serialno_updated_at": "2025-05-19T10:27:38.853040+02:00",
+          "serialno_updated_at": "2026-07-01T13:38:22.572683+02:00",
           "refresh": 360,
           "retry": 1800,
           "expire": 2400,
           "soa_ttl": 1800,
           "default_ttl": 300,
           "name": "example.org"
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hosts/ns2.example.org",
-        "data": {},
-        "status": 404,
-        "response": {
-          "type": "client_error",
-          "errors": [
-            {
-              "code": "not_found",
-              "detail": "Not found.",
-              "attr": null
-            }
-          ]
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/cnames/ns2.example.org",
-        "data": {},
-        "status": 404,
-        "response": {
-          "type": "client_error",
-          "errors": [
-            {
-              "code": "not_found",
-              "detail": "Not found.",
-              "attr": null
-            }
-          ]
         }
       },
       {
@@ -17882,7 +17500,8 @@
           "name": "wut.example.org",
           "nameservers": [
             "ns2.example.org"
-          ]
+          ],
+          "comment": ""
         },
         "status": 201
       },
@@ -17894,14 +17513,14 @@
         "response": {
           "nameservers": [
             {
-              "created_at": "2025-05-19T10:27:38.778680+02:00",
-              "updated_at": "2025-05-19T10:27:38.778705+02:00",
+              "created_at": "2026-07-01T13:38:22.454153+02:00",
+              "updated_at": "2026-07-01T13:38:22.454239+02:00",
               "name": "ns2.example.org",
               "ttl": null
             }
           ],
-          "created_at": "2025-05-19T10:27:47.606669+02:00",
-          "updated_at": "2025-05-19T10:27:47.611536+02:00",
+          "created_at": "2026-07-01T13:38:55.130500+02:00",
+          "updated_at": "2026-07-01T13:38:55.149344+02:00",
           "name": "wut.example.org",
           "comment": "",
           "zone": 1
@@ -17930,18 +17549,18 @@
         "response": {
           "nameservers": [
             {
-              "created_at": "2025-08-26T11:56:35.781651+02:00",
-              "updated_at": "2025-08-26T11:56:35.781663+02:00",
+              "created_at": "2026-07-01T13:38:22.454153+02:00",
+              "updated_at": "2026-07-01T13:38:22.454239+02:00",
               "name": "ns2.example.org",
               "ttl": null
             }
           ],
-          "created_at": "2025-08-26T11:56:35.478972+02:00",
-          "updated_at": "2025-08-26T11:56:46.169656+02:00",
+          "created_at": "2026-07-01T13:38:21.914790+02:00",
+          "updated_at": "2026-07-01T13:38:55.152979+02:00",
           "updated": true,
           "primary_ns": "ns2.example.org",
           "email": "hostperson@example.org",
-          "serialno_updated_at": "2025-08-26T11:56:36.090230+02:00",
+          "serialno_updated_at": "2026-07-01T13:38:22.572683+02:00",
           "refresh": 360,
           "retry": 1800,
           "expire": 2400,
@@ -17957,6 +17576,27 @@
           "comment": "This is a comment"
         },
         "status": 204
+      },
+      {
+        "method": "GET",
+        "url": "/api/v1/zones/forward/example.org/delegations/wut.example.org",
+        "data": {},
+        "status": 200,
+        "response": {
+          "nameservers": [
+            {
+              "created_at": "2026-07-01T13:38:22.454153+02:00",
+              "updated_at": "2026-07-01T13:38:22.454239+02:00",
+              "name": "ns2.example.org",
+              "ttl": null
+            }
+          ],
+          "created_at": "2026-07-01T13:38:55.130500+02:00",
+          "updated_at": "2026-07-01T13:38:55.317780+02:00",
+          "name": "wut.example.org",
+          "comment": "This is a comment",
+          "zone": 1
+        }
       }
     ],
     "time": null
@@ -18236,18 +17876,18 @@
         "response": {
           "nameservers": [
             {
-              "created_at": "2024-12-11T16:44:40.356452+01:00",
-              "updated_at": "2024-12-11T16:44:40.356481+01:00",
+              "created_at": "2026-07-01T13:38:22.454153+02:00",
+              "updated_at": "2026-07-01T13:38:22.454239+02:00",
               "name": "ns2.example.org",
               "ttl": null
             }
           ],
-          "created_at": "2024-12-11T16:44:39.701254+01:00",
-          "updated_at": "2024-12-11T16:44:58.774765+01:00",
+          "created_at": "2026-07-01T13:38:21.914790+02:00",
+          "updated_at": "2026-07-01T13:38:55.295794+02:00",
           "updated": true,
           "primary_ns": "ns2.example.org",
           "email": "hostperson@example.org",
-          "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
+          "serialno_updated_at": "2026-07-01T13:38:22.572683+02:00",
           "refresh": 360,
           "retry": 1800,
           "expire": 2400,
@@ -18264,14 +17904,14 @@
         "response": {
           "nameservers": [
             {
-              "created_at": "2024-12-11T16:44:40.356452+01:00",
-              "updated_at": "2024-12-11T16:44:40.356481+01:00",
+              "created_at": "2026-07-01T13:38:22.454153+02:00",
+              "updated_at": "2026-07-01T13:38:22.454239+02:00",
               "name": "ns2.example.org",
               "ttl": null
             }
           ],
-          "created_at": "2024-12-11T16:44:58.566491+01:00",
-          "updated_at": "2024-12-11T16:44:58.811285+01:00",
+          "created_at": "2026-07-01T13:38:55.130500+02:00",
+          "updated_at": "2026-07-01T13:38:55.317780+02:00",
           "name": "wut.example.org",
           "comment": "This is a comment",
           "zone": 1
@@ -18284,6 +17924,27 @@
           "comment": ""
         },
         "status": 204
+      },
+      {
+        "method": "GET",
+        "url": "/api/v1/zones/forward/example.org/delegations/wut.example.org",
+        "data": {},
+        "status": 200,
+        "response": {
+          "nameservers": [
+            {
+              "created_at": "2026-07-01T13:38:22.454153+02:00",
+              "updated_at": "2026-07-01T13:38:22.454239+02:00",
+              "name": "ns2.example.org",
+              "ttl": null
+            }
+          ],
+          "created_at": "2026-07-01T13:38:55.130500+02:00",
+          "updated_at": "2026-07-01T13:38:56.371477+02:00",
+          "name": "wut.example.org",
+          "comment": "",
+          "zone": 1
+        }
       }
     ],
     "time": null
@@ -18308,45 +17969,24 @@
         "response": {
           "nameservers": [
             {
-              "created_at": "2024-12-11T16:44:40.356452+01:00",
-              "updated_at": "2024-12-11T16:44:40.356481+01:00",
+              "created_at": "2026-07-01T13:38:22.454153+02:00",
+              "updated_at": "2026-07-01T13:38:22.454239+02:00",
               "name": "ns2.example.org",
               "ttl": null
             }
           ],
-          "created_at": "2024-12-11T16:44:39.701254+01:00",
-          "updated_at": "2024-12-11T16:44:59.950305+01:00",
+          "created_at": "2026-07-01T13:38:21.914790+02:00",
+          "updated_at": "2026-07-01T13:38:56.345107+02:00",
           "updated": true,
           "primary_ns": "ns2.example.org",
           "email": "hostperson@example.org",
-          "serialno_updated_at": "2024-12-11T16:44:40.474871+01:00",
+          "serialno_updated_at": "2026-07-01T13:38:22.572683+02:00",
           "refresh": 360,
           "retry": 1800,
           "expire": 2400,
           "soa_ttl": 1800,
           "default_ttl": 300,
           "name": "example.org"
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/zones/forward/example.org/delegations/wut.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "nameservers": [
-            {
-              "created_at": "2024-12-11T16:44:40.356452+01:00",
-              "updated_at": "2024-12-11T16:44:40.356481+01:00",
-              "name": "ns2.example.org",
-              "ttl": null
-            }
-          ],
-          "created_at": "2024-12-11T16:44:58.566491+01:00",
-          "updated_at": "2024-12-11T16:44:59.996272+01:00",
-          "name": "wut.example.org",
-          "comment": "",
-          "zone": 1
         }
       },
       {
@@ -18443,8 +18083,7 @@
         "url": "/api/v1/hostpolicy/atoms/",
         "data": {
           "name": "orange",
-          "description": "Round and orange",
-          "create_date": "2018-07-07"
+          "description": "Round and orange"
         },
         "status": 201
       },
@@ -18455,7 +18094,7 @@
         "status": 200,
         "response": {
           "roles": [],
-          "updated_at": "2025-05-19T10:27:48.328583+02:00",
+          "updated_at": "2026-07-01T13:38:56.946759+02:00",
           "description": "Round and orange",
           "name": "orange"
         }
@@ -18990,37 +18629,9 @@
               "name": "fruit"
             }
           ],
-          "updated_at": "2024-12-11T16:45:00.243440+01:00",
+          "updated_at": "2026-07-02T13:13:47.288856+02:00",
           "description": "Here's the description",
           "name": "apple"
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hostpolicy/roles/?atoms__name__exact=apple",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
-            {
-              "hosts": [],
-              "atoms": [
-                {
-                  "name": "apple"
-                },
-                {
-                  "name": "orange"
-                }
-              ],
-              "updated_at": "2024-12-11T16:45:01.258316+01:00",
-              "description": "5 a day",
-              "name": "fruit",
-              "labels": []
-            }
-          ]
         }
       }
     ],
@@ -19168,21 +18779,9 @@
         "status": 200,
         "response": {
           "roles": [],
-          "updated_at": "2024-12-11T16:45:00.243440+01:00",
+          "updated_at": "2026-07-02T13:13:47.288856+02:00",
           "description": "Here's the description",
           "name": "apple"
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hostpolicy/roles/?atoms__name__exact=apple",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
         }
       },
       {
@@ -19543,7 +19142,7 @@
     "command_issued": "policy host_add tangerine foo # should fail, tangerine is an atom, not a role",
     "ok": [],
     "warning": [
-      "Role with name 'tangerine' not found."
+      "Role 'tangerine' not found."
     ],
     "error": [],
     "output": [],
@@ -19803,7 +19402,7 @@
     "command_issued": "policy role_delete vegetables  # fails, that role doesn't exist",
     "ok": [],
     "warning": [
-      "Role with name 'vegetables' not found."
+      "Role 'vegetables' not found."
     ],
     "error": [],
     "output": [],
@@ -20116,21 +19715,9 @@
         "status": 200,
         "response": {
           "roles": [],
-          "updated_at": "2024-12-11T16:45:02.667228+01:00",
+          "updated_at": "2026-07-02T13:13:49.683811+02:00",
           "description": "Juicy",
           "name": "tangerine"
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hostpolicy/roles/?atoms__name__exact=tangerine",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
         }
       },
       {
@@ -20214,7 +19801,7 @@
     "api_requests": [
       {
         "method": "GET",
-        "url": "/api/v1/permissions/netgroupregex/?range=10.0.0.0%2F24&group=somegroup&regex=%5Babc%5D%2B.uio.no",
+        "url": "/api/v1/permissions/netgroupregex/?group=somegroup&range=10.0.0.0%2F24&regex=%5Babc%5D%2B.uio.no",
         "data": {},
         "status": 200,
         "response": {
@@ -20228,14 +19815,14 @@
         "method": "POST",
         "url": "/api/v1/permissions/netgroupregex/",
         "data": {
-          "range": "10.0.0.0/24",
           "group": "somegroup",
+          "range": "10.0.0.0/24",
           "regex": "[abc]+.uio.no"
         },
         "status": 201,
         "response": {
-          "created_at": "2024-12-11T16:45:05.428527+01:00",
-          "updated_at": "2024-12-11T16:45:05.428550+01:00",
+          "created_at": "2026-07-02T12:41:15.536175+02:00",
+          "updated_at": "2026-07-02T12:41:15.536259+02:00",
           "group": "somegroup",
           "range": "10.0.0.0/24",
           "regex": "[abc]+.uio.no",
@@ -20301,7 +19888,7 @@
     "command_issued": "permission network_remove 10.0.0.0/24 othergroup \"[abc]*.uio.no\"  # fails, no match",
     "ok": [],
     "warning": [
-      "Permission with query {'group': 'othergroup', 'range': '10.0.0.0/24', 'regex': '[abc]*.uio.no'} not found."
+      "Permission not found for group='othergroup', range='10.0.0.0/24', regex='[abc]*.uio.no'."
     ],
     "error": [],
     "output": [],
@@ -20393,7 +19980,7 @@
         "data": {
           "network": "10.0.0.0/24",
           "description": "foo",
-          "vlan": "1234",
+          "vlan": 1234,
           "frozen": false
         },
         "status": 201
@@ -20407,8 +19994,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-11-21T13:43:52.405866+01:00",
-          "updated_at": "2025-11-21T13:43:52.405885+01:00",
+          "created_at": "2026-07-02T12:41:16.091707+02:00",
+          "updated_at": "2026-07-02T12:41:16.091792+02:00",
           "network": "10.0.0.0/24",
           "description": "foo",
           "vlan": 1234,
@@ -20575,8 +20162,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-12-18T11:57:39.783040+01:00",
-              "updated_at": "2025-12-18T11:57:39.783047+01:00",
+              "created_at": "2026-07-02T15:42:27.072321+02:00",
+              "updated_at": "2026-07-02T15:42:27.072380+02:00",
               "txt": "v=spf1 -all",
               "host": 18
             }
@@ -20592,8 +20179,8 @@
           "bacnetid": null,
           "communities": [],
           "contacts": [],
-          "created_at": "2025-12-18T11:57:39.780995+01:00",
-          "updated_at": "2025-12-18T11:57:39.781005+01:00",
+          "created_at": "2026-07-02T15:42:27.058955+02:00",
+          "updated_at": "2026-07-02T15:42:27.059018+02:00",
           "name": "foo.example.org",
           "ttl": null,
           "comment": "",
@@ -20610,8 +20197,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-12-18T11:57:39.665988+01:00",
-          "updated_at": "2025-12-18T11:57:39.665997+01:00",
+          "created_at": "2026-07-02T15:42:26.815544+02:00",
+          "updated_at": "2026-07-02T15:42:26.815612+02:00",
           "network": "10.0.0.0/24",
           "description": "foo",
           "vlan": 1234,
@@ -20625,7 +20212,19 @@
       },
       {
         "method": "GET",
-        "url": "/api/v1/hosts/?ipaddresses__ipaddress=10.0.0.5&ordering=name",
+        "url": "/api/v1/hosts/?ipaddresses__ipaddress=10.0.0.5",
+        "data": {},
+        "status": 200,
+        "response": {
+          "count": 0,
+          "next": null,
+          "previous": null,
+          "results": []
+        }
+      },
+      {
+        "method": "GET",
+        "url": "/api/v1/hosts/?ptr_overrides__ipaddress=10.0.0.5",
         "data": {},
         "status": 200,
         "response": {
@@ -20640,67 +20239,60 @@
         "url": "/api/v1/ipaddresses/",
         "data": {
           "ipaddress": "10.0.0.5",
-          "host": "18"
+          "host": 18
         },
         "status": 201,
         "response": {
           "macaddress": "",
-          "created_at": "2025-12-18T11:57:39.939680+01:00",
-          "updated_at": "2025-12-18T11:57:39.939687+01:00",
+          "created_at": "2026-07-02T15:42:28.297030+02:00",
+          "updated_at": "2026-07-02T15:42:28.297106+02:00",
           "ipaddress": "10.0.0.5",
           "host": 18
         }
       },
       {
         "method": "GET",
-        "url": "/api/v1/hosts/?id=18",
+        "url": "/api/v1/hosts/foo.example.org",
         "data": {},
         "status": 200,
         "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
+          "ipaddresses": [
             {
-              "ipaddresses": [
-                {
-                  "macaddress": "",
-                  "created_at": "2025-12-18T11:57:39.939680+01:00",
-                  "updated_at": "2025-12-18T11:57:39.939687+01:00",
-                  "ipaddress": "10.0.0.5",
-                  "host": 18
-                }
-              ],
-              "cnames": [],
-              "mxs": [],
-              "txts": [
-                {
-                  "created_at": "2025-12-18T11:57:39.783040+01:00",
-                  "updated_at": "2025-12-18T11:57:39.783047+01:00",
-                  "txt": "v=spf1 -all",
-                  "host": 18
-                }
-              ],
-              "ptr_overrides": [],
-              "srvs": [],
-              "naptrs": [],
-              "sshfps": [],
-              "hostgroups": [],
-              "roles": [],
-              "hinfo": null,
-              "loc": null,
-              "bacnetid": null,
-              "communities": [],
-              "contacts": [],
-              "created_at": "2025-12-18T11:57:39.780995+01:00",
-              "updated_at": "2025-12-18T11:57:39.781005+01:00",
-              "name": "foo.example.org",
-              "ttl": null,
-              "comment": "",
-              "zone": 1,
-              "contact": ""
+              "macaddress": "",
+              "created_at": "2026-07-02T15:42:28.297030+02:00",
+              "updated_at": "2026-07-02T15:42:28.297106+02:00",
+              "ipaddress": "10.0.0.5",
+              "host": 18
             }
-          ]
+          ],
+          "cnames": [],
+          "mxs": [],
+          "txts": [
+            {
+              "created_at": "2026-07-02T15:42:27.072321+02:00",
+              "updated_at": "2026-07-02T15:42:27.072380+02:00",
+              "txt": "v=spf1 -all",
+              "host": 18
+            }
+          ],
+          "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "hostgroups": [],
+          "roles": [],
+          "hinfo": null,
+          "loc": null,
+          "bacnetid": null,
+          "communities": [],
+          "contacts": [],
+          "created_at": "2026-07-02T15:42:27.058955+02:00",
+          "updated_at": "2026-07-02T15:42:27.059018+02:00",
+          "name": "foo.example.org",
+          "ttl": null,
+          "comment": "",
+          "zone": 1,
+          "contact": ""
         }
       }
     ],
@@ -20891,7 +20483,7 @@
     "command_issued": "dhcp assoc meh 11:22:33:44:55:66  # host not found",
     "ok": [],
     "warning": [
-      "Host meh not found."
+      "Host 'meh' not found."
     ],
     "error": [],
     "output": [],
@@ -21124,7 +20716,7 @@
     "command_issued": "dhcp disassoc meh   # host not found",
     "ok": [],
     "warning": [
-      "Host meh not found."
+      "Host 'meh' not found."
     ],
     "error": [],
     "output": [],
@@ -21265,8 +20857,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-12-18T11:57:39.783040+01:00",
-              "updated_at": "2025-12-18T11:57:39.783047+01:00",
+              "created_at": "2026-07-02T15:12:34.049138+02:00",
+              "updated_at": "2026-07-02T15:12:34.049206+02:00",
               "txt": "v=spf1 -all",
               "host": 18
             }
@@ -21282,8 +20874,8 @@
           "bacnetid": null,
           "communities": [],
           "contacts": [],
-          "created_at": "2025-12-18T11:57:39.780995+01:00",
-          "updated_at": "2025-12-18T11:57:39.781005+01:00",
+          "created_at": "2026-07-02T15:12:34.033000+02:00",
+          "updated_at": "2026-07-02T15:12:34.033068+02:00",
           "name": "foo.example.org",
           "ttl": null,
           "comment": "",
@@ -21315,8 +20907,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-12-18T11:57:39.665988+01:00",
-          "updated_at": "2025-12-18T11:57:39.665997+01:00",
+          "created_at": "2026-07-02T15:42:26.815544+02:00",
+          "updated_at": "2026-07-02T15:42:26.815612+02:00",
           "network": "10.0.0.0/24",
           "description": "foo",
           "vlan": 1234,
@@ -21330,7 +20922,19 @@
       },
       {
         "method": "GET",
-        "url": "/api/v1/hosts/?ipaddresses__ipaddress=10.0.0.5&ordering=name",
+        "url": "/api/v1/hosts/?ipaddresses__ipaddress=10.0.0.5",
+        "data": {},
+        "status": 200,
+        "response": {
+          "count": 0,
+          "next": null,
+          "previous": null,
+          "results": []
+        }
+      },
+      {
+        "method": "GET",
+        "url": "/api/v1/hosts/?ptr_overrides__ipaddress=10.0.0.5",
         "data": {},
         "status": 200,
         "response": {
@@ -21345,67 +20949,60 @@
         "url": "/api/v1/ipaddresses/",
         "data": {
           "ipaddress": "10.0.0.5",
-          "host": "18"
+          "host": 18
         },
         "status": 201,
         "response": {
           "macaddress": "",
-          "created_at": "2025-12-18T11:57:40.666165+01:00",
-          "updated_at": "2025-12-18T11:57:40.666171+01:00",
+          "created_at": "2026-07-02T15:42:31.941677+02:00",
+          "updated_at": "2026-07-02T15:42:31.941732+02:00",
           "ipaddress": "10.0.0.5",
           "host": 18
         }
       },
       {
         "method": "GET",
-        "url": "/api/v1/hosts/?id=18",
+        "url": "/api/v1/hosts/foo.example.org",
         "data": {},
         "status": 200,
         "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
+          "ipaddresses": [
             {
-              "ipaddresses": [
-                {
-                  "macaddress": "",
-                  "created_at": "2025-12-18T11:57:40.666165+01:00",
-                  "updated_at": "2025-12-18T11:57:40.666171+01:00",
-                  "ipaddress": "10.0.0.5",
-                  "host": 18
-                }
-              ],
-              "cnames": [],
-              "mxs": [],
-              "txts": [
-                {
-                  "created_at": "2025-12-18T11:57:39.783040+01:00",
-                  "updated_at": "2025-12-18T11:57:39.783047+01:00",
-                  "txt": "v=spf1 -all",
-                  "host": 18
-                }
-              ],
-              "ptr_overrides": [],
-              "srvs": [],
-              "naptrs": [],
-              "sshfps": [],
-              "hostgroups": [],
-              "roles": [],
-              "hinfo": null,
-              "loc": null,
-              "bacnetid": null,
-              "communities": [],
-              "contacts": [],
-              "created_at": "2025-12-18T11:57:39.780995+01:00",
-              "updated_at": "2025-12-18T11:57:39.781005+01:00",
-              "name": "foo.example.org",
-              "ttl": null,
-              "comment": "",
-              "zone": 1,
-              "contact": ""
+              "macaddress": "",
+              "created_at": "2026-07-02T15:42:31.941677+02:00",
+              "updated_at": "2026-07-02T15:42:31.941732+02:00",
+              "ipaddress": "10.0.0.5",
+              "host": 18
             }
-          ]
+          ],
+          "cnames": [],
+          "mxs": [],
+          "txts": [
+            {
+              "created_at": "2026-07-02T15:42:27.072321+02:00",
+              "updated_at": "2026-07-02T15:42:27.072380+02:00",
+              "txt": "v=spf1 -all",
+              "host": 18
+            }
+          ],
+          "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "hostgroups": [],
+          "roles": [],
+          "hinfo": null,
+          "loc": null,
+          "bacnetid": null,
+          "communities": [],
+          "contacts": [],
+          "created_at": "2026-07-02T15:42:27.058955+02:00",
+          "updated_at": "2026-07-02T15:42:27.059018+02:00",
+          "name": "foo.example.org",
+          "ttl": null,
+          "comment": "",
+          "zone": 1,
+          "contact": ""
         }
       }
     ],
@@ -21425,51 +21022,6 @@
     "api_requests": [
       {
         "method": "GET",
-        "url": "/api/v1/hosts/foo.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "",
-              "created_at": "2025-12-18T11:57:40.666165+01:00",
-              "updated_at": "2025-12-18T11:57:40.666171+01:00",
-              "ipaddress": "10.0.0.5",
-              "host": 18
-            }
-          ],
-          "cnames": [],
-          "mxs": [],
-          "txts": [
-            {
-              "created_at": "2025-12-18T11:57:39.783040+01:00",
-              "updated_at": "2025-12-18T11:57:39.783047+01:00",
-              "txt": "v=spf1 -all",
-              "host": 18
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "contacts": [],
-          "created_at": "2025-12-18T11:57:39.780995+01:00",
-          "updated_at": "2025-12-18T11:57:39.781005+01:00",
-          "name": "foo.example.org",
-          "ttl": null,
-          "comment": "",
-          "zone": 1,
-          "contact": ""
-        }
-      },
-      {
-        "method": "GET",
         "url": "/api/v1/networks/ip/10.0.0.6",
         "data": {},
         "status": 200,
@@ -21477,8 +21029,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-12-18T11:57:39.665988+01:00",
-          "updated_at": "2025-12-18T11:57:39.665997+01:00",
+          "created_at": "2026-07-02T15:42:26.815544+02:00",
+          "updated_at": "2026-07-02T15:42:26.815612+02:00",
           "network": "10.0.0.0/24",
           "description": "foo",
           "vlan": 1234,
@@ -21495,74 +21047,67 @@
         "url": "/api/v1/ipaddresses/",
         "data": {
           "ipaddress": "10.0.0.6",
-          "host": "18"
+          "host": 18
         },
         "status": 201,
         "response": {
           "macaddress": "",
-          "created_at": "2025-12-18T11:57:40.788476+01:00",
-          "updated_at": "2025-12-18T11:57:40.788486+01:00",
+          "created_at": "2026-07-02T15:42:32.168661+02:00",
+          "updated_at": "2026-07-02T15:42:32.168718+02:00",
           "ipaddress": "10.0.0.6",
           "host": 18
         }
       },
       {
         "method": "GET",
-        "url": "/api/v1/hosts/?id=18",
+        "url": "/api/v1/hosts/foo.example.org",
         "data": {},
         "status": 200,
         "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
+          "ipaddresses": [
             {
-              "ipaddresses": [
-                {
-                  "macaddress": "",
-                  "created_at": "2025-12-18T11:57:40.666165+01:00",
-                  "updated_at": "2025-12-18T11:57:40.666171+01:00",
-                  "ipaddress": "10.0.0.5",
-                  "host": 18
-                },
-                {
-                  "macaddress": "",
-                  "created_at": "2025-12-18T11:57:40.788476+01:00",
-                  "updated_at": "2025-12-18T11:57:40.788486+01:00",
-                  "ipaddress": "10.0.0.6",
-                  "host": 18
-                }
-              ],
-              "cnames": [],
-              "mxs": [],
-              "txts": [
-                {
-                  "created_at": "2025-12-18T11:57:39.783040+01:00",
-                  "updated_at": "2025-12-18T11:57:39.783047+01:00",
-                  "txt": "v=spf1 -all",
-                  "host": 18
-                }
-              ],
-              "ptr_overrides": [],
-              "srvs": [],
-              "naptrs": [],
-              "sshfps": [],
-              "hostgroups": [],
-              "roles": [],
-              "hinfo": null,
-              "loc": null,
-              "bacnetid": null,
-              "communities": [],
-              "contacts": [],
-              "created_at": "2025-12-18T11:57:39.780995+01:00",
-              "updated_at": "2025-12-18T11:57:39.781005+01:00",
-              "name": "foo.example.org",
-              "ttl": null,
-              "comment": "",
-              "zone": 1,
-              "contact": ""
+              "macaddress": "",
+              "created_at": "2026-07-02T15:42:31.941677+02:00",
+              "updated_at": "2026-07-02T15:42:31.941732+02:00",
+              "ipaddress": "10.0.0.5",
+              "host": 18
+            },
+            {
+              "macaddress": "",
+              "created_at": "2026-07-02T15:42:32.168661+02:00",
+              "updated_at": "2026-07-02T15:42:32.168718+02:00",
+              "ipaddress": "10.0.0.6",
+              "host": 18
             }
-          ]
+          ],
+          "cnames": [],
+          "mxs": [],
+          "txts": [
+            {
+              "created_at": "2026-07-02T15:42:27.072321+02:00",
+              "updated_at": "2026-07-02T15:42:27.072380+02:00",
+              "txt": "v=spf1 -all",
+              "host": 18
+            }
+          ],
+          "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "hostgroups": [],
+          "roles": [],
+          "hinfo": null,
+          "loc": null,
+          "bacnetid": null,
+          "communities": [],
+          "contacts": [],
+          "created_at": "2026-07-02T15:42:27.058955+02:00",
+          "updated_at": "2026-07-02T15:42:27.059018+02:00",
+          "name": "foo.example.org",
+          "ttl": null,
+          "comment": "",
+          "zone": 1,
+          "contact": ""
         }
       }
     ],
@@ -21590,58 +21135,6 @@
           "next": null,
           "previous": null,
           "results": []
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hosts/foo.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "",
-              "created_at": "2025-12-18T11:57:40.666165+01:00",
-              "updated_at": "2025-12-18T11:57:40.666171+01:00",
-              "ipaddress": "10.0.0.5",
-              "host": 18
-            },
-            {
-              "macaddress": "",
-              "created_at": "2025-12-18T11:57:40.788476+01:00",
-              "updated_at": "2025-12-18T11:57:40.788486+01:00",
-              "ipaddress": "10.0.0.6",
-              "host": 18
-            }
-          ],
-          "cnames": [],
-          "mxs": [],
-          "txts": [
-            {
-              "created_at": "2025-12-18T11:57:39.783040+01:00",
-              "updated_at": "2025-12-18T11:57:39.783047+01:00",
-              "txt": "v=spf1 -all",
-              "host": 18
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "contacts": [],
-          "created_at": "2025-12-18T11:57:39.780995+01:00",
-          "updated_at": "2025-12-18T11:57:39.781005+01:00",
-          "name": "foo.example.org",
-          "ttl": null,
-          "comment": "",
-          "zone": 1,
-          "contact": ""
         }
       }
     ],
@@ -21694,8 +21187,8 @@
               "excluded_ranges": [],
               "policy": null,
               "communities": [],
-              "created_at": "2025-11-21T13:43:52.405866+01:00",
-              "updated_at": "2025-11-21T13:43:52.405885+01:00",
+              "created_at": "2026-07-02T13:13:52.295007+02:00",
+              "updated_at": "2026-07-02T13:13:52.295078+02:00",
               "network": "10.0.0.0/24",
               "description": "foo",
               "vlan": 1234,
@@ -21715,7 +21208,7 @@
         "data": {
           "network": "2001:db8::/64",
           "description": "foo_ipv6",
-          "vlan": "1234",
+          "vlan": 1234,
           "frozen": false
         },
         "status": 201
@@ -21729,8 +21222,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-11-21T13:43:56.452216+01:00",
-          "updated_at": "2025-11-21T13:43:56.452255+01:00",
+          "created_at": "2026-07-02T13:13:56.934335+02:00",
+          "updated_at": "2026-07-02T13:13:56.934404+02:00",
           "network": "2001:db8::/64",
           "description": "foo_ipv6",
           "vlan": 1234,
@@ -21771,8 +21264,8 @@
               "excluded_ranges": [],
               "policy": null,
               "communities": [],
-              "created_at": "2025-11-21T13:43:52.405866+01:00",
-              "updated_at": "2025-11-21T13:43:52.405885+01:00",
+              "created_at": "2026-07-02T13:13:52.295007+02:00",
+              "updated_at": "2026-07-02T13:13:52.295078+02:00",
               "network": "10.0.0.0/24",
               "description": "foo",
               "vlan": 1234,
@@ -21787,8 +21280,8 @@
               "excluded_ranges": [],
               "policy": null,
               "communities": [],
-              "created_at": "2025-11-21T13:43:56.452216+01:00",
-              "updated_at": "2025-11-21T13:43:56.452255+01:00",
+              "created_at": "2026-07-02T13:13:56.934335+02:00",
+              "updated_at": "2026-07-02T13:13:56.934404+02:00",
               "network": "2001:db8::/64",
               "description": "foo_ipv6",
               "vlan": 1234,
@@ -21808,7 +21301,7 @@
         "data": {
           "network": "2001:db9::/64",
           "description": "notfoo_ipv6",
-          "vlan": "1235",
+          "vlan": 1235,
           "frozen": false
         },
         "status": 201
@@ -21822,8 +21315,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-11-21T13:43:56.555611+01:00",
-          "updated_at": "2025-11-21T13:43:56.555650+01:00",
+          "created_at": "2026-07-02T13:13:57.146466+02:00",
+          "updated_at": "2026-07-02T13:13:57.146547+02:00",
           "network": "2001:db9::/64",
           "description": "notfoo_ipv6",
           "vlan": 1235,
@@ -21859,8 +21352,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-12-18T11:57:40.666165+01:00",
-              "updated_at": "2025-12-18T11:57:40.666171+01:00",
+              "created_at": "2026-07-02T15:42:31.941677+02:00",
+              "updated_at": "2026-07-02T15:42:31.941732+02:00",
               "ipaddress": "10.0.0.5",
               "host": 18
             }
@@ -21869,8 +21362,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-12-18T11:57:39.783040+01:00",
-              "updated_at": "2025-12-18T11:57:39.783047+01:00",
+              "created_at": "2026-07-02T15:42:27.072321+02:00",
+              "updated_at": "2026-07-02T15:42:27.072380+02:00",
               "txt": "v=spf1 -all",
               "host": 18
             }
@@ -21886,8 +21379,8 @@
           "bacnetid": null,
           "communities": [],
           "contacts": [],
-          "created_at": "2025-12-18T11:57:39.780995+01:00",
-          "updated_at": "2025-12-18T11:57:39.781005+01:00",
+          "created_at": "2026-07-02T15:42:27.058955+02:00",
+          "updated_at": "2026-07-02T15:42:27.059018+02:00",
           "name": "foo.example.org",
           "ttl": null,
           "comment": "",
@@ -21904,8 +21397,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-12-18T11:57:41.079099+01:00",
-          "updated_at": "2025-12-18T11:57:41.079110+01:00",
+          "created_at": "2026-07-02T15:42:32.786875+02:00",
+          "updated_at": "2026-07-02T15:42:32.786941+02:00",
           "network": "2001:db9::/64",
           "description": "notfoo_ipv6",
           "vlan": 1235,
@@ -21922,74 +21415,67 @@
         "url": "/api/v1/ipaddresses/",
         "data": {
           "ipaddress": "2001:db9::5",
-          "host": "18"
+          "host": 18
         },
         "status": 201,
         "response": {
           "macaddress": "",
-          "created_at": "2025-12-18T11:57:41.179826+01:00",
-          "updated_at": "2025-12-18T11:57:41.179833+01:00",
+          "created_at": "2026-07-02T15:42:33.108108+02:00",
+          "updated_at": "2026-07-02T15:42:33.108169+02:00",
           "ipaddress": "2001:db9::5",
           "host": 18
         }
       },
       {
         "method": "GET",
-        "url": "/api/v1/hosts/?id=18",
+        "url": "/api/v1/hosts/foo.example.org",
         "data": {},
         "status": 200,
         "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
+          "ipaddresses": [
             {
-              "ipaddresses": [
-                {
-                  "macaddress": "",
-                  "created_at": "2025-12-18T11:57:40.666165+01:00",
-                  "updated_at": "2025-12-18T11:57:40.666171+01:00",
-                  "ipaddress": "10.0.0.5",
-                  "host": 18
-                },
-                {
-                  "macaddress": "",
-                  "created_at": "2025-12-18T11:57:41.179826+01:00",
-                  "updated_at": "2025-12-18T11:57:41.179833+01:00",
-                  "ipaddress": "2001:db9::5",
-                  "host": 18
-                }
-              ],
-              "cnames": [],
-              "mxs": [],
-              "txts": [
-                {
-                  "created_at": "2025-12-18T11:57:39.783040+01:00",
-                  "updated_at": "2025-12-18T11:57:39.783047+01:00",
-                  "txt": "v=spf1 -all",
-                  "host": 18
-                }
-              ],
-              "ptr_overrides": [],
-              "srvs": [],
-              "naptrs": [],
-              "sshfps": [],
-              "hostgroups": [],
-              "roles": [],
-              "hinfo": null,
-              "loc": null,
-              "bacnetid": null,
-              "communities": [],
-              "contacts": [],
-              "created_at": "2025-12-18T11:57:39.780995+01:00",
-              "updated_at": "2025-12-18T11:57:39.781005+01:00",
-              "name": "foo.example.org",
-              "ttl": null,
-              "comment": "",
-              "zone": 1,
-              "contact": ""
+              "macaddress": "",
+              "created_at": "2026-07-02T15:42:31.941677+02:00",
+              "updated_at": "2026-07-02T15:42:31.941732+02:00",
+              "ipaddress": "10.0.0.5",
+              "host": 18
+            },
+            {
+              "macaddress": "",
+              "created_at": "2026-07-02T15:42:33.108108+02:00",
+              "updated_at": "2026-07-02T15:42:33.108169+02:00",
+              "ipaddress": "2001:db9::5",
+              "host": 18
             }
-          ]
+          ],
+          "cnames": [],
+          "mxs": [],
+          "txts": [
+            {
+              "created_at": "2026-07-02T15:42:27.072321+02:00",
+              "updated_at": "2026-07-02T15:42:27.072380+02:00",
+              "txt": "v=spf1 -all",
+              "host": 18
+            }
+          ],
+          "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "hostgroups": [],
+          "roles": [],
+          "hinfo": null,
+          "loc": null,
+          "bacnetid": null,
+          "communities": [],
+          "contacts": [],
+          "created_at": "2026-07-02T15:42:27.058955+02:00",
+          "updated_at": "2026-07-02T15:42:27.059018+02:00",
+          "name": "foo.example.org",
+          "ttl": null,
+          "comment": "",
+          "zone": 1,
+          "contact": ""
         }
       }
     ],
@@ -22021,58 +21507,6 @@
       },
       {
         "method": "GET",
-        "url": "/api/v1/hosts/foo.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "",
-              "created_at": "2025-12-18T11:57:40.666165+01:00",
-              "updated_at": "2025-12-18T11:57:40.666171+01:00",
-              "ipaddress": "10.0.0.5",
-              "host": 18
-            },
-            {
-              "macaddress": "",
-              "created_at": "2025-12-18T11:57:41.179826+01:00",
-              "updated_at": "2025-12-18T11:57:41.179833+01:00",
-              "ipaddress": "2001:db9::5",
-              "host": 18
-            }
-          ],
-          "cnames": [],
-          "mxs": [],
-          "txts": [
-            {
-              "created_at": "2025-12-18T11:57:39.783040+01:00",
-              "updated_at": "2025-12-18T11:57:39.783047+01:00",
-              "txt": "v=spf1 -all",
-              "host": 18
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "contacts": [],
-          "created_at": "2025-12-18T11:57:39.780995+01:00",
-          "updated_at": "2025-12-18T11:57:39.781005+01:00",
-          "name": "foo.example.org",
-          "ttl": null,
-          "comment": "",
-          "zone": 1,
-          "contact": ""
-        }
-      },
-      {
-        "method": "GET",
         "url": "/api/v1/networks/ip/10.0.0.5",
         "data": {},
         "status": 200,
@@ -22080,8 +21514,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-12-18T11:57:39.665988+01:00",
-          "updated_at": "2025-12-18T11:57:39.665997+01:00",
+          "created_at": "2026-07-02T15:12:33.801417+02:00",
+          "updated_at": "2026-07-02T15:12:33.801501+02:00",
           "network": "10.0.0.0/24",
           "description": "foo",
           "vlan": 1234,
@@ -22102,8 +21536,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-12-18T11:57:41.079099+01:00",
-          "updated_at": "2025-12-18T11:57:41.079110+01:00",
+          "created_at": "2026-07-02T15:12:41.345910+02:00",
+          "updated_at": "2026-07-02T15:12:41.345999+02:00",
           "network": "2001:db9::/64",
           "description": "notfoo_ipv6",
           "vlan": 1235,
@@ -22160,8 +21594,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-12-18T11:57:40.666165+01:00",
-              "updated_at": "2025-12-18T11:57:40.666171+01:00",
+              "created_at": "2026-07-02T15:42:31.941677+02:00",
+              "updated_at": "2026-07-02T15:42:31.941732+02:00",
               "ipaddress": "10.0.0.5",
               "host": 18
             }
@@ -22170,8 +21604,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-12-18T11:57:39.783040+01:00",
-              "updated_at": "2025-12-18T11:57:39.783047+01:00",
+              "created_at": "2026-07-02T15:42:27.072321+02:00",
+              "updated_at": "2026-07-02T15:42:27.072380+02:00",
               "txt": "v=spf1 -all",
               "host": 18
             }
@@ -22187,8 +21621,8 @@
           "bacnetid": null,
           "communities": [],
           "contacts": [],
-          "created_at": "2025-12-18T11:57:39.780995+01:00",
-          "updated_at": "2025-12-18T11:57:39.781005+01:00",
+          "created_at": "2026-07-02T15:42:27.058955+02:00",
+          "updated_at": "2026-07-02T15:42:27.059018+02:00",
           "name": "foo.example.org",
           "ttl": null,
           "comment": "",
@@ -22205,8 +21639,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-12-18T11:57:40.995174+01:00",
-          "updated_at": "2025-12-18T11:57:40.995182+01:00",
+          "created_at": "2026-07-02T15:42:32.581378+02:00",
+          "updated_at": "2026-07-02T15:42:32.581447+02:00",
           "network": "2001:db8::/64",
           "description": "foo_ipv6",
           "vlan": 1234,
@@ -22223,74 +21657,67 @@
         "url": "/api/v1/ipaddresses/",
         "data": {
           "ipaddress": "2001:db8::5",
-          "host": "18"
+          "host": 18
         },
         "status": 201,
         "response": {
           "macaddress": "",
-          "created_at": "2025-12-18T11:57:41.434196+01:00",
-          "updated_at": "2025-12-18T11:57:41.434204+01:00",
+          "created_at": "2026-07-02T15:42:33.732129+02:00",
+          "updated_at": "2026-07-02T15:42:33.732184+02:00",
           "ipaddress": "2001:db8::5",
           "host": 18
         }
       },
       {
         "method": "GET",
-        "url": "/api/v1/hosts/?id=18",
+        "url": "/api/v1/hosts/foo.example.org",
         "data": {},
         "status": 200,
         "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
+          "ipaddresses": [
             {
-              "ipaddresses": [
-                {
-                  "macaddress": "",
-                  "created_at": "2025-12-18T11:57:40.666165+01:00",
-                  "updated_at": "2025-12-18T11:57:40.666171+01:00",
-                  "ipaddress": "10.0.0.5",
-                  "host": 18
-                },
-                {
-                  "macaddress": "",
-                  "created_at": "2025-12-18T11:57:41.434196+01:00",
-                  "updated_at": "2025-12-18T11:57:41.434204+01:00",
-                  "ipaddress": "2001:db8::5",
-                  "host": 18
-                }
-              ],
-              "cnames": [],
-              "mxs": [],
-              "txts": [
-                {
-                  "created_at": "2025-12-18T11:57:39.783040+01:00",
-                  "updated_at": "2025-12-18T11:57:39.783047+01:00",
-                  "txt": "v=spf1 -all",
-                  "host": 18
-                }
-              ],
-              "ptr_overrides": [],
-              "srvs": [],
-              "naptrs": [],
-              "sshfps": [],
-              "hostgroups": [],
-              "roles": [],
-              "hinfo": null,
-              "loc": null,
-              "bacnetid": null,
-              "communities": [],
-              "contacts": [],
-              "created_at": "2025-12-18T11:57:39.780995+01:00",
-              "updated_at": "2025-12-18T11:57:39.781005+01:00",
-              "name": "foo.example.org",
-              "ttl": null,
-              "comment": "",
-              "zone": 1,
-              "contact": ""
+              "macaddress": "",
+              "created_at": "2026-07-02T15:42:31.941677+02:00",
+              "updated_at": "2026-07-02T15:42:31.941732+02:00",
+              "ipaddress": "10.0.0.5",
+              "host": 18
+            },
+            {
+              "macaddress": "",
+              "created_at": "2026-07-02T15:42:33.732129+02:00",
+              "updated_at": "2026-07-02T15:42:33.732184+02:00",
+              "ipaddress": "2001:db8::5",
+              "host": 18
             }
-          ]
+          ],
+          "cnames": [],
+          "mxs": [],
+          "txts": [
+            {
+              "created_at": "2026-07-02T15:42:27.072321+02:00",
+              "updated_at": "2026-07-02T15:42:27.072380+02:00",
+              "txt": "v=spf1 -all",
+              "host": 18
+            }
+          ],
+          "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "hostgroups": [],
+          "roles": [],
+          "hinfo": null,
+          "loc": null,
+          "bacnetid": null,
+          "communities": [],
+          "contacts": [],
+          "created_at": "2026-07-02T15:42:27.058955+02:00",
+          "updated_at": "2026-07-02T15:42:27.059018+02:00",
+          "name": "foo.example.org",
+          "ttl": null,
+          "comment": "",
+          "zone": 1,
+          "contact": ""
         }
       }
     ],
@@ -22322,58 +21749,6 @@
       },
       {
         "method": "GET",
-        "url": "/api/v1/hosts/foo.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "",
-              "created_at": "2025-12-18T11:57:40.666165+01:00",
-              "updated_at": "2025-12-18T11:57:40.666171+01:00",
-              "ipaddress": "10.0.0.5",
-              "host": 18
-            },
-            {
-              "macaddress": "",
-              "created_at": "2025-12-18T11:57:41.434196+01:00",
-              "updated_at": "2025-12-18T11:57:41.434204+01:00",
-              "ipaddress": "2001:db8::5",
-              "host": 18
-            }
-          ],
-          "cnames": [],
-          "mxs": [],
-          "txts": [
-            {
-              "created_at": "2025-12-18T11:57:39.783040+01:00",
-              "updated_at": "2025-12-18T11:57:39.783047+01:00",
-              "txt": "v=spf1 -all",
-              "host": 18
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "contacts": [],
-          "created_at": "2025-12-18T11:57:39.780995+01:00",
-          "updated_at": "2025-12-18T11:57:39.781005+01:00",
-          "name": "foo.example.org",
-          "ttl": null,
-          "comment": "",
-          "zone": 1,
-          "contact": ""
-        }
-      },
-      {
-        "method": "GET",
         "url": "/api/v1/networks/ip/10.0.0.5",
         "data": {},
         "status": 200,
@@ -22381,8 +21756,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-12-18T11:57:39.665988+01:00",
-          "updated_at": "2025-12-18T11:57:39.665997+01:00",
+          "created_at": "2026-07-02T15:12:33.801417+02:00",
+          "updated_at": "2026-07-02T15:12:33.801501+02:00",
           "network": "10.0.0.0/24",
           "description": "foo",
           "vlan": 1234,
@@ -22403,8 +21778,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-12-18T11:57:40.995174+01:00",
-          "updated_at": "2025-12-18T11:57:40.995182+01:00",
+          "created_at": "2026-07-02T15:12:40.995724+02:00",
+          "updated_at": "2026-07-02T15:12:40.995804+02:00",
           "network": "2001:db8::/64",
           "description": "foo_ipv6",
           "vlan": 1234,
@@ -22431,8 +21806,8 @@
         "status": 200,
         "response": {
           "macaddress": "aa:bb:cc:dd:ee:ff",
-          "created_at": "2025-12-18T11:57:40.666165+01:00",
-          "updated_at": "2025-12-18T11:57:41.644800+01:00",
+          "created_at": "2026-07-02T15:12:39.561031+02:00",
+          "updated_at": "2026-07-02T15:12:42.892751+02:00",
           "ipaddress": "10.0.0.5",
           "host": 18
         }
@@ -22887,8 +22262,8 @@
       "              10.0.0.10   11:22:33:aa:bb:cc   ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Sat Dec 20 12:45:11 2025",
-      "Updated:      Sat Dec 20 12:45:11 2025"
+      "Created:      Thu Jul  2 13:13:59 2026",
+      "Updated:      Thu Jul  2 13:13:59 2026"
     ],
     "api_requests": [
       {
@@ -22944,18 +22319,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2025-12-20T12:44:56.292305+01:00",
-                "updated_at": "2025-12-20T12:44:56.292318+01:00",
+                "created_at": "2026-07-02T13:13:16.058928+02:00",
+                "updated_at": "2026-07-02T13:13:16.058997+02:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-12-20T12:44:56.003483+01:00",
-            "updated_at": "2025-12-20T12:45:11.068458+01:00",
+            "created_at": "2026-07-02T13:13:15.549017+02:00",
+            "updated_at": "2026-07-02T13:13:58.392211+02:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-12-20T12:44:56.349179+01:00",
+            "serialno_updated_at": "2026-07-02T13:13:16.156907+02:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -22974,8 +22349,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-12-20T12:45:11.318919+01:00",
-          "updated_at": "2025-12-20T12:45:11.318932+01:00",
+          "created_at": "2026-07-02T13:13:58.937752+02:00",
+          "updated_at": "2026-07-02T13:13:58.937824+02:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -22992,10 +22367,10 @@
         "url": "/api/v1/hosts/",
         "data": {
           "name": "foo.example.org",
+          "comment": "meh",
           "contacts": [
             "hi@ho.com"
           ],
-          "comment": "meh",
           "ipaddress": "10.0.0.10"
         },
         "status": 201
@@ -23009,8 +22384,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-12-20T12:45:11.577078+01:00",
-              "updated_at": "2025-12-20T12:45:11.577084+01:00",
+              "created_at": "2026-07-02T13:13:59.623077+02:00",
+              "updated_at": "2026-07-02T13:13:59.623132+02:00",
               "ipaddress": "10.0.0.10",
               "host": 19
             }
@@ -23019,8 +22394,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-12-20T12:45:11.555297+01:00",
-              "updated_at": "2025-12-20T12:45:11.555305+01:00",
+              "created_at": "2026-07-02T13:13:59.499363+02:00",
+              "updated_at": "2026-07-02T13:13:59.499416+02:00",
               "txt": "v=spf1 -all",
               "host": 19
             }
@@ -23038,29 +22413,17 @@
           "contacts": [
             {
               "email": "hi@ho.com",
-              "created_at": "2025-12-20T12:45:11.558068+01:00",
-              "updated_at": "2025-12-20T12:45:11.558078+01:00"
+              "created_at": "2026-07-02T13:13:59.517973+02:00",
+              "updated_at": "2026-07-02T13:13:59.518032+02:00"
             }
           ],
-          "created_at": "2025-12-20T12:45:11.552482+01:00",
-          "updated_at": "2025-12-20T12:45:11.552491+01:00",
+          "created_at": "2026-07-02T13:13:59.487010+02:00",
+          "updated_at": "2026-07-02T13:13:59.487067+02:00",
           "name": "foo.example.org",
           "ttl": null,
           "comment": "meh",
           "zone": 1,
           "contact": "hi@ho.com"
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/ipaddresses/?macaddress=11%3A22%3A33%3Aaa%3Abb%3Acc&ordering=ipaddress",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
         }
       },
       {
@@ -23078,68 +22441,61 @@
         "status": 200,
         "response": {
           "macaddress": "11:22:33:aa:bb:cc",
-          "created_at": "2025-12-20T12:45:11.577078+01:00",
-          "updated_at": "2025-12-20T12:45:11.660436+01:00",
+          "created_at": "2026-07-02T13:13:59.623077+02:00",
+          "updated_at": "2026-07-02T13:13:59.864330+02:00",
           "ipaddress": "10.0.0.10",
           "host": 19
         }
       },
       {
         "method": "GET",
-        "url": "/api/v1/hosts/?id=19",
+        "url": "/api/v1/hosts/foo.example.org",
         "data": {},
         "status": 200,
         "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
+          "ipaddresses": [
             {
-              "ipaddresses": [
-                {
-                  "macaddress": "11:22:33:aa:bb:cc",
-                  "created_at": "2025-12-20T12:45:11.577078+01:00",
-                  "updated_at": "2025-12-20T12:45:11.660436+01:00",
-                  "ipaddress": "10.0.0.10",
-                  "host": 19
-                }
-              ],
-              "cnames": [],
-              "mxs": [],
-              "txts": [
-                {
-                  "created_at": "2025-12-20T12:45:11.555297+01:00",
-                  "updated_at": "2025-12-20T12:45:11.555305+01:00",
-                  "txt": "v=spf1 -all",
-                  "host": 19
-                }
-              ],
-              "ptr_overrides": [],
-              "srvs": [],
-              "naptrs": [],
-              "sshfps": [],
-              "hostgroups": [],
-              "roles": [],
-              "hinfo": null,
-              "loc": null,
-              "bacnetid": null,
-              "communities": [],
-              "contacts": [
-                {
-                  "email": "hi@ho.com",
-                  "created_at": "2025-12-20T12:45:11.558068+01:00",
-                  "updated_at": "2025-12-20T12:45:11.558078+01:00"
-                }
-              ],
-              "created_at": "2025-12-20T12:45:11.552482+01:00",
-              "updated_at": "2025-12-20T12:45:11.552491+01:00",
-              "name": "foo.example.org",
-              "ttl": null,
-              "comment": "meh",
-              "zone": 1,
-              "contact": "hi@ho.com"
+              "macaddress": "11:22:33:aa:bb:cc",
+              "created_at": "2026-07-02T13:13:59.623077+02:00",
+              "updated_at": "2026-07-02T13:13:59.864330+02:00",
+              "ipaddress": "10.0.0.10",
+              "host": 19
             }
-          ]
+          ],
+          "cnames": [],
+          "mxs": [],
+          "txts": [
+            {
+              "created_at": "2026-07-02T13:13:59.499363+02:00",
+              "updated_at": "2026-07-02T13:13:59.499416+02:00",
+              "txt": "v=spf1 -all",
+              "host": 19
+            }
+          ],
+          "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "hostgroups": [],
+          "roles": [],
+          "hinfo": null,
+          "loc": null,
+          "bacnetid": null,
+          "communities": [],
+          "contacts": [
+            {
+              "email": "hi@ho.com",
+              "created_at": "2026-07-02T13:13:59.517973+02:00",
+              "updated_at": "2026-07-02T13:13:59.518032+02:00"
+            }
+          ],
+          "created_at": "2026-07-02T13:13:59.487010+02:00",
+          "updated_at": "2026-07-02T13:13:59.487067+02:00",
+          "name": "foo.example.org",
+          "ttl": null,
+          "comment": "meh",
+          "zone": 1,
+          "contact": "hi@ho.com"
         }
       },
       {
@@ -23151,8 +22507,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-12-20T12:45:11.318919+01:00",
-          "updated_at": "2025-12-20T12:45:11.318932+01:00",
+          "created_at": "2026-07-02T13:13:58.937752+02:00",
+          "updated_at": "2026-07-02T13:13:58.937824+02:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -23184,62 +22540,10 @@
       "              10.0.0.10   11:22:33:aa:bb:cc   ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Thu Dec 18 11:57:42 2025",
-      "Updated:      Thu Dec 18 11:57:42 2025"
+      "Created:      Thu Jul  2 13:13:59 2026",
+      "Updated:      Thu Jul  2 13:13:59 2026"
     ],
-    "api_requests": [
-      {
-        "method": "GET",
-        "url": "/api/v1/hosts/foo.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2025-12-18T11:57:42.249661+01:00",
-              "updated_at": "2025-12-18T11:57:42.329996+01:00",
-              "ipaddress": "10.0.0.10",
-              "host": 19
-            }
-          ],
-          "cnames": [],
-          "mxs": [],
-          "txts": [
-            {
-              "created_at": "2025-12-18T11:57:42.230049+01:00",
-              "updated_at": "2025-12-18T11:57:42.230056+01:00",
-              "txt": "v=spf1 -all",
-              "host": 19
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "contacts": [
-            {
-              "email": "hi@ho.com",
-              "created_at": "2025-12-18T11:57:42.232796+01:00",
-              "updated_at": "2025-12-18T11:57:42.232806+01:00"
-            }
-          ],
-          "created_at": "2025-12-18T11:57:42.227827+01:00",
-          "updated_at": "2025-12-18T11:57:42.227837+01:00",
-          "name": "foo.example.org",
-          "ttl": null,
-          "comment": "meh",
-          "zone": 1,
-          "contact": "hi@ho.com"
-        }
-      }
-    ],
+    "api_requests": [],
     "time": null
   },
   {
@@ -24087,80 +23391,73 @@
         "url": "/api/v1/ipaddresses/",
         "data": {
           "ipaddress": "10.0.0.12",
-          "host": "19"
+          "host": 19
         },
         "status": 201,
         "response": {
           "macaddress": "",
-          "created_at": "2025-12-18T11:57:43.239182+01:00",
-          "updated_at": "2025-12-18T11:57:43.239188+01:00",
+          "created_at": "2026-07-02T15:42:41.680236+02:00",
+          "updated_at": "2026-07-02T15:42:41.680316+02:00",
           "ipaddress": "10.0.0.12",
           "host": 19
         }
       },
       {
         "method": "GET",
-        "url": "/api/v1/hosts/?id=19",
+        "url": "/api/v1/hosts/bar.example.org",
         "data": {},
         "status": 200,
         "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
+          "ipaddresses": [
             {
-              "ipaddresses": [
-                {
-                  "macaddress": "11:22:33:aa:bb:cc",
-                  "created_at": "2025-12-18T11:57:42.249661+01:00",
-                  "updated_at": "2025-12-18T11:57:42.329996+01:00",
-                  "ipaddress": "10.0.0.10",
-                  "host": 19
-                },
-                {
-                  "macaddress": "",
-                  "created_at": "2025-12-18T11:57:43.239182+01:00",
-                  "updated_at": "2025-12-18T11:57:43.239188+01:00",
-                  "ipaddress": "10.0.0.12",
-                  "host": 19
-                }
-              ],
-              "cnames": [],
-              "mxs": [],
-              "txts": [
-                {
-                  "created_at": "2025-12-18T11:57:42.230049+01:00",
-                  "updated_at": "2025-12-18T11:57:42.230056+01:00",
-                  "txt": "v=spf1 -all",
-                  "host": 19
-                }
-              ],
-              "ptr_overrides": [],
-              "srvs": [],
-              "naptrs": [],
-              "sshfps": [],
-              "hostgroups": [],
-              "roles": [],
-              "hinfo": null,
-              "loc": null,
-              "bacnetid": null,
-              "communities": [],
-              "contacts": [
-                {
-                  "email": "me@example.org",
-                  "created_at": "2025-12-18T11:57:30.192767+01:00",
-                  "updated_at": "2025-12-18T11:57:30.192776+01:00"
-                }
-              ],
-              "created_at": "2025-12-18T11:57:42.227827+01:00",
-              "updated_at": "2025-12-18T11:57:43.108914+01:00",
-              "name": "bar.example.org",
-              "ttl": null,
-              "comment": "This is the comment",
-              "zone": 1,
-              "contact": "me@example.org"
+              "macaddress": "11:22:33:aa:bb:cc",
+              "created_at": "2026-07-02T15:42:36.257996+02:00",
+              "updated_at": "2026-07-02T15:42:36.514761+02:00",
+              "ipaddress": "10.0.0.10",
+              "host": 19
+            },
+            {
+              "macaddress": "",
+              "created_at": "2026-07-02T15:42:41.680236+02:00",
+              "updated_at": "2026-07-02T15:42:41.680316+02:00",
+              "ipaddress": "10.0.0.12",
+              "host": 19
             }
-          ]
+          ],
+          "cnames": [],
+          "mxs": [],
+          "txts": [
+            {
+              "created_at": "2026-07-02T15:42:36.107569+02:00",
+              "updated_at": "2026-07-02T15:42:36.107628+02:00",
+              "txt": "v=spf1 -all",
+              "host": 19
+            }
+          ],
+          "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "hostgroups": [],
+          "roles": [],
+          "hinfo": null,
+          "loc": null,
+          "bacnetid": null,
+          "communities": [],
+          "contacts": [
+            {
+              "email": "me@example.org",
+              "created_at": "2026-07-02T15:42:41.009832+02:00",
+              "updated_at": "2026-07-02T15:42:41.009917+02:00"
+            }
+          ],
+          "created_at": "2026-07-02T15:42:36.090492+02:00",
+          "updated_at": "2026-07-02T15:42:40.980440+02:00",
+          "name": "bar.example.org",
+          "ttl": null,
+          "comment": "This is the comment",
+          "zone": 1,
+          "contact": "me@example.org"
         }
       }
     ],
@@ -24180,6 +23477,45 @@
     "api_requests": [
       {
         "method": "GET",
+        "url": "/api/v1/networks/ip/10.0.0.13",
+        "data": {},
+        "status": 200,
+        "response": {
+          "excluded_ranges": [],
+          "policy": null,
+          "communities": [],
+          "created_at": "2026-07-02T15:42:35.504123+02:00",
+          "updated_at": "2026-07-02T15:42:35.504218+02:00",
+          "network": "10.0.0.0/24",
+          "description": "lorem ipsum",
+          "vlan": null,
+          "dns_delegated": false,
+          "category": "",
+          "location": "",
+          "frozen": false,
+          "reserved": 3,
+          "max_communities": null
+        }
+      },
+      {
+        "method": "POST",
+        "url": "/api/v1/ipaddresses/",
+        "data": {
+          "ipaddress": "10.0.0.13",
+          "macaddress": "11:22:33:44:55:66",
+          "host": 19
+        },
+        "status": 201,
+        "response": {
+          "macaddress": "11:22:33:44:55:66",
+          "created_at": "2026-07-02T15:42:41.928158+02:00",
+          "updated_at": "2026-07-02T15:42:41.928216+02:00",
+          "ipaddress": "10.0.0.13",
+          "host": 19
+        }
+      },
+      {
+        "method": "GET",
         "url": "/api/v1/hosts/bar.example.org",
         "data": {},
         "status": 200,
@@ -24187,16 +23523,23 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2025-12-18T11:57:42.249661+01:00",
-              "updated_at": "2025-12-18T11:57:42.329996+01:00",
+              "created_at": "2026-07-02T15:42:36.257996+02:00",
+              "updated_at": "2026-07-02T15:42:36.514761+02:00",
               "ipaddress": "10.0.0.10",
               "host": 19
             },
             {
               "macaddress": "",
-              "created_at": "2025-12-18T11:57:43.239182+01:00",
-              "updated_at": "2025-12-18T11:57:43.239188+01:00",
+              "created_at": "2026-07-02T15:42:41.680236+02:00",
+              "updated_at": "2026-07-02T15:42:41.680316+02:00",
               "ipaddress": "10.0.0.12",
+              "host": 19
+            },
+            {
+              "macaddress": "11:22:33:44:55:66",
+              "created_at": "2026-07-02T15:42:41.928158+02:00",
+              "updated_at": "2026-07-02T15:42:41.928216+02:00",
+              "ipaddress": "10.0.0.13",
               "host": 19
             }
           ],
@@ -24204,8 +23547,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-12-18T11:57:42.230049+01:00",
-              "updated_at": "2025-12-18T11:57:42.230056+01:00",
+              "created_at": "2026-07-02T15:42:36.107569+02:00",
+              "updated_at": "2026-07-02T15:42:36.107628+02:00",
               "txt": "v=spf1 -all",
               "host": 19
             }
@@ -24223,128 +23566,17 @@
           "contacts": [
             {
               "email": "me@example.org",
-              "created_at": "2025-12-18T11:57:30.192767+01:00",
-              "updated_at": "2025-12-18T11:57:30.192776+01:00"
+              "created_at": "2026-07-02T15:42:41.009832+02:00",
+              "updated_at": "2026-07-02T15:42:41.009917+02:00"
             }
           ],
-          "created_at": "2025-12-18T11:57:42.227827+01:00",
-          "updated_at": "2025-12-18T11:57:43.108914+01:00",
+          "created_at": "2026-07-02T15:42:36.090492+02:00",
+          "updated_at": "2026-07-02T15:42:40.980440+02:00",
           "name": "bar.example.org",
           "ttl": null,
           "comment": "This is the comment",
           "zone": 1,
           "contact": "me@example.org"
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/ip/10.0.0.13",
-        "data": {},
-        "status": 200,
-        "response": {
-          "excluded_ranges": [],
-          "policy": null,
-          "communities": [],
-          "created_at": "2025-12-18T11:57:42.027647+01:00",
-          "updated_at": "2025-12-18T11:57:42.027657+01:00",
-          "network": "10.0.0.0/24",
-          "description": "lorem ipsum",
-          "vlan": null,
-          "dns_delegated": false,
-          "category": "",
-          "location": "",
-          "frozen": false,
-          "reserved": 3,
-          "max_communities": null
-        }
-      },
-      {
-        "method": "POST",
-        "url": "/api/v1/ipaddresses/",
-        "data": {
-          "ipaddress": "10.0.0.13",
-          "host": "19",
-          "macaddress": "11:22:33:44:55:66"
-        },
-        "status": 201,
-        "response": {
-          "macaddress": "11:22:33:44:55:66",
-          "created_at": "2025-12-18T11:57:43.362990+01:00",
-          "updated_at": "2025-12-18T11:57:43.362997+01:00",
-          "ipaddress": "10.0.0.13",
-          "host": 19
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hosts/?id=19",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
-            {
-              "ipaddresses": [
-                {
-                  "macaddress": "11:22:33:aa:bb:cc",
-                  "created_at": "2025-12-18T11:57:42.249661+01:00",
-                  "updated_at": "2025-12-18T11:57:42.329996+01:00",
-                  "ipaddress": "10.0.0.10",
-                  "host": 19
-                },
-                {
-                  "macaddress": "",
-                  "created_at": "2025-12-18T11:57:43.239182+01:00",
-                  "updated_at": "2025-12-18T11:57:43.239188+01:00",
-                  "ipaddress": "10.0.0.12",
-                  "host": 19
-                },
-                {
-                  "macaddress": "11:22:33:44:55:66",
-                  "created_at": "2025-12-18T11:57:43.362990+01:00",
-                  "updated_at": "2025-12-18T11:57:43.362997+01:00",
-                  "ipaddress": "10.0.0.13",
-                  "host": 19
-                }
-              ],
-              "cnames": [],
-              "mxs": [],
-              "txts": [
-                {
-                  "created_at": "2025-12-18T11:57:42.230049+01:00",
-                  "updated_at": "2025-12-18T11:57:42.230056+01:00",
-                  "txt": "v=spf1 -all",
-                  "host": 19
-                }
-              ],
-              "ptr_overrides": [],
-              "srvs": [],
-              "naptrs": [],
-              "sshfps": [],
-              "hostgroups": [],
-              "roles": [],
-              "hinfo": null,
-              "loc": null,
-              "bacnetid": null,
-              "communities": [],
-              "contacts": [
-                {
-                  "email": "me@example.org",
-                  "created_at": "2025-12-18T11:57:30.192767+01:00",
-                  "updated_at": "2025-12-18T11:57:30.192776+01:00"
-                }
-              ],
-              "created_at": "2025-12-18T11:57:42.227827+01:00",
-              "updated_at": "2025-12-18T11:57:43.108914+01:00",
-              "name": "bar.example.org",
-              "ttl": null,
-              "comment": "This is the comment",
-              "zone": 1,
-              "contact": "me@example.org"
-            }
-          ]
         }
       }
     ],
@@ -24371,8 +23603,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-12-18T11:57:42.027647+01:00",
-          "updated_at": "2025-12-18T11:57:42.027657+01:00",
+          "created_at": "2026-07-02T13:13:58.937752+02:00",
+          "updated_at": "2026-07-02T13:13:58.937824+02:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -24386,72 +23618,19 @@
       },
       {
         "method": "GET",
-        "url": "/api/v1/hosts/bar.example.org",
+        "url": "/api/v1/hosts/?ipaddresses__ipaddress=10.0.0.14",
         "data": {},
         "status": 200,
         "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2025-12-18T11:57:42.249661+01:00",
-              "updated_at": "2025-12-18T11:57:42.329996+01:00",
-              "ipaddress": "10.0.0.10",
-              "host": 19
-            },
-            {
-              "macaddress": "",
-              "created_at": "2025-12-18T11:57:43.239182+01:00",
-              "updated_at": "2025-12-18T11:57:43.239188+01:00",
-              "ipaddress": "10.0.0.12",
-              "host": 19
-            },
-            {
-              "macaddress": "11:22:33:44:55:66",
-              "created_at": "2025-12-18T11:57:43.362990+01:00",
-              "updated_at": "2025-12-18T11:57:43.362997+01:00",
-              "ipaddress": "10.0.0.13",
-              "host": 19
-            }
-          ],
-          "cnames": [],
-          "mxs": [],
-          "txts": [
-            {
-              "created_at": "2025-12-18T11:57:42.230049+01:00",
-              "updated_at": "2025-12-18T11:57:42.230056+01:00",
-              "txt": "v=spf1 -all",
-              "host": 19
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "contacts": [
-            {
-              "email": "me@example.org",
-              "created_at": "2025-12-18T11:57:30.192767+01:00",
-              "updated_at": "2025-12-18T11:57:30.192776+01:00"
-            }
-          ],
-          "created_at": "2025-12-18T11:57:42.227827+01:00",
-          "updated_at": "2025-12-18T11:57:43.108914+01:00",
-          "name": "bar.example.org",
-          "ttl": null,
-          "comment": "This is the comment",
-          "zone": 1,
-          "contact": "me@example.org"
+          "count": 0,
+          "next": null,
+          "previous": null,
+          "results": []
         }
       },
       {
         "method": "GET",
-        "url": "/api/v1/hosts/?ipaddresses__ipaddress=10.0.0.14&ordering=name",
+        "url": "/api/v1/hosts/?ptr_overrides__ipaddress=10.0.0.14",
         "data": {},
         "status": 200,
         "response": {
@@ -24476,8 +23655,8 @@
         "status": 200,
         "response": {
           "macaddress": "",
-          "created_at": "2025-12-18T11:57:43.239182+01:00",
-          "updated_at": "2025-12-18T11:57:43.570824+01:00",
+          "created_at": "2026-07-02T13:14:05.101869+02:00",
+          "updated_at": "2026-07-02T13:14:06.244202+02:00",
           "ipaddress": "10.0.0.14",
           "host": 19
         }
@@ -24506,8 +23685,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-12-18T11:57:42.027647+01:00",
-          "updated_at": "2025-12-18T11:57:42.027657+01:00",
+          "created_at": "2026-07-02T13:13:58.937752+02:00",
+          "updated_at": "2026-07-02T13:13:58.937824+02:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -24528,22 +23707,22 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2025-12-18T11:57:42.249661+01:00",
-              "updated_at": "2025-12-18T11:57:42.329996+01:00",
+              "created_at": "2026-07-02T13:13:59.623077+02:00",
+              "updated_at": "2026-07-02T13:13:59.864330+02:00",
               "ipaddress": "10.0.0.10",
               "host": 19
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2025-12-18T11:57:43.362990+01:00",
-              "updated_at": "2025-12-18T11:57:43.362997+01:00",
+              "created_at": "2026-07-02T13:14:05.374299+02:00",
+              "updated_at": "2026-07-02T13:14:05.374360+02:00",
               "ipaddress": "10.0.0.13",
               "host": 19
             },
             {
               "macaddress": "",
-              "created_at": "2025-12-18T11:57:43.239182+01:00",
-              "updated_at": "2025-12-18T11:57:43.570824+01:00",
+              "created_at": "2026-07-02T13:14:05.101869+02:00",
+              "updated_at": "2026-07-02T13:14:06.244202+02:00",
               "ipaddress": "10.0.0.14",
               "host": 19
             }
@@ -24552,8 +23731,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-12-18T11:57:42.230049+01:00",
-              "updated_at": "2025-12-18T11:57:42.230056+01:00",
+              "created_at": "2026-07-02T13:13:59.499363+02:00",
+              "updated_at": "2026-07-02T13:13:59.499416+02:00",
               "txt": "v=spf1 -all",
               "host": 19
             }
@@ -24571,12 +23750,12 @@
           "contacts": [
             {
               "email": "me@example.org",
-              "created_at": "2025-12-18T11:57:30.192767+01:00",
-              "updated_at": "2025-12-18T11:57:30.192776+01:00"
+              "created_at": "2026-07-02T13:14:04.498267+02:00",
+              "updated_at": "2026-07-02T13:14:04.498352+02:00"
             }
           ],
-          "created_at": "2025-12-18T11:57:42.227827+01:00",
-          "updated_at": "2025-12-18T11:57:43.108914+01:00",
+          "created_at": "2026-07-02T13:13:59.487010+02:00",
+          "updated_at": "2026-07-02T13:14:04.468914+02:00",
           "name": "bar.example.org",
           "ttl": null,
           "comment": "This is the comment",
@@ -24586,7 +23765,19 @@
       },
       {
         "method": "GET",
-        "url": "/api/v1/hosts/?ipaddresses__ipaddress=10.0.0.15&ordering=name",
+        "url": "/api/v1/hosts/?ipaddresses__ipaddress=10.0.0.15",
+        "data": {},
+        "status": 200,
+        "response": {
+          "count": 0,
+          "next": null,
+          "previous": null,
+          "results": []
+        }
+      },
+      {
+        "method": "GET",
+        "url": "/api/v1/hosts/?ptr_overrides__ipaddress=10.0.0.15",
         "data": {},
         "status": 200,
         "response": {
@@ -24611,8 +23802,8 @@
         "status": 200,
         "response": {
           "macaddress": "11:22:33:44:55:66",
-          "created_at": "2025-12-18T11:57:43.362990+01:00",
-          "updated_at": "2025-12-18T11:57:43.705817+01:00",
+          "created_at": "2026-07-02T13:14:05.374299+02:00",
+          "updated_at": "2026-07-02T13:14:07.149956+02:00",
           "ipaddress": "10.0.0.15",
           "host": 19
         }
@@ -25151,8 +24342,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-12-18T11:57:42.092548+01:00",
-          "updated_at": "2025-12-18T11:57:42.092561+01:00",
+          "created_at": "2026-07-02T15:42:35.739389+02:00",
+          "updated_at": "2026-07-02T15:42:35.739454+02:00",
           "network": "2001:db8::/64",
           "description": "dolor sit amet",
           "vlan": null,
@@ -25169,87 +24360,80 @@
         "url": "/api/v1/ipaddresses/",
         "data": {
           "ipaddress": "2001:db8::11",
-          "host": "19"
+          "host": 19
         },
         "status": 201,
         "response": {
           "macaddress": "",
-          "created_at": "2025-12-18T11:57:44.135080+01:00",
-          "updated_at": "2025-12-18T11:57:44.135087+01:00",
+          "created_at": "2026-07-02T15:42:45.268908+02:00",
+          "updated_at": "2026-07-02T15:42:45.268968+02:00",
           "ipaddress": "2001:db8::11",
           "host": 19
         }
       },
       {
         "method": "GET",
-        "url": "/api/v1/hosts/?id=19",
+        "url": "/api/v1/hosts/bar.example.org",
         "data": {},
         "status": 200,
         "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
+          "ipaddresses": [
             {
-              "ipaddresses": [
-                {
-                  "macaddress": "",
-                  "created_at": "2025-12-18T11:57:43.239182+01:00",
-                  "updated_at": "2025-12-18T11:57:43.570824+01:00",
-                  "ipaddress": "10.0.0.14",
-                  "host": 19
-                },
-                {
-                  "macaddress": "11:22:33:44:55:66",
-                  "created_at": "2025-12-18T11:57:43.362990+01:00",
-                  "updated_at": "2025-12-18T11:57:43.705817+01:00",
-                  "ipaddress": "10.0.0.15",
-                  "host": 19
-                },
-                {
-                  "macaddress": "",
-                  "created_at": "2025-12-18T11:57:44.135080+01:00",
-                  "updated_at": "2025-12-18T11:57:44.135087+01:00",
-                  "ipaddress": "2001:db8::11",
-                  "host": 19
-                }
-              ],
-              "cnames": [],
-              "mxs": [],
-              "txts": [
-                {
-                  "created_at": "2025-12-18T11:57:42.230049+01:00",
-                  "updated_at": "2025-12-18T11:57:42.230056+01:00",
-                  "txt": "v=spf1 -all",
-                  "host": 19
-                }
-              ],
-              "ptr_overrides": [],
-              "srvs": [],
-              "naptrs": [],
-              "sshfps": [],
-              "hostgroups": [],
-              "roles": [],
-              "hinfo": null,
-              "loc": null,
-              "bacnetid": null,
-              "communities": [],
-              "contacts": [
-                {
-                  "email": "me@example.org",
-                  "created_at": "2025-12-18T11:57:30.192767+01:00",
-                  "updated_at": "2025-12-18T11:57:30.192776+01:00"
-                }
-              ],
-              "created_at": "2025-12-18T11:57:42.227827+01:00",
-              "updated_at": "2025-12-18T11:57:43.108914+01:00",
-              "name": "bar.example.org",
-              "ttl": null,
-              "comment": "This is the comment",
-              "zone": 1,
-              "contact": "me@example.org"
+              "macaddress": "",
+              "created_at": "2026-07-02T15:42:41.680236+02:00",
+              "updated_at": "2026-07-02T15:42:42.802948+02:00",
+              "ipaddress": "10.0.0.14",
+              "host": 19
+            },
+            {
+              "macaddress": "11:22:33:44:55:66",
+              "created_at": "2026-07-02T15:42:41.928158+02:00",
+              "updated_at": "2026-07-02T15:42:43.880065+02:00",
+              "ipaddress": "10.0.0.15",
+              "host": 19
+            },
+            {
+              "macaddress": "",
+              "created_at": "2026-07-02T15:42:45.268908+02:00",
+              "updated_at": "2026-07-02T15:42:45.268968+02:00",
+              "ipaddress": "2001:db8::11",
+              "host": 19
             }
-          ]
+          ],
+          "cnames": [],
+          "mxs": [],
+          "txts": [
+            {
+              "created_at": "2026-07-02T15:42:36.107569+02:00",
+              "updated_at": "2026-07-02T15:42:36.107628+02:00",
+              "txt": "v=spf1 -all",
+              "host": 19
+            }
+          ],
+          "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "hostgroups": [],
+          "roles": [],
+          "hinfo": null,
+          "loc": null,
+          "bacnetid": null,
+          "communities": [],
+          "contacts": [
+            {
+              "email": "me@example.org",
+              "created_at": "2026-07-02T15:42:41.009832+02:00",
+              "updated_at": "2026-07-02T15:42:41.009917+02:00"
+            }
+          ],
+          "created_at": "2026-07-02T15:42:36.090492+02:00",
+          "updated_at": "2026-07-02T15:42:40.980440+02:00",
+          "name": "bar.example.org",
+          "ttl": null,
+          "comment": "This is the comment",
+          "zone": 1,
+          "contact": "me@example.org"
         }
       }
     ],
@@ -25269,6 +24453,45 @@
     "api_requests": [
       {
         "method": "GET",
+        "url": "/api/v1/networks/ip/2001%3Adb8%3A%3A12",
+        "data": {},
+        "status": 200,
+        "response": {
+          "excluded_ranges": [],
+          "policy": null,
+          "communities": [],
+          "created_at": "2026-07-02T15:42:35.739389+02:00",
+          "updated_at": "2026-07-02T15:42:35.739454+02:00",
+          "network": "2001:db8::/64",
+          "description": "dolor sit amet",
+          "vlan": null,
+          "dns_delegated": false,
+          "category": "",
+          "location": "",
+          "frozen": false,
+          "reserved": 3,
+          "max_communities": null
+        }
+      },
+      {
+        "method": "POST",
+        "url": "/api/v1/ipaddresses/",
+        "data": {
+          "ipaddress": "2001:db8::12",
+          "macaddress": "11:22:33:44:55:67",
+          "host": 19
+        },
+        "status": 201,
+        "response": {
+          "macaddress": "11:22:33:44:55:67",
+          "created_at": "2026-07-02T15:42:45.516752+02:00",
+          "updated_at": "2026-07-02T15:42:45.516806+02:00",
+          "ipaddress": "2001:db8::12",
+          "host": 19
+        }
+      },
+      {
+        "method": "GET",
         "url": "/api/v1/hosts/bar.example.org",
         "data": {},
         "status": 200,
@@ -25276,23 +24499,30 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-12-18T11:57:43.239182+01:00",
-              "updated_at": "2025-12-18T11:57:43.570824+01:00",
+              "created_at": "2026-07-02T15:42:41.680236+02:00",
+              "updated_at": "2026-07-02T15:42:42.802948+02:00",
               "ipaddress": "10.0.0.14",
               "host": 19
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2025-12-18T11:57:43.362990+01:00",
-              "updated_at": "2025-12-18T11:57:43.705817+01:00",
+              "created_at": "2026-07-02T15:42:41.928158+02:00",
+              "updated_at": "2026-07-02T15:42:43.880065+02:00",
               "ipaddress": "10.0.0.15",
               "host": 19
             },
             {
               "macaddress": "",
-              "created_at": "2025-12-18T11:57:44.135080+01:00",
-              "updated_at": "2025-12-18T11:57:44.135087+01:00",
+              "created_at": "2026-07-02T15:42:45.268908+02:00",
+              "updated_at": "2026-07-02T15:42:45.268968+02:00",
               "ipaddress": "2001:db8::11",
+              "host": 19
+            },
+            {
+              "macaddress": "11:22:33:44:55:67",
+              "created_at": "2026-07-02T15:42:45.516752+02:00",
+              "updated_at": "2026-07-02T15:42:45.516806+02:00",
+              "ipaddress": "2001:db8::12",
               "host": 19
             }
           ],
@@ -25300,8 +24530,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-12-18T11:57:42.230049+01:00",
-              "updated_at": "2025-12-18T11:57:42.230056+01:00",
+              "created_at": "2026-07-02T15:42:36.107569+02:00",
+              "updated_at": "2026-07-02T15:42:36.107628+02:00",
               "txt": "v=spf1 -all",
               "host": 19
             }
@@ -25319,135 +24549,17 @@
           "contacts": [
             {
               "email": "me@example.org",
-              "created_at": "2025-12-18T11:57:30.192767+01:00",
-              "updated_at": "2025-12-18T11:57:30.192776+01:00"
+              "created_at": "2026-07-02T15:42:41.009832+02:00",
+              "updated_at": "2026-07-02T15:42:41.009917+02:00"
             }
           ],
-          "created_at": "2025-12-18T11:57:42.227827+01:00",
-          "updated_at": "2025-12-18T11:57:43.108914+01:00",
+          "created_at": "2026-07-02T15:42:36.090492+02:00",
+          "updated_at": "2026-07-02T15:42:40.980440+02:00",
           "name": "bar.example.org",
           "ttl": null,
           "comment": "This is the comment",
           "zone": 1,
           "contact": "me@example.org"
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/ip/2001%3Adb8%3A%3A12",
-        "data": {},
-        "status": 200,
-        "response": {
-          "excluded_ranges": [],
-          "policy": null,
-          "communities": [],
-          "created_at": "2025-12-18T11:57:42.092548+01:00",
-          "updated_at": "2025-12-18T11:57:42.092561+01:00",
-          "network": "2001:db8::/64",
-          "description": "dolor sit amet",
-          "vlan": null,
-          "dns_delegated": false,
-          "category": "",
-          "location": "",
-          "frozen": false,
-          "reserved": 3,
-          "max_communities": null
-        }
-      },
-      {
-        "method": "POST",
-        "url": "/api/v1/ipaddresses/",
-        "data": {
-          "ipaddress": "2001:db8::12",
-          "host": "19",
-          "macaddress": "11:22:33:44:55:67"
-        },
-        "status": 201,
-        "response": {
-          "macaddress": "11:22:33:44:55:67",
-          "created_at": "2025-12-18T11:57:44.257547+01:00",
-          "updated_at": "2025-12-18T11:57:44.257553+01:00",
-          "ipaddress": "2001:db8::12",
-          "host": 19
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hosts/?id=19",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
-            {
-              "ipaddresses": [
-                {
-                  "macaddress": "",
-                  "created_at": "2025-12-18T11:57:43.239182+01:00",
-                  "updated_at": "2025-12-18T11:57:43.570824+01:00",
-                  "ipaddress": "10.0.0.14",
-                  "host": 19
-                },
-                {
-                  "macaddress": "11:22:33:44:55:66",
-                  "created_at": "2025-12-18T11:57:43.362990+01:00",
-                  "updated_at": "2025-12-18T11:57:43.705817+01:00",
-                  "ipaddress": "10.0.0.15",
-                  "host": 19
-                },
-                {
-                  "macaddress": "",
-                  "created_at": "2025-12-18T11:57:44.135080+01:00",
-                  "updated_at": "2025-12-18T11:57:44.135087+01:00",
-                  "ipaddress": "2001:db8::11",
-                  "host": 19
-                },
-                {
-                  "macaddress": "11:22:33:44:55:67",
-                  "created_at": "2025-12-18T11:57:44.257547+01:00",
-                  "updated_at": "2025-12-18T11:57:44.257553+01:00",
-                  "ipaddress": "2001:db8::12",
-                  "host": 19
-                }
-              ],
-              "cnames": [],
-              "mxs": [],
-              "txts": [
-                {
-                  "created_at": "2025-12-18T11:57:42.230049+01:00",
-                  "updated_at": "2025-12-18T11:57:42.230056+01:00",
-                  "txt": "v=spf1 -all",
-                  "host": 19
-                }
-              ],
-              "ptr_overrides": [],
-              "srvs": [],
-              "naptrs": [],
-              "sshfps": [],
-              "hostgroups": [],
-              "roles": [],
-              "hinfo": null,
-              "loc": null,
-              "bacnetid": null,
-              "communities": [],
-              "contacts": [
-                {
-                  "email": "me@example.org",
-                  "created_at": "2025-12-18T11:57:30.192767+01:00",
-                  "updated_at": "2025-12-18T11:57:30.192776+01:00"
-                }
-              ],
-              "created_at": "2025-12-18T11:57:42.227827+01:00",
-              "updated_at": "2025-12-18T11:57:43.108914+01:00",
-              "name": "bar.example.org",
-              "ttl": null,
-              "comment": "This is the comment",
-              "zone": 1,
-              "contact": "me@example.org"
-            }
-          ]
         }
       }
     ],
@@ -25467,78 +24579,6 @@
     "api_requests": [
       {
         "method": "GET",
-        "url": "/api/v1/hosts/bar.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "",
-              "created_at": "2025-12-18T11:57:43.239182+01:00",
-              "updated_at": "2025-12-18T11:57:43.570824+01:00",
-              "ipaddress": "10.0.0.14",
-              "host": 19
-            },
-            {
-              "macaddress": "11:22:33:44:55:66",
-              "created_at": "2025-12-18T11:57:43.362990+01:00",
-              "updated_at": "2025-12-18T11:57:43.705817+01:00",
-              "ipaddress": "10.0.0.15",
-              "host": 19
-            },
-            {
-              "macaddress": "",
-              "created_at": "2025-12-18T11:57:44.135080+01:00",
-              "updated_at": "2025-12-18T11:57:44.135087+01:00",
-              "ipaddress": "2001:db8::11",
-              "host": 19
-            },
-            {
-              "macaddress": "11:22:33:44:55:67",
-              "created_at": "2025-12-18T11:57:44.257547+01:00",
-              "updated_at": "2025-12-18T11:57:44.257553+01:00",
-              "ipaddress": "2001:db8::12",
-              "host": 19
-            }
-          ],
-          "cnames": [],
-          "mxs": [],
-          "txts": [
-            {
-              "created_at": "2025-12-18T11:57:42.230049+01:00",
-              "updated_at": "2025-12-18T11:57:42.230056+01:00",
-              "txt": "v=spf1 -all",
-              "host": 19
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "contacts": [
-            {
-              "email": "me@example.org",
-              "created_at": "2025-12-18T11:57:30.192767+01:00",
-              "updated_at": "2025-12-18T11:57:30.192776+01:00"
-            }
-          ],
-          "created_at": "2025-12-18T11:57:42.227827+01:00",
-          "updated_at": "2025-12-18T11:57:43.108914+01:00",
-          "name": "bar.example.org",
-          "ttl": null,
-          "comment": "This is the comment",
-          "zone": 1,
-          "contact": "me@example.org"
-        }
-      },
-      {
-        "method": "GET",
         "url": "/api/v1/networks/ip/10.0.0.14",
         "data": {},
         "status": 200,
@@ -25546,8 +24586,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-12-18T11:57:42.027647+01:00",
-          "updated_at": "2025-12-18T11:57:42.027657+01:00",
+          "created_at": "2026-07-02T15:42:35.504123+02:00",
+          "updated_at": "2026-07-02T15:42:35.504218+02:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -25568,8 +24608,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-12-18T11:57:42.027647+01:00",
-          "updated_at": "2025-12-18T11:57:42.027657+01:00",
+          "created_at": "2026-07-02T15:42:35.504123+02:00",
+          "updated_at": "2026-07-02T15:42:35.504218+02:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -25590,8 +24630,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-12-18T11:57:42.092548+01:00",
-          "updated_at": "2025-12-18T11:57:42.092561+01:00",
+          "created_at": "2026-07-02T15:42:35.739389+02:00",
+          "updated_at": "2026-07-02T15:42:35.739454+02:00",
           "network": "2001:db8::/64",
           "description": "dolor sit amet",
           "vlan": null,
@@ -25612,8 +24652,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-12-18T11:57:42.092548+01:00",
-          "updated_at": "2025-12-18T11:57:42.092561+01:00",
+          "created_at": "2026-07-02T15:42:35.739389+02:00",
+          "updated_at": "2026-07-02T15:42:35.739454+02:00",
           "network": "2001:db8::/64",
           "description": "dolor sit amet",
           "vlan": null,
@@ -25665,8 +24705,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-11-21T13:43:57.952836+01:00",
-          "updated_at": "2025-11-21T13:43:57.952852+01:00",
+          "created_at": "2026-07-02T15:42:35.739389+02:00",
+          "updated_at": "2026-07-02T15:42:35.739454+02:00",
           "network": "2001:db8::/64",
           "description": "dolor sit amet",
           "vlan": null,
@@ -25680,7 +24720,19 @@
       },
       {
         "method": "GET",
-        "url": "/api/v1/hosts/?ipaddresses__ipaddress=2001%3Adb8%3A%3A13&ordering=name",
+        "url": "/api/v1/hosts/?ipaddresses__ipaddress=2001%3Adb8%3A%3A13",
+        "data": {},
+        "status": 200,
+        "response": {
+          "count": 0,
+          "next": null,
+          "previous": null,
+          "results": []
+        }
+      },
+      {
+        "method": "GET",
+        "url": "/api/v1/hosts/?ptr_overrides__ipaddress=2001%3Adb8%3A%3A13",
         "data": {},
         "status": 200,
         "response": {
@@ -25705,8 +24757,8 @@
         "status": 200,
         "response": {
           "macaddress": "",
-          "created_at": "2025-11-21T13:44:01.817350+01:00",
-          "updated_at": "2025-11-21T13:44:02.394290+01:00",
+          "created_at": "2026-07-02T15:42:45.268908+02:00",
+          "updated_at": "2026-07-02T15:42:46.725954+02:00",
           "ipaddress": "2001:db8::13",
           "host": 19
         }
@@ -25735,8 +24787,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-12-18T11:57:42.092548+01:00",
-          "updated_at": "2025-12-18T11:57:42.092561+01:00",
+          "created_at": "2026-07-02T15:42:35.739389+02:00",
+          "updated_at": "2026-07-02T15:42:35.739454+02:00",
           "network": "2001:db8::/64",
           "description": "dolor sit amet",
           "vlan": null,
@@ -25757,29 +24809,29 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-12-18T11:57:43.239182+01:00",
-              "updated_at": "2025-12-18T11:57:43.570824+01:00",
+              "created_at": "2026-07-02T15:42:41.680236+02:00",
+              "updated_at": "2026-07-02T15:42:42.802948+02:00",
               "ipaddress": "10.0.0.14",
               "host": 19
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2025-12-18T11:57:43.362990+01:00",
-              "updated_at": "2025-12-18T11:57:43.705817+01:00",
+              "created_at": "2026-07-02T15:42:41.928158+02:00",
+              "updated_at": "2026-07-02T15:42:43.880065+02:00",
               "ipaddress": "10.0.0.15",
               "host": 19
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2025-12-18T11:57:44.257547+01:00",
-              "updated_at": "2025-12-18T11:57:44.257553+01:00",
+              "created_at": "2026-07-02T15:42:45.516752+02:00",
+              "updated_at": "2026-07-02T15:42:45.516806+02:00",
               "ipaddress": "2001:db8::12",
               "host": 19
             },
             {
               "macaddress": "",
-              "created_at": "2025-12-18T11:57:44.135080+01:00",
-              "updated_at": "2025-12-18T11:57:44.500670+01:00",
+              "created_at": "2026-07-02T15:42:45.268908+02:00",
+              "updated_at": "2026-07-02T15:42:46.725954+02:00",
               "ipaddress": "2001:db8::13",
               "host": 19
             }
@@ -25788,8 +24840,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-12-18T11:57:42.230049+01:00",
-              "updated_at": "2025-12-18T11:57:42.230056+01:00",
+              "created_at": "2026-07-02T15:42:36.107569+02:00",
+              "updated_at": "2026-07-02T15:42:36.107628+02:00",
               "txt": "v=spf1 -all",
               "host": 19
             }
@@ -25807,12 +24859,12 @@
           "contacts": [
             {
               "email": "me@example.org",
-              "created_at": "2025-12-18T11:57:30.192767+01:00",
-              "updated_at": "2025-12-18T11:57:30.192776+01:00"
+              "created_at": "2026-07-02T15:42:41.009832+02:00",
+              "updated_at": "2026-07-02T15:42:41.009917+02:00"
             }
           ],
-          "created_at": "2025-12-18T11:57:42.227827+01:00",
-          "updated_at": "2025-12-18T11:57:43.108914+01:00",
+          "created_at": "2026-07-02T15:42:36.090492+02:00",
+          "updated_at": "2026-07-02T15:42:40.980440+02:00",
           "name": "bar.example.org",
           "ttl": null,
           "comment": "This is the comment",
@@ -25822,7 +24874,19 @@
       },
       {
         "method": "GET",
-        "url": "/api/v1/hosts/?ipaddresses__ipaddress=2001%3Adb8%3A%3A14&ordering=name",
+        "url": "/api/v1/hosts/?ipaddresses__ipaddress=2001%3Adb8%3A%3A14",
+        "data": {},
+        "status": 200,
+        "response": {
+          "count": 0,
+          "next": null,
+          "previous": null,
+          "results": []
+        }
+      },
+      {
+        "method": "GET",
+        "url": "/api/v1/hosts/?ptr_overrides__ipaddress=2001%3Adb8%3A%3A14",
         "data": {},
         "status": 200,
         "response": {
@@ -25847,8 +24911,8 @@
         "status": 200,
         "response": {
           "macaddress": "11:22:33:44:55:67",
-          "created_at": "2025-12-18T11:57:44.257547+01:00",
-          "updated_at": "2025-12-18T11:57:44.639146+01:00",
+          "created_at": "2026-07-02T15:42:45.516752+02:00",
+          "updated_at": "2026-07-02T15:42:47.678166+02:00",
           "ipaddress": "2001:db8::14",
           "host": 19
         }
@@ -26184,15 +25248,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-12-18T11:57:43.239182+01:00",
-              "updated_at": "2025-12-18T11:57:43.570824+01:00",
+              "created_at": "2026-07-02T15:54:14.139983+02:00",
+              "updated_at": "2026-07-02T15:54:15.362398+02:00",
               "ipaddress": "10.0.0.14",
               "host": 19
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2025-12-18T11:57:43.362990+01:00",
-              "updated_at": "2025-12-18T11:57:43.705817+01:00",
+              "created_at": "2026-07-02T15:54:14.369446+02:00",
+              "updated_at": "2026-07-02T15:54:16.374090+02:00",
               "ipaddress": "10.0.0.15",
               "host": 19
             }
@@ -26201,8 +25265,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-12-18T11:57:42.230049+01:00",
-              "updated_at": "2025-12-18T11:57:42.230056+01:00",
+              "created_at": "2026-07-02T15:54:08.992515+02:00",
+              "updated_at": "2026-07-02T15:54:08.992570+02:00",
               "txt": "v=spf1 -all",
               "host": 19
             }
@@ -26220,12 +25284,12 @@
           "contacts": [
             {
               "email": "me@example.org",
-              "created_at": "2025-12-18T11:57:30.192767+01:00",
-              "updated_at": "2025-12-18T11:57:30.192776+01:00"
+              "created_at": "2026-07-02T15:54:13.502932+02:00",
+              "updated_at": "2026-07-02T15:54:13.503001+02:00"
             }
           ],
-          "created_at": "2025-12-18T11:57:42.227827+01:00",
-          "updated_at": "2025-12-18T11:57:43.108914+01:00",
+          "created_at": "2026-07-02T15:54:08.979653+02:00",
+          "updated_at": "2026-07-02T15:54:13.479118+02:00",
           "name": "bar.example.org",
           "ttl": null,
           "comment": "This is the comment",
@@ -26274,18 +25338,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2025-12-18T11:57:28.616170+01:00",
-                "updated_at": "2025-12-18T11:57:28.616179+01:00",
+                "created_at": "2026-07-02T15:53:25.620694+02:00",
+                "updated_at": "2026-07-02T15:53:25.620774+02:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-12-18T11:57:28.475473+01:00",
-            "updated_at": "2025-12-18T11:57:44.799559+01:00",
+            "created_at": "2026-07-02T15:53:23.929576+02:00",
+            "updated_at": "2026-07-02T15:54:20.519498+02:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-12-18T11:57:28.657477+01:00",
+            "serialno_updated_at": "2026-07-02T15:53:27.305422+02:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -26304,8 +25368,8 @@
         },
         "status": 201,
         "response": {
-          "created_at": "2025-12-18T11:57:44.948284+01:00",
-          "updated_at": "2025-12-18T11:57:44.948304+01:00",
+          "created_at": "2026-07-02T15:54:20.926129+02:00",
+          "updated_at": "2026-07-02T15:54:20.926190+02:00",
           "name": "fubar.example.org",
           "ttl": null,
           "zone": 1,
@@ -26314,74 +25378,7 @@
       },
       {
         "method": "GET",
-        "url": "/api/v1/hosts/bar.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "",
-              "created_at": "2025-12-18T11:57:43.239182+01:00",
-              "updated_at": "2025-12-18T11:57:43.570824+01:00",
-              "ipaddress": "10.0.0.14",
-              "host": 19
-            },
-            {
-              "macaddress": "11:22:33:44:55:66",
-              "created_at": "2025-12-18T11:57:43.362990+01:00",
-              "updated_at": "2025-12-18T11:57:43.705817+01:00",
-              "ipaddress": "10.0.0.15",
-              "host": 19
-            }
-          ],
-          "cnames": [
-            {
-              "created_at": "2025-12-18T11:57:44.948284+01:00",
-              "updated_at": "2025-12-18T11:57:44.948304+01:00",
-              "name": "fubar.example.org",
-              "ttl": null,
-              "zone": 1,
-              "host": 19
-            }
-          ],
-          "mxs": [],
-          "txts": [
-            {
-              "created_at": "2025-12-18T11:57:42.230049+01:00",
-              "updated_at": "2025-12-18T11:57:42.230056+01:00",
-              "txt": "v=spf1 -all",
-              "host": 19
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "contacts": [
-            {
-              "email": "me@example.org",
-              "created_at": "2025-12-18T11:57:30.192767+01:00",
-              "updated_at": "2025-12-18T11:57:30.192776+01:00"
-            }
-          ],
-          "created_at": "2025-12-18T11:57:42.227827+01:00",
-          "updated_at": "2025-12-18T11:57:43.108914+01:00",
-          "name": "bar.example.org",
-          "ttl": null,
-          "comment": "This is the comment",
-          "zone": 1,
-          "contact": "me@example.org"
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/cnames/?host=19&name=fubar.example.org",
+        "url": "/api/v1/cnames/?name=fubar.example.org&host=19",
         "data": {},
         "status": 200,
         "response": {
@@ -26390,8 +25387,8 @@
           "previous": null,
           "results": [
             {
-              "created_at": "2025-12-18T11:57:44.948284+01:00",
-              "updated_at": "2025-12-18T11:57:44.948304+01:00",
+              "created_at": "2026-07-02T15:54:20.926129+02:00",
+              "updated_at": "2026-07-02T15:54:20.926190+02:00",
               "name": "fubar.example.org",
               "ttl": null,
               "zone": 1,
@@ -26417,6 +25414,73 @@
     "api_requests": [
       {
         "method": "GET",
+        "url": "/api/v1/hosts/bar.example.org",
+        "data": {},
+        "status": 200,
+        "response": {
+          "ipaddresses": [
+            {
+              "macaddress": "",
+              "created_at": "2026-07-02T15:54:14.139983+02:00",
+              "updated_at": "2026-07-02T15:54:15.362398+02:00",
+              "ipaddress": "10.0.0.14",
+              "host": 19
+            },
+            {
+              "macaddress": "11:22:33:44:55:66",
+              "created_at": "2026-07-02T15:54:14.369446+02:00",
+              "updated_at": "2026-07-02T15:54:16.374090+02:00",
+              "ipaddress": "10.0.0.15",
+              "host": 19
+            }
+          ],
+          "cnames": [
+            {
+              "created_at": "2026-07-02T15:54:20.926129+02:00",
+              "updated_at": "2026-07-02T15:54:20.926190+02:00",
+              "name": "fubar.example.org",
+              "ttl": null,
+              "zone": 1,
+              "host": 19
+            }
+          ],
+          "mxs": [],
+          "txts": [
+            {
+              "created_at": "2026-07-02T15:54:08.992515+02:00",
+              "updated_at": "2026-07-02T15:54:08.992570+02:00",
+              "txt": "v=spf1 -all",
+              "host": 19
+            }
+          ],
+          "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "hostgroups": [],
+          "roles": [],
+          "hinfo": null,
+          "loc": null,
+          "bacnetid": null,
+          "communities": [],
+          "contacts": [
+            {
+              "email": "me@example.org",
+              "created_at": "2026-07-02T15:54:13.502932+02:00",
+              "updated_at": "2026-07-02T15:54:13.503001+02:00"
+            }
+          ],
+          "created_at": "2026-07-02T15:54:08.979653+02:00",
+          "updated_at": "2026-07-02T15:54:13.479118+02:00",
+          "name": "bar.example.org",
+          "ttl": null,
+          "comment": "This is the comment",
+          "zone": 1,
+          "contact": "me@example.org"
+        }
+      },
+      {
+        "method": "GET",
         "url": "/api/v1/networks/ip/10.0.0.14",
         "data": {},
         "status": 200,
@@ -26424,8 +25488,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2026-03-27T11:43:07.055968+01:00",
-          "updated_at": "2026-03-27T11:43:07.055977+01:00",
+          "created_at": "2026-07-02T15:54:08.446436+02:00",
+          "updated_at": "2026-07-02T15:54:08.446498+02:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -26446,8 +25510,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2026-03-27T11:43:07.055968+01:00",
-          "updated_at": "2026-03-27T11:43:07.055977+01:00",
+          "created_at": "2026-07-02T15:54:08.446436+02:00",
+          "updated_at": "2026-07-02T15:54:08.446498+02:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -26548,15 +25612,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2025-12-18T11:57:42.249661+01:00",
-              "updated_at": "2025-12-18T11:57:43.967359+01:00",
+              "created_at": "2026-07-02T15:54:09.136747+02:00",
+              "updated_at": "2026-07-02T15:54:17.369260+02:00",
               "ipaddress": "10.0.0.10",
               "host": 20
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2025-12-18T11:57:44.257547+01:00",
-              "updated_at": "2025-12-18T11:57:44.800173+01:00",
+              "created_at": "2026-07-02T15:54:18.111329+02:00",
+              "updated_at": "2026-07-02T15:54:20.522842+02:00",
               "ipaddress": "2001:db8::14",
               "host": 20
             }
@@ -26565,8 +25629,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-12-18T11:57:43.828754+01:00",
-              "updated_at": "2025-12-18T11:57:43.828759+01:00",
+              "created_at": "2026-07-02T15:54:16.693866+02:00",
+              "updated_at": "2026-07-02T15:54:16.693922+02:00",
               "txt": "v=spf1 -all",
               "host": 20
             }
@@ -26582,8 +25646,8 @@
           "bacnetid": null,
           "communities": [],
           "contacts": [],
-          "created_at": "2025-12-18T11:57:43.827115+01:00",
-          "updated_at": "2025-12-18T11:57:43.827125+01:00",
+          "created_at": "2026-07-02T15:54:16.681911+02:00",
+          "updated_at": "2026-07-02T15:54:16.681966+02:00",
           "name": "baz.example.org",
           "ttl": null,
           "comment": "",
@@ -26602,75 +25666,23 @@
         "status": 201,
         "response": {
           "host": 20,
-          "created_at": "2025-12-18T11:57:45.147882+01:00",
-          "updated_at": "2025-12-18T11:57:45.147888+01:00",
+          "created_at": "2026-07-02T15:54:21.613218+02:00",
+          "updated_at": "2026-07-02T15:54:21.613275+02:00",
           "cpu": "x86",
           "os": "Win"
         }
       },
       {
         "method": "GET",
-        "url": "/api/v1/hosts/?id=20",
+        "url": "/api/v1/hinfos/20",
         "data": {},
         "status": 200,
         "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
-            {
-              "ipaddresses": [
-                {
-                  "macaddress": "11:22:33:aa:bb:cc",
-                  "created_at": "2025-12-18T11:57:42.249661+01:00",
-                  "updated_at": "2025-12-18T11:57:43.967359+01:00",
-                  "ipaddress": "10.0.0.10",
-                  "host": 20
-                },
-                {
-                  "macaddress": "11:22:33:44:55:67",
-                  "created_at": "2025-12-18T11:57:44.257547+01:00",
-                  "updated_at": "2025-12-18T11:57:44.800173+01:00",
-                  "ipaddress": "2001:db8::14",
-                  "host": 20
-                }
-              ],
-              "cnames": [],
-              "mxs": [],
-              "txts": [
-                {
-                  "created_at": "2025-12-18T11:57:43.828754+01:00",
-                  "updated_at": "2025-12-18T11:57:43.828759+01:00",
-                  "txt": "v=spf1 -all",
-                  "host": 20
-                }
-              ],
-              "ptr_overrides": [],
-              "srvs": [],
-              "naptrs": [],
-              "sshfps": [],
-              "hostgroups": [],
-              "roles": [],
-              "hinfo": {
-                "host": 20,
-                "created_at": "2025-12-18T11:57:45.147882+01:00",
-                "updated_at": "2025-12-18T11:57:45.147888+01:00",
-                "cpu": "x86",
-                "os": "Win"
-              },
-              "loc": null,
-              "bacnetid": null,
-              "communities": [],
-              "contacts": [],
-              "created_at": "2025-12-18T11:57:43.827115+01:00",
-              "updated_at": "2025-12-18T11:57:43.827125+01:00",
-              "name": "baz.example.org",
-              "ttl": null,
-              "comment": "",
-              "zone": 1,
-              "contact": ""
-            }
-          ]
+          "host": 20,
+          "created_at": "2026-07-02T15:54:21.613218+02:00",
+          "updated_at": "2026-07-02T15:54:21.613275+02:00",
+          "cpu": "x86",
+          "os": "Win"
         }
       }
     ],
@@ -26697,15 +25709,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2025-12-18T11:57:42.249661+01:00",
-              "updated_at": "2025-12-18T11:57:43.967359+01:00",
+              "created_at": "2026-07-02T15:54:09.136747+02:00",
+              "updated_at": "2026-07-02T15:54:17.369260+02:00",
               "ipaddress": "10.0.0.10",
               "host": 20
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2025-12-18T11:57:44.257547+01:00",
-              "updated_at": "2025-12-18T11:57:44.800173+01:00",
+              "created_at": "2026-07-02T15:54:18.111329+02:00",
+              "updated_at": "2026-07-02T15:54:20.522842+02:00",
               "ipaddress": "2001:db8::14",
               "host": 20
             }
@@ -26714,8 +25726,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-12-18T11:57:43.828754+01:00",
-              "updated_at": "2025-12-18T11:57:43.828759+01:00",
+              "created_at": "2026-07-02T15:54:16.693866+02:00",
+              "updated_at": "2026-07-02T15:54:16.693922+02:00",
               "txt": "v=spf1 -all",
               "host": 20
             }
@@ -26728,8 +25740,8 @@
           "roles": [],
           "hinfo": {
             "host": 20,
-            "created_at": "2025-12-18T11:57:45.147882+01:00",
-            "updated_at": "2025-12-18T11:57:45.147888+01:00",
+            "created_at": "2026-07-02T15:54:21.613218+02:00",
+            "updated_at": "2026-07-02T15:54:21.613275+02:00",
             "cpu": "x86",
             "os": "Win"
           },
@@ -26737,26 +25749,13 @@
           "bacnetid": null,
           "communities": [],
           "contacts": [],
-          "created_at": "2025-12-18T11:57:43.827115+01:00",
-          "updated_at": "2025-12-18T11:57:43.827125+01:00",
+          "created_at": "2026-07-02T15:54:16.681911+02:00",
+          "updated_at": "2026-07-02T15:54:16.681966+02:00",
           "name": "baz.example.org",
           "ttl": null,
           "comment": "",
           "zone": 1,
           "contact": ""
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/hinfos/20",
-        "data": {},
-        "status": 200,
-        "response": {
-          "host": 20,
-          "created_at": "2025-12-18T11:57:45.147882+01:00",
-          "updated_at": "2025-12-18T11:57:45.147888+01:00",
-          "cpu": "x86",
-          "os": "Win"
         }
       }
     ],
@@ -26804,15 +25803,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2025-12-18T11:57:42.249661+01:00",
-              "updated_at": "2025-12-18T11:57:43.967359+01:00",
+              "created_at": "2026-07-02T15:54:09.136747+02:00",
+              "updated_at": "2026-07-02T15:54:17.369260+02:00",
               "ipaddress": "10.0.0.10",
               "host": 20
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2025-12-18T11:57:44.257547+01:00",
-              "updated_at": "2025-12-18T11:57:44.800173+01:00",
+              "created_at": "2026-07-02T15:54:18.111329+02:00",
+              "updated_at": "2026-07-02T15:54:20.522842+02:00",
               "ipaddress": "2001:db8::14",
               "host": 20
             }
@@ -26821,8 +25820,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-12-18T11:57:43.828754+01:00",
-              "updated_at": "2025-12-18T11:57:43.828759+01:00",
+              "created_at": "2026-07-02T15:54:16.693866+02:00",
+              "updated_at": "2026-07-02T15:54:16.693922+02:00",
               "txt": "v=spf1 -all",
               "host": 20
             }
@@ -26838,8 +25837,8 @@
           "bacnetid": null,
           "communities": [],
           "contacts": [],
-          "created_at": "2025-12-18T11:57:43.827115+01:00",
-          "updated_at": "2025-12-18T11:57:43.827125+01:00",
+          "created_at": "2026-07-02T15:54:16.681911+02:00",
+          "updated_at": "2026-07-02T15:54:16.681966+02:00",
           "name": "baz.example.org",
           "ttl": null,
           "comment": "",
@@ -26857,73 +25856,21 @@
         "status": 201,
         "response": {
           "host": 20,
-          "created_at": "2025-12-18T11:57:45.348974+01:00",
-          "updated_at": "2025-12-18T11:57:45.348980+01:00",
+          "created_at": "2026-07-02T15:54:21.973323+02:00",
+          "updated_at": "2026-07-02T15:54:21.973381+02:00",
           "loc": "52 22 23.000 N 4 53 32.000 E -2.00m 0.00m 10000m 10m"
         }
       },
       {
         "method": "GET",
-        "url": "/api/v1/hosts/?id=20",
+        "url": "/api/v1/locs/20",
         "data": {},
         "status": 200,
         "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
-            {
-              "ipaddresses": [
-                {
-                  "macaddress": "11:22:33:aa:bb:cc",
-                  "created_at": "2025-12-18T11:57:42.249661+01:00",
-                  "updated_at": "2025-12-18T11:57:43.967359+01:00",
-                  "ipaddress": "10.0.0.10",
-                  "host": 20
-                },
-                {
-                  "macaddress": "11:22:33:44:55:67",
-                  "created_at": "2025-12-18T11:57:44.257547+01:00",
-                  "updated_at": "2025-12-18T11:57:44.800173+01:00",
-                  "ipaddress": "2001:db8::14",
-                  "host": 20
-                }
-              ],
-              "cnames": [],
-              "mxs": [],
-              "txts": [
-                {
-                  "created_at": "2025-12-18T11:57:43.828754+01:00",
-                  "updated_at": "2025-12-18T11:57:43.828759+01:00",
-                  "txt": "v=spf1 -all",
-                  "host": 20
-                }
-              ],
-              "ptr_overrides": [],
-              "srvs": [],
-              "naptrs": [],
-              "sshfps": [],
-              "hostgroups": [],
-              "roles": [],
-              "hinfo": null,
-              "loc": {
-                "host": 20,
-                "created_at": "2025-12-18T11:57:45.348974+01:00",
-                "updated_at": "2025-12-18T11:57:45.348980+01:00",
-                "loc": "52 22 23.000 N 4 53 32.000 E -2.00m 0.00m 10000m 10m"
-              },
-              "bacnetid": null,
-              "communities": [],
-              "contacts": [],
-              "created_at": "2025-12-18T11:57:43.827115+01:00",
-              "updated_at": "2025-12-18T11:57:43.827125+01:00",
-              "name": "baz.example.org",
-              "ttl": null,
-              "comment": "",
-              "zone": 1,
-              "contact": ""
-            }
-          ]
+          "host": 20,
+          "created_at": "2026-07-02T15:54:21.973323+02:00",
+          "updated_at": "2026-07-02T15:54:21.973381+02:00",
+          "loc": "52 22 23.000 N 4 53 32.000 E -2.00m 0.00m 10000m 10m"
         }
       }
     ],
@@ -27043,15 +25990,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2025-12-18T11:57:42.249661+01:00",
-              "updated_at": "2025-12-18T11:57:43.967359+01:00",
+              "created_at": "2026-07-02T15:54:09.136747+02:00",
+              "updated_at": "2026-07-02T15:54:17.369260+02:00",
               "ipaddress": "10.0.0.10",
               "host": 20
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2025-12-18T11:57:44.257547+01:00",
-              "updated_at": "2025-12-18T11:57:44.800173+01:00",
+              "created_at": "2026-07-02T15:54:18.111329+02:00",
+              "updated_at": "2026-07-02T15:54:20.522842+02:00",
               "ipaddress": "2001:db8::14",
               "host": 20
             }
@@ -27060,8 +26007,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-12-18T11:57:43.828754+01:00",
-              "updated_at": "2025-12-18T11:57:43.828759+01:00",
+              "created_at": "2026-07-02T15:54:16.693866+02:00",
+              "updated_at": "2026-07-02T15:54:16.693922+02:00",
               "txt": "v=spf1 -all",
               "host": 20
             }
@@ -27077,8 +26024,8 @@
           "bacnetid": null,
           "communities": [],
           "contacts": [],
-          "created_at": "2025-12-18T11:57:43.827115+01:00",
-          "updated_at": "2025-12-18T11:57:43.827125+01:00",
+          "created_at": "2026-07-02T15:54:16.681911+02:00",
+          "updated_at": "2026-07-02T15:54:16.681966+02:00",
           "name": "baz.example.org",
           "ttl": null,
           "comment": "",
@@ -27091,13 +26038,13 @@
         "url": "/api/v1/mxs/",
         "data": {
           "host": 20,
-          "priority": 10,
-          "mx": "mail.example.org"
+          "mx": "mail.example.org",
+          "priority": 10
         },
         "status": 201,
         "response": {
-          "created_at": "2025-12-18T11:57:45.502612+01:00",
-          "updated_at": "2025-12-18T11:57:45.502618+01:00",
+          "created_at": "2026-07-02T15:54:22.340464+02:00",
+          "updated_at": "2026-07-02T15:54:22.340518+02:00",
           "priority": 10,
           "mx": "mail.example.org",
           "host": 20
@@ -27303,15 +26250,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2025-12-18T11:57:42.249661+01:00",
-              "updated_at": "2025-12-18T11:57:43.967359+01:00",
+              "created_at": "2026-07-02T15:54:09.136747+02:00",
+              "updated_at": "2026-07-02T15:54:17.369260+02:00",
               "ipaddress": "10.0.0.10",
               "host": 20
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2025-12-18T11:57:44.257547+01:00",
-              "updated_at": "2025-12-18T11:57:44.800173+01:00",
+              "created_at": "2026-07-02T15:54:18.111329+02:00",
+              "updated_at": "2026-07-02T15:54:20.522842+02:00",
               "ipaddress": "2001:db8::14",
               "host": 20
             }
@@ -27320,8 +26267,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-12-18T11:57:43.828754+01:00",
-              "updated_at": "2025-12-18T11:57:43.828759+01:00",
+              "created_at": "2026-07-02T15:54:16.693866+02:00",
+              "updated_at": "2026-07-02T15:54:16.693922+02:00",
               "txt": "v=spf1 -all",
               "host": 20
             }
@@ -27337,8 +26284,8 @@
           "bacnetid": null,
           "communities": [],
           "contacts": [],
-          "created_at": "2025-12-18T11:57:43.827115+01:00",
-          "updated_at": "2025-12-18T11:57:43.827125+01:00",
+          "created_at": "2026-07-02T15:54:16.681911+02:00",
+          "updated_at": "2026-07-02T15:54:16.681966+02:00",
           "name": "baz.example.org",
           "ttl": null,
           "comment": "",
@@ -27348,7 +26295,7 @@
       },
       {
         "method": "GET",
-        "url": "/api/v1/naptrs/?preference=16384&order=3&flag=u&service=SIP&regex=%5Babc%5D%2B&replacement=wonk&host=20",
+        "url": "/api/v1/naptrs/?host=20&preference=16384&order=3&flag=u&service=SIP&regex=%5Babc%5D%2B&replacement=wonk&page_size=1",
         "data": {},
         "status": 200,
         "response": {
@@ -27362,18 +26309,18 @@
         "method": "POST",
         "url": "/api/v1/naptrs/",
         "data": {
+          "host": 20,
           "preference": 16384,
           "order": 3,
           "flag": "u",
           "service": "SIP",
           "regex": "[abc]+",
-          "replacement": "wonk",
-          "host": 20
+          "replacement": "wonk"
         },
         "status": 201,
         "response": {
-          "created_at": "2025-12-18T11:57:45.700638+01:00",
-          "updated_at": "2025-12-18T11:57:45.700645+01:00",
+          "created_at": "2026-07-02T15:54:23.040839+02:00",
+          "updated_at": "2026-07-02T15:54:23.040924+02:00",
           "preference": 16384,
           "order": 3,
           "flag": "u",
@@ -27508,15 +26455,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2026-04-24T13:14:13.137107+02:00",
-              "updated_at": "2026-04-24T13:14:23.189953+02:00",
+              "created_at": "2026-07-02T15:54:09.136747+02:00",
+              "updated_at": "2026-07-02T15:54:17.369260+02:00",
               "ipaddress": "10.0.0.10",
               "host": 20
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2026-04-24T13:14:24.505828+02:00",
-              "updated_at": "2026-04-24T13:14:27.229134+02:00",
+              "created_at": "2026-07-02T15:54:18.111329+02:00",
+              "updated_at": "2026-07-02T15:54:20.522842+02:00",
               "ipaddress": "2001:db8::14",
               "host": 20
             }
@@ -27525,8 +26472,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2026-04-24T13:14:22.395738+02:00",
-              "updated_at": "2026-04-24T13:14:22.395797+02:00",
+              "created_at": "2026-07-02T15:54:16.693866+02:00",
+              "updated_at": "2026-07-02T15:54:16.693922+02:00",
               "txt": "v=spf1 -all",
               "host": 20
             }
@@ -27542,8 +26489,8 @@
           "bacnetid": null,
           "communities": [],
           "contacts": [],
-          "created_at": "2026-04-24T13:14:22.378394+02:00",
-          "updated_at": "2026-04-24T13:14:22.378456+02:00",
+          "created_at": "2026-07-02T15:54:16.681911+02:00",
+          "updated_at": "2026-07-02T15:54:16.681966+02:00",
           "name": "baz.example.org",
           "ttl": null,
           "comment": "",
@@ -27553,7 +26500,7 @@
       },
       {
         "method": "GET",
-        "url": "/api/v1/naptrs/?preference=101&order=4&flag=s&service=http%2BI2R&regex=&replacement=.&host=20",
+        "url": "/api/v1/naptrs/?host=20&preference=101&order=4&flag=s&service=http%2BI2R&regex=&replacement=.&page_size=1",
         "data": {},
         "status": 200,
         "response": {
@@ -27567,18 +26514,18 @@
         "method": "POST",
         "url": "/api/v1/naptrs/",
         "data": {
+          "host": 20,
           "preference": 101,
           "order": 4,
           "flag": "s",
           "service": "http+I2R",
           "regex": "",
-          "replacement": ".",
-          "host": 20
+          "replacement": "."
         },
         "status": 201,
         "response": {
-          "created_at": "2026-04-24T13:14:31.810704+02:00",
-          "updated_at": "2026-04-24T13:14:31.810798+02:00",
+          "created_at": "2026-07-02T15:54:23.498972+02:00",
+          "updated_at": "2026-07-02T15:54:23.499036+02:00",
           "preference": 101,
           "order": 4,
           "flag": "s",
@@ -27612,15 +26559,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2026-04-24T13:14:13.137107+02:00",
-              "updated_at": "2026-04-24T13:14:23.189953+02:00",
+              "created_at": "2026-07-02T15:54:09.136747+02:00",
+              "updated_at": "2026-07-02T15:54:17.369260+02:00",
               "ipaddress": "10.0.0.10",
               "host": 20
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2026-04-24T13:14:24.505828+02:00",
-              "updated_at": "2026-04-24T13:14:27.229134+02:00",
+              "created_at": "2026-07-02T15:54:18.111329+02:00",
+              "updated_at": "2026-07-02T15:54:20.522842+02:00",
               "ipaddress": "2001:db8::14",
               "host": 20
             }
@@ -27629,8 +26576,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2026-04-24T13:14:22.395738+02:00",
-              "updated_at": "2026-04-24T13:14:22.395797+02:00",
+              "created_at": "2026-07-02T15:54:16.693866+02:00",
+              "updated_at": "2026-07-02T15:54:16.693922+02:00",
               "txt": "v=spf1 -all",
               "host": 20
             }
@@ -27639,8 +26586,8 @@
           "srvs": [],
           "naptrs": [
             {
-              "created_at": "2026-04-24T13:14:31.810704+02:00",
-              "updated_at": "2026-04-24T13:14:31.810798+02:00",
+              "created_at": "2026-07-02T15:54:23.498972+02:00",
+              "updated_at": "2026-07-02T15:54:23.499036+02:00",
               "preference": 101,
               "order": 4,
               "flag": "s",
@@ -27658,8 +26605,8 @@
           "bacnetid": null,
           "communities": [],
           "contacts": [],
-          "created_at": "2026-04-24T13:14:22.378394+02:00",
-          "updated_at": "2026-04-24T13:14:22.378456+02:00",
+          "created_at": "2026-07-02T15:54:16.681911+02:00",
+          "updated_at": "2026-07-02T15:54:16.681966+02:00",
           "name": "baz.example.org",
           "ttl": null,
           "comment": "",
@@ -27669,7 +26616,7 @@
       },
       {
         "method": "GET",
-        "url": "/api/v1/naptrs/?preference=101&order=4&flag=s&service=ftp%2BI2R&regex=&replacement=.&host=20",
+        "url": "/api/v1/naptrs/?host=20&preference=101&order=4&flag=s&service=ftp%2BI2R&regex=&replacement=.&page_size=1",
         "data": {},
         "status": 200,
         "response": {
@@ -27683,18 +26630,18 @@
         "method": "POST",
         "url": "/api/v1/naptrs/",
         "data": {
+          "host": 20,
           "preference": 101,
           "order": 4,
           "flag": "s",
           "service": "ftp+I2R",
           "regex": "",
-          "replacement": ".",
-          "host": 20
+          "replacement": "."
         },
         "status": 201,
         "response": {
-          "created_at": "2026-04-24T13:14:32.141394+02:00",
-          "updated_at": "2026-04-24T13:14:32.141451+02:00",
+          "created_at": "2026-07-02T15:54:23.866816+02:00",
+          "updated_at": "2026-07-02T15:54:23.866876+02:00",
           "preference": 101,
           "order": 4,
           "flag": "s",
@@ -28476,15 +27423,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2025-12-18T11:57:42.249661+01:00",
-              "updated_at": "2025-12-18T11:57:43.967359+01:00",
+              "created_at": "2026-07-02T15:54:09.136747+02:00",
+              "updated_at": "2026-07-02T15:54:17.369260+02:00",
               "ipaddress": "10.0.0.10",
               "host": 20
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2025-12-18T11:57:44.257547+01:00",
-              "updated_at": "2025-12-18T11:57:44.800173+01:00",
+              "created_at": "2026-07-02T15:54:18.111329+02:00",
+              "updated_at": "2026-07-02T15:54:20.522842+02:00",
               "ipaddress": "2001:db8::14",
               "host": 20
             }
@@ -28493,8 +27440,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-12-18T11:57:43.828754+01:00",
-              "updated_at": "2025-12-18T11:57:43.828759+01:00",
+              "created_at": "2026-07-02T15:54:16.693866+02:00",
+              "updated_at": "2026-07-02T15:54:16.693922+02:00",
               "txt": "v=spf1 -all",
               "host": 20
             }
@@ -28510,8 +27457,8 @@
           "bacnetid": null,
           "communities": [],
           "contacts": [],
-          "created_at": "2025-12-18T11:57:43.827115+01:00",
-          "updated_at": "2025-12-18T11:57:43.827125+01:00",
+          "created_at": "2026-07-02T15:54:16.681911+02:00",
+          "updated_at": "2026-07-02T15:54:16.681966+02:00",
           "name": "baz.example.org",
           "ttl": null,
           "comment": "",
@@ -28528,18 +27475,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2025-12-18T11:57:28.616170+01:00",
-                "updated_at": "2025-12-18T11:57:28.616179+01:00",
+                "created_at": "2026-07-02T15:53:25.620694+02:00",
+                "updated_at": "2026-07-02T15:53:25.620774+02:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-12-18T11:57:28.475473+01:00",
-            "updated_at": "2025-12-18T11:57:46.301353+01:00",
+            "created_at": "2026-07-02T15:53:23.929576+02:00",
+            "updated_at": "2026-07-02T15:54:26.496225+02:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-12-18T11:57:28.657477+01:00",
+            "serialno_updated_at": "2026-07-02T15:53:27.305422+02:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -28558,18 +27505,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2025-12-18T11:57:28.616170+01:00",
-                "updated_at": "2025-12-18T11:57:28.616179+01:00",
+                "created_at": "2026-07-02T15:53:25.620694+02:00",
+                "updated_at": "2026-07-02T15:53:25.620774+02:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-12-18T11:57:28.475473+01:00",
-            "updated_at": "2025-12-18T11:57:46.301353+01:00",
+            "created_at": "2026-07-02T15:53:23.929576+02:00",
+            "updated_at": "2026-07-02T15:54:26.496225+02:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-12-18T11:57:28.657477+01:00",
+            "serialno_updated_at": "2026-07-02T15:53:27.305422+02:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -28581,7 +27528,7 @@
       },
       {
         "method": "GET",
-        "url": "/api/v1/srvs/?name=whatever.example.org&priority=1&weight=1&port=80&ttl=&host=20",
+        "url": "/api/v1/srvs/?name=whatever.example.org&host=20&priority=1&weight=1&port=80&page_size=1",
         "data": {},
         "status": 200,
         "response": {
@@ -28595,11 +27542,11 @@
         "method": "POST",
         "url": "/api/v1/srvs/",
         "data": {
+          "host": 20,
           "name": "whatever.example.org",
           "priority": "1",
           "weight": "1",
-          "port": "80",
-          "host": 20
+          "port": "80"
         },
         "status": 400,
         "response": {
@@ -28637,18 +27584,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2026-01-21T16:12:47.064969+01:00",
-                "updated_at": "2026-01-21T16:12:47.064985+01:00",
+                "created_at": "2026-07-02T15:53:25.620694+02:00",
+                "updated_at": "2026-07-02T15:53:25.620774+02:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2026-01-21T16:12:46.601861+01:00",
-            "updated_at": "2026-01-21T16:13:09.218173+01:00",
+            "created_at": "2026-07-02T15:53:23.929576+02:00",
+            "updated_at": "2026-07-02T15:54:26.496225+02:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2026-01-21T16:12:47.143749+01:00",
+            "serialno_updated_at": "2026-07-02T15:53:27.305422+02:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -28660,7 +27607,7 @@
       },
       {
         "method": "GET",
-        "url": "/api/v1/srvs/?name=_sip._tcp.example.org&priority=10&weight=5&port=3456&ttl=&host=20",
+        "url": "/api/v1/srvs/?name=_sip._tcp.example.org&host=20&priority=10&weight=5&port=3456&page_size=1",
         "data": {},
         "status": 200,
         "response": {
@@ -28674,16 +27621,16 @@
         "method": "POST",
         "url": "/api/v1/srvs/",
         "data": {
+          "host": 20,
           "name": "_sip._tcp.example.org",
           "priority": "10",
           "weight": "5",
-          "port": "3456",
-          "host": 20
+          "port": "3456"
         },
         "status": 201,
         "response": {
-          "created_at": "2026-01-21T16:13:09.563514+01:00",
-          "updated_at": "2026-01-21T16:13:09.563521+01:00",
+          "created_at": "2026-07-02T15:54:27.113748+02:00",
+          "updated_at": "2026-07-02T15:54:27.113848+02:00",
           "name": "_sip._tcp.example.org",
           "priority": 10,
           "weight": 5,
@@ -28827,15 +27774,15 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2025-12-18T11:57:42.249661+01:00",
-              "updated_at": "2025-12-18T11:57:43.967359+01:00",
+              "created_at": "2026-07-02T15:54:09.136747+02:00",
+              "updated_at": "2026-07-02T15:54:17.369260+02:00",
               "ipaddress": "10.0.0.10",
               "host": 20
             },
             {
               "macaddress": "11:22:33:44:55:67",
-              "created_at": "2025-12-18T11:57:44.257547+01:00",
-              "updated_at": "2025-12-18T11:57:44.800173+01:00",
+              "created_at": "2026-07-02T15:54:18.111329+02:00",
+              "updated_at": "2026-07-02T15:54:20.522842+02:00",
               "ipaddress": "2001:db8::14",
               "host": 20
             }
@@ -28844,8 +27791,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-12-18T11:57:43.828754+01:00",
-              "updated_at": "2025-12-18T11:57:43.828759+01:00",
+              "created_at": "2026-07-02T15:54:16.693866+02:00",
+              "updated_at": "2026-07-02T15:54:16.693922+02:00",
               "txt": "v=spf1 -all",
               "host": 20
             }
@@ -28853,8 +27800,8 @@
           "ptr_overrides": [],
           "srvs": [
             {
-              "created_at": "2025-12-18T11:57:46.473348+01:00",
-              "updated_at": "2025-12-18T11:57:46.473355+01:00",
+              "created_at": "2026-07-02T15:54:27.113748+02:00",
+              "updated_at": "2026-07-02T15:54:27.113848+02:00",
               "name": "_sip._tcp.example.org",
               "priority": 10,
               "weight": 5,
@@ -28873,8 +27820,8 @@
           "bacnetid": null,
           "communities": [],
           "contacts": [],
-          "created_at": "2025-12-18T11:57:43.827115+01:00",
-          "updated_at": "2025-12-18T11:57:43.827125+01:00",
+          "created_at": "2026-07-02T15:54:16.681911+02:00",
+          "updated_at": "2026-07-02T15:54:16.681966+02:00",
           "name": "baz.example.org",
           "ttl": null,
           "comment": "",
@@ -28884,7 +27831,7 @@
       },
       {
         "method": "GET",
-        "url": "/api/v1/srvs/?name=_sip._tcp.example.org&host=20&priority=10&port=3456&weight=5",
+        "url": "/api/v1/srvs/?name=_sip._tcp.example.org&host=20&priority=10&port=3456&weight=5&page_size=1",
         "data": {},
         "status": 200,
         "response": {
@@ -28893,8 +27840,8 @@
           "previous": null,
           "results": [
             {
-              "created_at": "2025-12-18T11:57:46.473348+01:00",
-              "updated_at": "2025-12-18T11:57:46.473355+01:00",
+              "created_at": "2026-07-02T15:54:27.113748+02:00",
+              "updated_at": "2026-07-02T15:54:27.113848+02:00",
               "name": "_sip._tcp.example.org",
               "priority": 10,
               "weight": 5,
@@ -28936,15 +27883,15 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-12-18T11:57:43.239182+01:00",
-              "updated_at": "2025-12-18T11:57:43.570824+01:00",
+              "created_at": "2026-07-02T15:54:14.139983+02:00",
+              "updated_at": "2026-07-02T15:54:15.362398+02:00",
               "ipaddress": "10.0.0.14",
               "host": 19
             },
             {
               "macaddress": "11:22:33:44:55:66",
-              "created_at": "2025-12-18T11:57:43.362990+01:00",
-              "updated_at": "2025-12-18T11:57:43.705817+01:00",
+              "created_at": "2026-07-02T15:54:14.369446+02:00",
+              "updated_at": "2026-07-02T15:54:16.374090+02:00",
               "ipaddress": "10.0.0.15",
               "host": 19
             }
@@ -28953,8 +27900,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-12-18T11:57:42.230049+01:00",
-              "updated_at": "2025-12-18T11:57:42.230056+01:00",
+              "created_at": "2026-07-02T15:54:08.992515+02:00",
+              "updated_at": "2026-07-02T15:54:08.992570+02:00",
               "txt": "v=spf1 -all",
               "host": 19
             }
@@ -28972,12 +27919,12 @@
           "contacts": [
             {
               "email": "me@example.org",
-              "created_at": "2025-12-18T11:57:30.192767+01:00",
-              "updated_at": "2025-12-18T11:57:30.192776+01:00"
+              "created_at": "2026-07-02T15:54:13.502932+02:00",
+              "updated_at": "2026-07-02T15:54:13.503001+02:00"
             }
           ],
-          "created_at": "2025-12-18T11:57:42.227827+01:00",
-          "updated_at": "2025-12-18T11:57:43.108914+01:00",
+          "created_at": "2026-07-02T15:54:08.979653+02:00",
+          "updated_at": "2026-07-02T15:54:13.479118+02:00",
           "name": "bar.example.org",
           "ttl": null,
           "comment": "This is the comment",
@@ -28987,7 +27934,7 @@
       },
       {
         "method": "GET",
-        "url": "/api/v1/sshfps/?algorithm=1&hash_type=1&fingerprint=12345678abcde&host=19",
+        "url": "/api/v1/sshfps/?host=19&algorithm=1&hash_type=1&fingerprint=12345678abcde&page_size=1",
         "data": {},
         "status": 200,
         "response": {
@@ -29001,15 +27948,15 @@
         "method": "POST",
         "url": "/api/v1/sshfps/",
         "data": {
+          "host": 19,
           "algorithm": "1",
           "hash_type": "1",
-          "fingerprint": "12345678abcde",
-          "host": 19
+          "fingerprint": "12345678abcde"
         },
         "status": 201,
         "response": {
-          "created_at": "2025-12-18T11:57:46.784088+01:00",
-          "updated_at": "2025-12-18T11:57:46.784098+01:00",
+          "created_at": "2026-07-02T15:54:28.198659+02:00",
+          "updated_at": "2026-07-02T15:54:28.198714+02:00",
           "ttl": null,
           "algorithm": 1,
           "hash_type": 1,
@@ -29111,14 +28058,14 @@
     "command_issued": "host sshfp_remove -fingerprint 394875985 bar   # not found",
     "ok": [],
     "warning": [
-      "SSHFP with query {'fingerprint': '394875985', 'host': 19} not found."
+      "No SSHFP found."
     ],
     "error": [],
     "output": [],
     "api_requests": [
       {
         "method": "GET",
-        "url": "/api/v1/sshfps/?fingerprint=394875985&host=19",
+        "url": "/api/v1/sshfps/?fingerprint=394875985&host=19&page_size=1",
         "data": {},
         "status": 200,
         "response": {
@@ -29641,7 +28588,7 @@
     "api_requests": [
       {
         "method": "GET",
-        "url": "/api/v1/txts/?host=19&txt=Whatever",
+        "url": "/api/v1/txts/?host=19&txt=Whatever&page_size=1",
         "data": {},
         "status": 200,
         "response": {
@@ -29668,7 +28615,7 @@
     "api_requests": [
       {
         "method": "GET",
-        "url": "/api/v1/txts/?host=19&txt=Lorem+ipsum+dolor+sit+amet",
+        "url": "/api/v1/txts/?host=19&txt=Lorem+ipsum+dolor+sit+amet&page_size=1",
         "data": {},
         "status": 200,
         "response": {
@@ -29677,8 +28624,8 @@
           "previous": null,
           "results": [
             {
-              "created_at": "2025-08-26T11:57:01.730234+02:00",
-              "updated_at": "2025-08-26T11:57:01.730241+02:00",
+              "created_at": "2026-07-02T15:54:30.269083+02:00",
+              "updated_at": "2026-07-02T15:54:30.269148+02:00",
               "txt": "Lorem ipsum dolor sit amet",
               "host": 19
             }
@@ -30197,8 +29144,8 @@
       "              10.0.0.4   aa:bb:cc:cc:bb:aa   ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Thu Dec 18 11:57:48 2025",
-      "Updated:      Thu Dec 18 11:57:48 2025"
+      "Created:      Thu Jul  2 15:54:33 2026",
+      "Updated:      Thu Jul  2 15:54:33 2026"
     ],
     "api_requests": [
       {
@@ -30254,18 +29201,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2025-12-18T11:57:28.616170+01:00",
-                "updated_at": "2025-12-18T11:57:28.616179+01:00",
+                "created_at": "2026-07-02T15:53:25.620694+02:00",
+                "updated_at": "2026-07-02T15:53:25.620774+02:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-12-18T11:57:28.475473+01:00",
-            "updated_at": "2025-12-18T11:57:48.156405+01:00",
+            "created_at": "2026-07-02T15:53:23.929576+02:00",
+            "updated_at": "2026-07-02T15:54:32.795980+02:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-12-18T11:57:28.657477+01:00",
+            "serialno_updated_at": "2026-07-02T15:53:27.305422+02:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -30284,8 +29231,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-12-18T11:57:42.027647+01:00",
-          "updated_at": "2025-12-18T11:57:42.027657+01:00",
+          "created_at": "2026-07-02T15:54:08.446436+02:00",
+          "updated_at": "2026-07-02T15:54:08.446498+02:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -30315,8 +29262,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-12-18T11:57:48.290528+01:00",
-              "updated_at": "2025-12-18T11:57:48.290534+01:00",
+              "created_at": "2026-07-02T15:54:33.222157+02:00",
+              "updated_at": "2026-07-02T15:54:33.222216+02:00",
               "ipaddress": "10.0.0.4",
               "host": 23
             }
@@ -30325,8 +29272,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-12-18T11:57:48.275722+01:00",
-              "updated_at": "2025-12-18T11:57:48.275727+01:00",
+              "created_at": "2026-07-02T15:54:33.113241+02:00",
+              "updated_at": "2026-07-02T15:54:33.113298+02:00",
               "txt": "v=spf1 -all",
               "host": 23
             }
@@ -30342,25 +29289,13 @@
           "bacnetid": null,
           "communities": [],
           "contacts": [],
-          "created_at": "2025-12-18T11:57:48.273947+01:00",
-          "updated_at": "2025-12-18T11:57:48.273954+01:00",
+          "created_at": "2026-07-02T15:54:33.100948+02:00",
+          "updated_at": "2026-07-02T15:54:33.101006+02:00",
           "name": "directok.example.org",
           "ttl": null,
           "comment": "",
           "zone": 1,
           "contact": ""
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/ipaddresses/?macaddress=aa%3Abb%3Acc%3Acc%3Abb%3Aaa&ordering=ipaddress",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
         }
       },
       {
@@ -30378,62 +29313,55 @@
         "status": 200,
         "response": {
           "macaddress": "aa:bb:cc:cc:bb:aa",
-          "created_at": "2025-12-18T11:57:48.290528+01:00",
-          "updated_at": "2025-12-18T11:57:48.382521+01:00",
+          "created_at": "2026-07-02T15:54:33.222157+02:00",
+          "updated_at": "2026-07-02T15:54:33.451884+02:00",
           "ipaddress": "10.0.0.4",
           "host": 23
         }
       },
       {
         "method": "GET",
-        "url": "/api/v1/hosts/?id=23",
+        "url": "/api/v1/hosts/directok.example.org",
         "data": {},
         "status": 200,
         "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
+          "ipaddresses": [
             {
-              "ipaddresses": [
-                {
-                  "macaddress": "aa:bb:cc:cc:bb:aa",
-                  "created_at": "2025-12-18T11:57:48.290528+01:00",
-                  "updated_at": "2025-12-18T11:57:48.382521+01:00",
-                  "ipaddress": "10.0.0.4",
-                  "host": 23
-                }
-              ],
-              "cnames": [],
-              "mxs": [],
-              "txts": [
-                {
-                  "created_at": "2025-12-18T11:57:48.275722+01:00",
-                  "updated_at": "2025-12-18T11:57:48.275727+01:00",
-                  "txt": "v=spf1 -all",
-                  "host": 23
-                }
-              ],
-              "ptr_overrides": [],
-              "srvs": [],
-              "naptrs": [],
-              "sshfps": [],
-              "hostgroups": [],
-              "roles": [],
-              "hinfo": null,
-              "loc": null,
-              "bacnetid": null,
-              "communities": [],
-              "contacts": [],
-              "created_at": "2025-12-18T11:57:48.273947+01:00",
-              "updated_at": "2025-12-18T11:57:48.273954+01:00",
-              "name": "directok.example.org",
-              "ttl": null,
-              "comment": "",
-              "zone": 1,
-              "contact": ""
+              "macaddress": "aa:bb:cc:cc:bb:aa",
+              "created_at": "2026-07-02T15:54:33.222157+02:00",
+              "updated_at": "2026-07-02T15:54:33.451884+02:00",
+              "ipaddress": "10.0.0.4",
+              "host": 23
             }
-          ]
+          ],
+          "cnames": [],
+          "mxs": [],
+          "txts": [
+            {
+              "created_at": "2026-07-02T15:54:33.113241+02:00",
+              "updated_at": "2026-07-02T15:54:33.113298+02:00",
+              "txt": "v=spf1 -all",
+              "host": 23
+            }
+          ],
+          "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "hostgroups": [],
+          "roles": [],
+          "hinfo": null,
+          "loc": null,
+          "bacnetid": null,
+          "communities": [],
+          "contacts": [],
+          "created_at": "2026-07-02T15:54:33.100948+02:00",
+          "updated_at": "2026-07-02T15:54:33.101006+02:00",
+          "name": "directok.example.org",
+          "ttl": null,
+          "comment": "",
+          "zone": 1,
+          "contact": ""
         }
       },
       {
@@ -30445,8 +29373,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-12-18T11:57:42.027647+01:00",
-          "updated_at": "2025-12-18T11:57:42.027657+01:00",
+          "created_at": "2026-07-02T15:54:08.446436+02:00",
+          "updated_at": "2026-07-02T15:54:08.446498+02:00",
           "network": "10.0.0.0/24",
           "description": "lorem ipsum",
           "vlan": null,
@@ -30508,51 +29436,6 @@
     "error": [],
     "output": [],
     "api_requests": [
-      {
-        "method": "GET",
-        "url": "/api/v1/hosts/directok.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "aa:bb:cc:cc:bb:aa",
-              "created_at": "2025-12-18T11:57:48.290528+01:00",
-              "updated_at": "2025-12-18T11:57:48.382521+01:00",
-              "ipaddress": "10.0.0.4",
-              "host": 23
-            }
-          ],
-          "cnames": [],
-          "mxs": [],
-          "txts": [
-            {
-              "created_at": "2025-12-18T11:57:48.275722+01:00",
-              "updated_at": "2025-12-18T11:57:48.275727+01:00",
-              "txt": "v=spf1 -all",
-              "host": 23
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "contacts": [],
-          "created_at": "2025-12-18T11:57:48.273947+01:00",
-          "updated_at": "2025-12-18T11:57:48.273954+01:00",
-          "name": "directok.example.org",
-          "ttl": null,
-          "comment": "",
-          "zone": 1,
-          "contact": ""
-        }
-      },
       {
         "method": "DELETE",
         "url": "/api/v1/hosts/directok.example.org",
@@ -30777,8 +29660,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-12-18T11:57:48.686766+01:00",
-              "updated_at": "2025-12-18T11:57:48.686772+01:00",
+              "created_at": "2026-07-02T15:54:34.393961+02:00",
+              "updated_at": "2026-07-02T15:54:34.394040+02:00",
               "ipaddress": "10.0.0.10",
               "host": 24
             }
@@ -30787,8 +29670,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-12-18T11:57:48.666452+01:00",
-              "updated_at": "2025-12-18T11:57:48.666458+01:00",
+              "created_at": "2026-07-02T15:54:34.229982+02:00",
+              "updated_at": "2026-07-02T15:54:34.230045+02:00",
               "txt": "v=spf1 -all",
               "host": 24
             }
@@ -30806,12 +29689,12 @@
           "contacts": [
             {
               "email": "foo@example.org",
-              "created_at": "2025-12-18T11:57:48.668874+01:00",
-              "updated_at": "2025-12-18T11:57:48.668883+01:00"
+              "created_at": "2026-07-02T15:54:34.248979+02:00",
+              "updated_at": "2026-07-02T15:54:34.249039+02:00"
             }
           ],
-          "created_at": "2025-12-18T11:57:48.664760+01:00",
-          "updated_at": "2025-12-18T11:57:48.664767+01:00",
+          "created_at": "2026-07-02T15:54:34.217067+02:00",
+          "updated_at": "2026-07-02T15:54:34.217121+02:00",
           "name": "foo.example.org",
           "ttl": null,
           "comment": "",
@@ -30824,13 +29707,13 @@
         "url": "/api/v1/mxs/",
         "data": {
           "host": 24,
-          "priority": 10,
-          "mx": "mail.example.org"
+          "mx": "mail.example.org",
+          "priority": 10
         },
         "status": 201,
         "response": {
-          "created_at": "2025-12-18T11:57:48.783536+01:00",
-          "updated_at": "2025-12-18T11:57:48.783541+01:00",
+          "created_at": "2026-07-02T15:54:34.702494+02:00",
+          "updated_at": "2026-07-02T15:54:34.702554+02:00",
           "priority": 10,
           "mx": "mail.example.org",
           "host": 24
@@ -31567,8 +30450,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-12-18T11:57:49.470631+01:00",
-              "updated_at": "2025-12-18T11:57:49.470638+01:00",
+              "created_at": "2026-07-02T15:54:36.857079+02:00",
+              "updated_at": "2026-07-02T15:54:36.857137+02:00",
               "ipaddress": "10.0.0.10",
               "host": 26
             }
@@ -31577,8 +30460,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-12-18T11:57:49.448092+01:00",
-              "updated_at": "2025-12-18T11:57:49.448099+01:00",
+              "created_at": "2026-07-02T15:54:36.698699+02:00",
+              "updated_at": "2026-07-02T15:54:36.698769+02:00",
               "txt": "v=spf1 -all",
               "host": 26
             }
@@ -31596,12 +30479,12 @@
           "contacts": [
             {
               "email": "foo@example.org",
-              "created_at": "2025-12-18T11:57:48.668874+01:00",
-              "updated_at": "2025-12-18T11:57:48.668883+01:00"
+              "created_at": "2026-07-02T15:54:36.722147+02:00",
+              "updated_at": "2026-07-02T15:54:36.722226+02:00"
             }
           ],
-          "created_at": "2025-12-18T11:57:49.445694+01:00",
-          "updated_at": "2025-12-18T11:57:49.445702+01:00",
+          "created_at": "2026-07-02T15:54:36.681440+02:00",
+          "updated_at": "2026-07-02T15:54:36.681496+02:00",
           "name": "foo.example.org",
           "ttl": null,
           "comment": "",
@@ -31611,7 +30494,7 @@
       },
       {
         "method": "GET",
-        "url": "/api/v1/naptrs/?preference=16384&order=3&flag=u&service=SIP&regex=%5Babc%5D%2B&replacement=wonk&host=26",
+        "url": "/api/v1/naptrs/?host=26&preference=16384&order=3&flag=u&service=SIP&regex=%5Babc%5D%2B&replacement=wonk&page_size=1",
         "data": {},
         "status": 200,
         "response": {
@@ -31625,18 +30508,18 @@
         "method": "POST",
         "url": "/api/v1/naptrs/",
         "data": {
+          "host": 26,
           "preference": 16384,
           "order": 3,
           "flag": "u",
           "service": "SIP",
           "regex": "[abc]+",
-          "replacement": "wonk",
-          "host": 26
+          "replacement": "wonk"
         },
         "status": 201,
         "response": {
-          "created_at": "2025-12-18T11:57:49.634908+01:00",
-          "updated_at": "2025-12-18T11:57:49.634920+01:00",
+          "created_at": "2026-07-02T15:54:37.382103+02:00",
+          "updated_at": "2026-07-02T15:54:37.382170+02:00",
           "preference": 16384,
           "order": 3,
           "flag": "u",
@@ -31964,8 +30847,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-12-18T11:57:49.879804+01:00",
-              "updated_at": "2025-12-18T11:57:49.879810+01:00",
+              "created_at": "2026-07-02T15:54:38.275774+02:00",
+              "updated_at": "2026-07-02T15:54:38.275833+02:00",
               "ipaddress": "10.0.0.10",
               "host": 27
             }
@@ -31974,8 +30857,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-12-18T11:57:49.858380+01:00",
-              "updated_at": "2025-12-18T11:57:49.858388+01:00",
+              "created_at": "2026-07-02T15:54:38.128321+02:00",
+              "updated_at": "2026-07-02T15:54:38.128380+02:00",
               "txt": "v=spf1 -all",
               "host": 27
             }
@@ -31993,12 +30876,12 @@
           "contacts": [
             {
               "email": "foo@example.org",
-              "created_at": "2025-12-18T11:57:48.668874+01:00",
-              "updated_at": "2025-12-18T11:57:48.668883+01:00"
+              "created_at": "2026-07-02T15:54:38.148674+02:00",
+              "updated_at": "2026-07-02T15:54:38.148759+02:00"
             }
           ],
-          "created_at": "2025-12-18T11:57:49.856055+01:00",
-          "updated_at": "2025-12-18T11:57:49.856062+01:00",
+          "created_at": "2026-07-02T15:54:38.111783+02:00",
+          "updated_at": "2026-07-02T15:54:38.111862+02:00",
           "name": "foo.example.org",
           "ttl": null,
           "comment": "",
@@ -32015,18 +30898,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2025-12-18T11:57:28.616170+01:00",
-                "updated_at": "2025-12-18T11:57:28.616179+01:00",
+                "created_at": "2026-07-02T15:53:25.620694+02:00",
+                "updated_at": "2026-07-02T15:53:25.620774+02:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-12-18T11:57:28.475473+01:00",
-            "updated_at": "2025-12-18T11:57:49.879116+01:00",
+            "created_at": "2026-07-02T15:53:23.929576+02:00",
+            "updated_at": "2026-07-02T15:54:38.271304+02:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-12-18T11:57:28.657477+01:00",
+            "serialno_updated_at": "2026-07-02T15:53:27.305422+02:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -32045,18 +30928,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2025-12-18T11:57:28.616170+01:00",
-                "updated_at": "2025-12-18T11:57:28.616179+01:00",
+                "created_at": "2026-07-02T15:53:25.620694+02:00",
+                "updated_at": "2026-07-02T15:53:25.620774+02:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-12-18T11:57:28.475473+01:00",
-            "updated_at": "2025-12-18T11:57:49.879116+01:00",
+            "created_at": "2026-07-02T15:53:23.929576+02:00",
+            "updated_at": "2026-07-02T15:54:38.271304+02:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-12-18T11:57:28.657477+01:00",
+            "serialno_updated_at": "2026-07-02T15:53:27.305422+02:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -32068,7 +30951,7 @@
       },
       {
         "method": "GET",
-        "url": "/api/v1/srvs/?name=_sip._tcp.example.org&priority=10&weight=5&port=3456&ttl=&host=27",
+        "url": "/api/v1/srvs/?name=_sip._tcp.example.org&host=27&priority=10&weight=5&port=3456&page_size=1",
         "data": {},
         "status": 200,
         "response": {
@@ -32082,16 +30965,16 @@
         "method": "POST",
         "url": "/api/v1/srvs/",
         "data": {
+          "host": 27,
           "name": "_sip._tcp.example.org",
           "priority": "10",
           "weight": "5",
-          "port": "3456",
-          "host": 27
+          "port": "3456"
         },
         "status": 201,
         "response": {
-          "created_at": "2025-12-18T11:57:50.078284+01:00",
-          "updated_at": "2025-12-18T11:57:50.078306+01:00",
+          "created_at": "2026-07-02T15:54:38.805115+02:00",
+          "updated_at": "2026-07-02T15:54:38.805179+02:00",
           "name": "_sip._tcp.example.org",
           "priority": 10,
           "weight": 5,
@@ -32419,8 +31302,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-12-18T11:57:50.298322+01:00",
-              "updated_at": "2025-12-18T11:57:50.298335+01:00",
+              "created_at": "2026-07-02T15:54:39.556053+02:00",
+              "updated_at": "2026-07-02T15:54:39.556109+02:00",
               "ipaddress": "10.0.0.10",
               "host": 28
             }
@@ -32429,8 +31312,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-12-18T11:57:50.275088+01:00",
-              "updated_at": "2025-12-18T11:57:50.275094+01:00",
+              "created_at": "2026-07-02T15:54:39.433198+02:00",
+              "updated_at": "2026-07-02T15:54:39.433253+02:00",
               "txt": "v=spf1 -all",
               "host": 28
             }
@@ -32448,12 +31331,12 @@
           "contacts": [
             {
               "email": "foo@example.org",
-              "created_at": "2025-12-18T11:57:48.668874+01:00",
-              "updated_at": "2025-12-18T11:57:48.668883+01:00"
+              "created_at": "2026-07-02T15:54:39.452133+02:00",
+              "updated_at": "2026-07-02T15:54:39.452193+02:00"
             }
           ],
-          "created_at": "2025-12-18T11:57:50.273212+01:00",
-          "updated_at": "2025-12-18T11:57:50.273220+01:00",
+          "created_at": "2026-07-02T15:54:39.419783+02:00",
+          "updated_at": "2026-07-02T15:54:39.419842+02:00",
           "name": "foo.example.org",
           "ttl": null,
           "comment": "",
@@ -32502,18 +31385,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2025-12-18T11:57:28.616170+01:00",
-                "updated_at": "2025-12-18T11:57:28.616179+01:00",
+                "created_at": "2026-07-02T15:53:25.620694+02:00",
+                "updated_at": "2026-07-02T15:53:25.620774+02:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-12-18T11:57:28.475473+01:00",
-            "updated_at": "2025-12-18T11:57:50.297550+01:00",
+            "created_at": "2026-07-02T15:53:23.929576+02:00",
+            "updated_at": "2026-07-02T15:54:39.552372+02:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-12-18T11:57:28.657477+01:00",
+            "serialno_updated_at": "2026-07-02T15:53:27.305422+02:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -32532,8 +31415,8 @@
         },
         "status": 201,
         "response": {
-          "created_at": "2025-12-18T11:57:50.468467+01:00",
-          "updated_at": "2025-12-18T11:57:50.468477+01:00",
+          "created_at": "2026-07-02T15:54:40.043856+02:00",
+          "updated_at": "2026-07-02T15:54:40.043930+02:00",
           "name": "fubar.example.org",
           "ttl": null,
           "zone": 1,
@@ -32542,67 +31425,7 @@
       },
       {
         "method": "GET",
-        "url": "/api/v1/hosts/foo.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "",
-              "created_at": "2025-12-18T11:57:50.298322+01:00",
-              "updated_at": "2025-12-18T11:57:50.298335+01:00",
-              "ipaddress": "10.0.0.10",
-              "host": 28
-            }
-          ],
-          "cnames": [
-            {
-              "created_at": "2025-12-18T11:57:50.468467+01:00",
-              "updated_at": "2025-12-18T11:57:50.468477+01:00",
-              "name": "fubar.example.org",
-              "ttl": null,
-              "zone": 1,
-              "host": 28
-            }
-          ],
-          "mxs": [],
-          "txts": [
-            {
-              "created_at": "2025-12-18T11:57:50.275088+01:00",
-              "updated_at": "2025-12-18T11:57:50.275094+01:00",
-              "txt": "v=spf1 -all",
-              "host": 28
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "contacts": [
-            {
-              "email": "foo@example.org",
-              "created_at": "2025-12-18T11:57:48.668874+01:00",
-              "updated_at": "2025-12-18T11:57:48.668883+01:00"
-            }
-          ],
-          "created_at": "2025-12-18T11:57:50.273212+01:00",
-          "updated_at": "2025-12-18T11:57:50.273220+01:00",
-          "name": "foo.example.org",
-          "ttl": null,
-          "comment": "",
-          "zone": 1,
-          "contact": "foo@example.org"
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/cnames/?host=28&name=fubar.example.org",
+        "url": "/api/v1/cnames/?name=fubar.example.org&host=28",
         "data": {},
         "status": 200,
         "response": {
@@ -32611,8 +31434,8 @@
           "previous": null,
           "results": [
             {
-              "created_at": "2025-12-18T11:57:50.468467+01:00",
-              "updated_at": "2025-12-18T11:57:50.468477+01:00",
+              "created_at": "2026-07-02T15:54:40.043856+02:00",
+              "updated_at": "2026-07-02T15:54:40.043930+02:00",
               "name": "fubar.example.org",
               "ttl": null,
               "zone": 1,
@@ -32635,7 +31458,68 @@
     ],
     "error": [],
     "output": [],
-    "api_requests": [],
+    "api_requests": [
+      {
+        "method": "GET",
+        "url": "/api/v1/hosts/foo.example.org",
+        "data": {},
+        "status": 200,
+        "response": {
+          "ipaddresses": [
+            {
+              "macaddress": "",
+              "created_at": "2026-07-02T15:54:39.556053+02:00",
+              "updated_at": "2026-07-02T15:54:39.556109+02:00",
+              "ipaddress": "10.0.0.10",
+              "host": 28
+            }
+          ],
+          "cnames": [
+            {
+              "created_at": "2026-07-02T15:54:40.043856+02:00",
+              "updated_at": "2026-07-02T15:54:40.043930+02:00",
+              "name": "fubar.example.org",
+              "ttl": null,
+              "zone": 1,
+              "host": 28
+            }
+          ],
+          "mxs": [],
+          "txts": [
+            {
+              "created_at": "2026-07-02T15:54:39.433198+02:00",
+              "updated_at": "2026-07-02T15:54:39.433253+02:00",
+              "txt": "v=spf1 -all",
+              "host": 28
+            }
+          ],
+          "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "hostgroups": [],
+          "roles": [],
+          "hinfo": null,
+          "loc": null,
+          "bacnetid": null,
+          "communities": [],
+          "contacts": [
+            {
+              "email": "foo@example.org",
+              "created_at": "2026-07-02T15:54:39.452133+02:00",
+              "updated_at": "2026-07-02T15:54:39.452193+02:00"
+            }
+          ],
+          "created_at": "2026-07-02T15:54:39.419783+02:00",
+          "updated_at": "2026-07-02T15:54:39.419842+02:00",
+          "name": "foo.example.org",
+          "ttl": null,
+          "comment": "",
+          "zone": 1,
+          "contact": "foo@example.org"
+        }
+      }
+    ],
     "time": null
   },
   {
@@ -32875,8 +31759,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-12-18T11:57:50.707521+01:00",
-              "updated_at": "2025-12-18T11:57:50.707527+01:00",
+              "created_at": "2026-07-02T15:54:40.860135+02:00",
+              "updated_at": "2026-07-02T15:54:40.860196+02:00",
               "ipaddress": "10.0.0.10",
               "host": 29
             }
@@ -32885,8 +31769,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-12-18T11:57:50.690623+01:00",
-              "updated_at": "2025-12-18T11:57:50.690629+01:00",
+              "created_at": "2026-07-02T15:54:40.721609+02:00",
+              "updated_at": "2026-07-02T15:54:40.721663+02:00",
               "txt": "v=spf1 -all",
               "host": 29
             }
@@ -32904,12 +31788,12 @@
           "contacts": [
             {
               "email": "foo@example.org",
-              "created_at": "2025-12-18T11:57:48.668874+01:00",
-              "updated_at": "2025-12-18T11:57:48.668883+01:00"
+              "created_at": "2026-07-02T15:54:40.740005+02:00",
+              "updated_at": "2026-07-02T15:54:40.740065+02:00"
             }
           ],
-          "created_at": "2025-12-18T11:57:50.688913+01:00",
-          "updated_at": "2025-12-18T11:57:50.688921+01:00",
+          "created_at": "2026-07-02T15:54:40.709543+02:00",
+          "updated_at": "2026-07-02T15:54:40.709600+02:00",
           "name": "foo.example.org",
           "ttl": null,
           "comment": "",
@@ -32922,13 +31806,13 @@
         "url": "/api/v1/mxs/",
         "data": {
           "host": 29,
-          "priority": 10,
-          "mx": "mail.example.org"
+          "mx": "mail.example.org",
+          "priority": 10
         },
         "status": 201,
         "response": {
-          "created_at": "2025-12-18T11:57:50.807545+01:00",
-          "updated_at": "2025-12-18T11:57:50.807552+01:00",
+          "created_at": "2026-07-02T15:54:41.263348+02:00",
+          "updated_at": "2026-07-02T15:54:41.263410+02:00",
           "priority": 10,
           "mx": "mail.example.org",
           "host": 29
@@ -33094,8 +31978,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-12-18T11:57:50.707521+01:00",
-              "updated_at": "2025-12-18T11:57:50.707527+01:00",
+              "created_at": "2026-07-02T15:54:40.860135+02:00",
+              "updated_at": "2026-07-02T15:54:40.860196+02:00",
               "ipaddress": "10.0.0.10",
               "host": 29
             }
@@ -33103,8 +31987,8 @@
           "cnames": [],
           "mxs": [
             {
-              "created_at": "2025-12-18T11:57:50.807545+01:00",
-              "updated_at": "2025-12-18T11:57:50.807552+01:00",
+              "created_at": "2026-07-02T15:54:41.263348+02:00",
+              "updated_at": "2026-07-02T15:54:41.263410+02:00",
               "priority": 10,
               "mx": "mail.example.org",
               "host": 29
@@ -33112,16 +31996,16 @@
           ],
           "txts": [
             {
-              "created_at": "2025-12-18T11:57:50.690623+01:00",
-              "updated_at": "2025-12-18T11:57:50.690629+01:00",
+              "created_at": "2026-07-02T15:54:40.721609+02:00",
+              "updated_at": "2026-07-02T15:54:40.721663+02:00",
               "txt": "v=spf1 -all",
               "host": 29
             }
           ],
           "ptr_overrides": [
             {
-              "created_at": "2025-12-18T11:57:50.929967+01:00",
-              "updated_at": "2025-12-18T11:57:50.929975+01:00",
+              "created_at": "2026-07-02T15:54:41.577404+02:00",
+              "updated_at": "2026-07-02T15:54:41.577458+02:00",
               "ipaddress": "10.0.0.11",
               "host": 29
             }
@@ -33138,12 +32022,12 @@
           "contacts": [
             {
               "email": "foo@example.org",
-              "created_at": "2025-12-18T11:57:48.668874+01:00",
-              "updated_at": "2025-12-18T11:57:48.668883+01:00"
+              "created_at": "2026-07-02T15:54:40.740005+02:00",
+              "updated_at": "2026-07-02T15:54:40.740065+02:00"
             }
           ],
-          "created_at": "2025-12-18T11:57:50.688913+01:00",
-          "updated_at": "2025-12-18T11:57:50.688921+01:00",
+          "created_at": "2026-07-02T15:54:40.709543+02:00",
+          "updated_at": "2026-07-02T15:54:40.709600+02:00",
           "name": "foo.example.org",
           "ttl": null,
           "comment": "",
@@ -33153,7 +32037,7 @@
       },
       {
         "method": "GET",
-        "url": "/api/v1/naptrs/?preference=16384&order=3&flag=u&service=SIP&regex=%5Babc%5D%2B&replacement=wonk&host=29",
+        "url": "/api/v1/naptrs/?host=29&preference=16384&order=3&flag=u&service=SIP&regex=%5Babc%5D%2B&replacement=wonk&page_size=1",
         "data": {},
         "status": 200,
         "response": {
@@ -33167,18 +32051,18 @@
         "method": "POST",
         "url": "/api/v1/naptrs/",
         "data": {
+          "host": 29,
           "preference": 16384,
           "order": 3,
           "flag": "u",
           "service": "SIP",
           "regex": "[abc]+",
-          "replacement": "wonk",
-          "host": 29
+          "replacement": "wonk"
         },
         "status": 201,
         "response": {
-          "created_at": "2025-12-18T11:57:51.011546+01:00",
-          "updated_at": "2025-12-18T11:57:51.011553+01:00",
+          "created_at": "2026-07-02T15:54:41.899664+02:00",
+          "updated_at": "2026-07-02T15:54:41.899935+02:00",
           "preference": 16384,
           "order": 3,
           "flag": "u",
@@ -33212,8 +32096,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-12-18T11:57:50.707521+01:00",
-              "updated_at": "2025-12-18T11:57:50.707527+01:00",
+              "created_at": "2026-07-02T15:54:40.860135+02:00",
+              "updated_at": "2026-07-02T15:54:40.860196+02:00",
               "ipaddress": "10.0.0.10",
               "host": 29
             }
@@ -33221,8 +32105,8 @@
           "cnames": [],
           "mxs": [
             {
-              "created_at": "2025-12-18T11:57:50.807545+01:00",
-              "updated_at": "2025-12-18T11:57:50.807552+01:00",
+              "created_at": "2026-07-02T15:54:41.263348+02:00",
+              "updated_at": "2026-07-02T15:54:41.263410+02:00",
               "priority": 10,
               "mx": "mail.example.org",
               "host": 29
@@ -33230,16 +32114,16 @@
           ],
           "txts": [
             {
-              "created_at": "2025-12-18T11:57:50.690623+01:00",
-              "updated_at": "2025-12-18T11:57:50.690629+01:00",
+              "created_at": "2026-07-02T15:54:40.721609+02:00",
+              "updated_at": "2026-07-02T15:54:40.721663+02:00",
               "txt": "v=spf1 -all",
               "host": 29
             }
           ],
           "ptr_overrides": [
             {
-              "created_at": "2025-12-18T11:57:50.929967+01:00",
-              "updated_at": "2025-12-18T11:57:50.929975+01:00",
+              "created_at": "2026-07-02T15:54:41.577404+02:00",
+              "updated_at": "2026-07-02T15:54:41.577458+02:00",
               "ipaddress": "10.0.0.11",
               "host": 29
             }
@@ -33247,8 +32131,8 @@
           "srvs": [],
           "naptrs": [
             {
-              "created_at": "2025-12-18T11:57:51.011546+01:00",
-              "updated_at": "2025-12-18T11:57:51.011553+01:00",
+              "created_at": "2026-07-02T15:54:41.899664+02:00",
+              "updated_at": "2026-07-02T15:54:41.899935+02:00",
               "preference": 16384,
               "order": 3,
               "flag": "u",
@@ -33268,12 +32152,12 @@
           "contacts": [
             {
               "email": "foo@example.org",
-              "created_at": "2025-12-18T11:57:48.668874+01:00",
-              "updated_at": "2025-12-18T11:57:48.668883+01:00"
+              "created_at": "2026-07-02T15:54:40.740005+02:00",
+              "updated_at": "2026-07-02T15:54:40.740065+02:00"
             }
           ],
-          "created_at": "2025-12-18T11:57:50.688913+01:00",
-          "updated_at": "2025-12-18T11:57:50.688921+01:00",
+          "created_at": "2026-07-02T15:54:40.709543+02:00",
+          "updated_at": "2026-07-02T15:54:40.709600+02:00",
           "name": "foo.example.org",
           "ttl": null,
           "comment": "",
@@ -33290,18 +32174,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2025-12-18T11:57:28.616170+01:00",
-                "updated_at": "2025-12-18T11:57:28.616179+01:00",
+                "created_at": "2026-07-02T15:53:25.620694+02:00",
+                "updated_at": "2026-07-02T15:53:25.620774+02:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-12-18T11:57:28.475473+01:00",
-            "updated_at": "2025-12-18T11:57:51.010646+01:00",
+            "created_at": "2026-07-02T15:53:23.929576+02:00",
+            "updated_at": "2026-07-02T15:54:41.887354+02:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-12-18T11:57:28.657477+01:00",
+            "serialno_updated_at": "2026-07-02T15:53:27.305422+02:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -33320,18 +32204,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2025-12-18T11:57:28.616170+01:00",
-                "updated_at": "2025-12-18T11:57:28.616179+01:00",
+                "created_at": "2026-07-02T15:53:25.620694+02:00",
+                "updated_at": "2026-07-02T15:53:25.620774+02:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-12-18T11:57:28.475473+01:00",
-            "updated_at": "2025-12-18T11:57:51.010646+01:00",
+            "created_at": "2026-07-02T15:53:23.929576+02:00",
+            "updated_at": "2026-07-02T15:54:41.887354+02:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-12-18T11:57:28.657477+01:00",
+            "serialno_updated_at": "2026-07-02T15:53:27.305422+02:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -33343,7 +32227,7 @@
       },
       {
         "method": "GET",
-        "url": "/api/v1/srvs/?name=_sip._tcp.example.org&priority=10&weight=5&port=3456&ttl=&host=29",
+        "url": "/api/v1/srvs/?name=_sip._tcp.example.org&host=29&priority=10&weight=5&port=3456&page_size=1",
         "data": {},
         "status": 200,
         "response": {
@@ -33357,16 +32241,16 @@
         "method": "POST",
         "url": "/api/v1/srvs/",
         "data": {
+          "host": 29,
           "name": "_sip._tcp.example.org",
           "priority": "10",
           "weight": "5",
-          "port": "3456",
-          "host": 29
+          "port": "3456"
         },
         "status": 201,
         "response": {
-          "created_at": "2025-12-18T11:57:51.125931+01:00",
-          "updated_at": "2025-12-18T11:57:51.125937+01:00",
+          "created_at": "2026-07-02T15:54:42.299690+02:00",
+          "updated_at": "2026-07-02T15:54:42.299758+02:00",
           "name": "_sip._tcp.example.org",
           "priority": 10,
           "weight": 5,
@@ -33400,8 +32284,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-12-18T11:57:50.707521+01:00",
-              "updated_at": "2025-12-18T11:57:50.707527+01:00",
+              "created_at": "2026-07-02T15:54:40.860135+02:00",
+              "updated_at": "2026-07-02T15:54:40.860196+02:00",
               "ipaddress": "10.0.0.10",
               "host": 29
             }
@@ -33409,8 +32293,8 @@
           "cnames": [],
           "mxs": [
             {
-              "created_at": "2025-12-18T11:57:50.807545+01:00",
-              "updated_at": "2025-12-18T11:57:50.807552+01:00",
+              "created_at": "2026-07-02T15:54:41.263348+02:00",
+              "updated_at": "2026-07-02T15:54:41.263410+02:00",
               "priority": 10,
               "mx": "mail.example.org",
               "host": 29
@@ -33418,24 +32302,24 @@
           ],
           "txts": [
             {
-              "created_at": "2025-12-18T11:57:50.690623+01:00",
-              "updated_at": "2025-12-18T11:57:50.690629+01:00",
+              "created_at": "2026-07-02T15:54:40.721609+02:00",
+              "updated_at": "2026-07-02T15:54:40.721663+02:00",
               "txt": "v=spf1 -all",
               "host": 29
             }
           ],
           "ptr_overrides": [
             {
-              "created_at": "2025-12-18T11:57:50.929967+01:00",
-              "updated_at": "2025-12-18T11:57:50.929975+01:00",
+              "created_at": "2026-07-02T15:54:41.577404+02:00",
+              "updated_at": "2026-07-02T15:54:41.577458+02:00",
               "ipaddress": "10.0.0.11",
               "host": 29
             }
           ],
           "srvs": [
             {
-              "created_at": "2025-12-18T11:57:51.125931+01:00",
-              "updated_at": "2025-12-18T11:57:51.125937+01:00",
+              "created_at": "2026-07-02T15:54:42.299690+02:00",
+              "updated_at": "2026-07-02T15:54:42.299758+02:00",
               "name": "_sip._tcp.example.org",
               "priority": 10,
               "weight": 5,
@@ -33447,8 +32331,8 @@
           ],
           "naptrs": [
             {
-              "created_at": "2025-12-18T11:57:51.011546+01:00",
-              "updated_at": "2025-12-18T11:57:51.011553+01:00",
+              "created_at": "2026-07-02T15:54:41.899664+02:00",
+              "updated_at": "2026-07-02T15:54:41.899935+02:00",
               "preference": 16384,
               "order": 3,
               "flag": "u",
@@ -33468,12 +32352,12 @@
           "contacts": [
             {
               "email": "foo@example.org",
-              "created_at": "2025-12-18T11:57:48.668874+01:00",
-              "updated_at": "2025-12-18T11:57:48.668883+01:00"
+              "created_at": "2026-07-02T15:54:40.740005+02:00",
+              "updated_at": "2026-07-02T15:54:40.740065+02:00"
             }
           ],
-          "created_at": "2025-12-18T11:57:50.688913+01:00",
-          "updated_at": "2025-12-18T11:57:50.688921+01:00",
+          "created_at": "2026-07-02T15:54:40.709543+02:00",
+          "updated_at": "2026-07-02T15:54:40.709600+02:00",
           "name": "foo.example.org",
           "ttl": null,
           "comment": "",
@@ -33522,18 +32406,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2025-12-18T11:57:28.616170+01:00",
-                "updated_at": "2025-12-18T11:57:28.616179+01:00",
+                "created_at": "2026-07-02T15:53:25.620694+02:00",
+                "updated_at": "2026-07-02T15:53:25.620774+02:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-12-18T11:57:28.475473+01:00",
-            "updated_at": "2025-12-18T11:57:51.125194+01:00",
+            "created_at": "2026-07-02T15:53:23.929576+02:00",
+            "updated_at": "2026-07-02T15:54:42.295248+02:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-12-18T11:57:28.657477+01:00",
+            "serialno_updated_at": "2026-07-02T15:53:27.305422+02:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -33552,8 +32436,8 @@
         },
         "status": 201,
         "response": {
-          "created_at": "2025-12-18T11:57:51.241275+01:00",
-          "updated_at": "2025-12-18T11:57:51.241304+01:00",
+          "created_at": "2026-07-02T15:54:42.636698+02:00",
+          "updated_at": "2026-07-02T15:54:42.636774+02:00",
           "name": "fubar.example.org",
           "ttl": null,
           "zone": 1,
@@ -33562,106 +32446,7 @@
       },
       {
         "method": "GET",
-        "url": "/api/v1/hosts/foo.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "",
-              "created_at": "2025-12-18T11:57:50.707521+01:00",
-              "updated_at": "2025-12-18T11:57:50.707527+01:00",
-              "ipaddress": "10.0.0.10",
-              "host": 29
-            }
-          ],
-          "cnames": [
-            {
-              "created_at": "2025-12-18T11:57:51.241275+01:00",
-              "updated_at": "2025-12-18T11:57:51.241304+01:00",
-              "name": "fubar.example.org",
-              "ttl": null,
-              "zone": 1,
-              "host": 29
-            }
-          ],
-          "mxs": [
-            {
-              "created_at": "2025-12-18T11:57:50.807545+01:00",
-              "updated_at": "2025-12-18T11:57:50.807552+01:00",
-              "priority": 10,
-              "mx": "mail.example.org",
-              "host": 29
-            }
-          ],
-          "txts": [
-            {
-              "created_at": "2025-12-18T11:57:50.690623+01:00",
-              "updated_at": "2025-12-18T11:57:50.690629+01:00",
-              "txt": "v=spf1 -all",
-              "host": 29
-            }
-          ],
-          "ptr_overrides": [
-            {
-              "created_at": "2025-12-18T11:57:50.929967+01:00",
-              "updated_at": "2025-12-18T11:57:50.929975+01:00",
-              "ipaddress": "10.0.0.11",
-              "host": 29
-            }
-          ],
-          "srvs": [
-            {
-              "created_at": "2025-12-18T11:57:51.125931+01:00",
-              "updated_at": "2025-12-18T11:57:51.125937+01:00",
-              "name": "_sip._tcp.example.org",
-              "priority": 10,
-              "weight": 5,
-              "port": 3456,
-              "ttl": null,
-              "zone": 1,
-              "host": 29
-            }
-          ],
-          "naptrs": [
-            {
-              "created_at": "2025-12-18T11:57:51.011546+01:00",
-              "updated_at": "2025-12-18T11:57:51.011553+01:00",
-              "preference": 16384,
-              "order": 3,
-              "flag": "u",
-              "service": "sip",
-              "regex": "[abc]+",
-              "replacement": "wonk",
-              "host": 29
-            }
-          ],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "contacts": [
-            {
-              "email": "foo@example.org",
-              "created_at": "2025-12-18T11:57:48.668874+01:00",
-              "updated_at": "2025-12-18T11:57:48.668883+01:00"
-            }
-          ],
-          "created_at": "2025-12-18T11:57:50.688913+01:00",
-          "updated_at": "2025-12-18T11:57:50.688921+01:00",
-          "name": "foo.example.org",
-          "ttl": null,
-          "comment": "",
-          "zone": 1,
-          "contact": "foo@example.org"
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/cnames/?host=29&name=fubar.example.org",
+        "url": "/api/v1/cnames/?name=fubar.example.org&host=29",
         "data": {},
         "status": 200,
         "response": {
@@ -33670,8 +32455,8 @@
           "previous": null,
           "results": [
             {
-              "created_at": "2025-12-18T11:57:51.241275+01:00",
-              "updated_at": "2025-12-18T11:57:51.241304+01:00",
+              "created_at": "2026-07-02T15:54:42.636698+02:00",
+              "updated_at": "2026-07-02T15:54:42.636774+02:00",
               "name": "fubar.example.org",
               "ttl": null,
               "zone": 1,
@@ -33694,7 +32479,107 @@
     ],
     "error": [],
     "output": [],
-    "api_requests": [],
+    "api_requests": [
+      {
+        "method": "GET",
+        "url": "/api/v1/hosts/foo.example.org",
+        "data": {},
+        "status": 200,
+        "response": {
+          "ipaddresses": [
+            {
+              "macaddress": "",
+              "created_at": "2026-07-02T15:54:40.860135+02:00",
+              "updated_at": "2026-07-02T15:54:40.860196+02:00",
+              "ipaddress": "10.0.0.10",
+              "host": 29
+            }
+          ],
+          "cnames": [
+            {
+              "created_at": "2026-07-02T15:54:42.636698+02:00",
+              "updated_at": "2026-07-02T15:54:42.636774+02:00",
+              "name": "fubar.example.org",
+              "ttl": null,
+              "zone": 1,
+              "host": 29
+            }
+          ],
+          "mxs": [
+            {
+              "created_at": "2026-07-02T15:54:41.263348+02:00",
+              "updated_at": "2026-07-02T15:54:41.263410+02:00",
+              "priority": 10,
+              "mx": "mail.example.org",
+              "host": 29
+            }
+          ],
+          "txts": [
+            {
+              "created_at": "2026-07-02T15:54:40.721609+02:00",
+              "updated_at": "2026-07-02T15:54:40.721663+02:00",
+              "txt": "v=spf1 -all",
+              "host": 29
+            }
+          ],
+          "ptr_overrides": [
+            {
+              "created_at": "2026-07-02T15:54:41.577404+02:00",
+              "updated_at": "2026-07-02T15:54:41.577458+02:00",
+              "ipaddress": "10.0.0.11",
+              "host": 29
+            }
+          ],
+          "srvs": [
+            {
+              "created_at": "2026-07-02T15:54:42.299690+02:00",
+              "updated_at": "2026-07-02T15:54:42.299758+02:00",
+              "name": "_sip._tcp.example.org",
+              "priority": 10,
+              "weight": 5,
+              "port": 3456,
+              "ttl": null,
+              "zone": 1,
+              "host": 29
+            }
+          ],
+          "naptrs": [
+            {
+              "created_at": "2026-07-02T15:54:41.899664+02:00",
+              "updated_at": "2026-07-02T15:54:41.899935+02:00",
+              "preference": 16384,
+              "order": 3,
+              "flag": "u",
+              "service": "sip",
+              "regex": "[abc]+",
+              "replacement": "wonk",
+              "host": 29
+            }
+          ],
+          "sshfps": [],
+          "hostgroups": [],
+          "roles": [],
+          "hinfo": null,
+          "loc": null,
+          "bacnetid": null,
+          "communities": [],
+          "contacts": [
+            {
+              "email": "foo@example.org",
+              "created_at": "2026-07-02T15:54:40.740005+02:00",
+              "updated_at": "2026-07-02T15:54:40.740065+02:00"
+            }
+          ],
+          "created_at": "2026-07-02T15:54:40.709543+02:00",
+          "updated_at": "2026-07-02T15:54:40.709600+02:00",
+          "name": "foo.example.org",
+          "ttl": null,
+          "comment": "",
+          "zone": 1,
+          "contact": "foo@example.org"
+        }
+      }
+    ],
     "time": null
   },
   {
@@ -34504,7 +33389,7 @@
     "api_requests": [
       {
         "method": "GET",
-        "url": "/api/v1/permissions/netgroupregex/?range=192.168.0.0%2F16&group=mygroup&regex=.%2A",
+        "url": "/api/v1/permissions/netgroupregex/?group=mygroup&range=192.168.0.0%2F16&regex=.%2A",
         "data": {},
         "status": 200,
         "response": {
@@ -34518,14 +33403,14 @@
         "method": "POST",
         "url": "/api/v1/permissions/netgroupregex/",
         "data": {
-          "range": "192.168.0.0/16",
           "group": "mygroup",
+          "range": "192.168.0.0/16",
           "regex": ".*"
         },
         "status": 201,
         "response": {
-          "created_at": "2024-12-11T16:45:39.885936+01:00",
-          "updated_at": "2024-12-11T16:45:39.885950+01:00",
+          "created_at": "2026-07-02T15:54:45.727169+02:00",
+          "updated_at": "2026-07-02T15:54:45.727244+02:00",
           "group": "mygroup",
           "range": "192.168.0.0/16",
           "regex": ".*",
@@ -37600,8 +36485,8 @@
       "              10.0.2.4   11:22:33:aa:bb:cc   ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Tue Jan  6 11:18:38 2026",
-      "Updated:      Tue Jan  6 11:18:38 2026"
+      "Created:      Thu Jul  2 15:54:53 2026",
+      "Updated:      Thu Jul  2 15:54:53 2026"
     ],
     "api_requests": [
       {
@@ -37657,18 +36542,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2026-01-06T11:18:02.748004+01:00",
-                "updated_at": "2026-01-06T11:18:02.748108+01:00",
+                "created_at": "2026-07-02T15:53:25.620694+02:00",
+                "updated_at": "2026-07-02T15:53:25.620774+02:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2026-01-06T11:18:01.732722+01:00",
-            "updated_at": "2026-01-06T11:18:33.120641+01:00",
+            "created_at": "2026-07-02T15:53:23.929576+02:00",
+            "updated_at": "2026-07-02T15:54:43.182130+02:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2026-01-06T11:18:02.981369+01:00",
+            "serialno_updated_at": "2026-07-02T15:53:27.305422+02:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -37695,12 +36580,12 @@
               }
             ],
             "community_template_pattern": null,
-            "created_at": "2026-01-06T11:18:36.027535+01:00",
-            "updated_at": "2026-01-06T11:18:38.444850+01:00"
+            "created_at": "2026-07-02T15:54:47.922981+02:00",
+            "updated_at": "2026-07-02T15:54:53.117952+02:00"
           },
           "communities": [],
-          "created_at": "2026-01-06T11:18:35.632035+01:00",
-          "updated_at": "2026-01-06T11:18:37.621965+01:00",
+          "created_at": "2026-07-02T15:54:47.041620+02:00",
+          "updated_at": "2026-07-02T15:54:51.272226+02:00",
           "network": "10.0.2.0/28",
           "description": "TinyNet",
           "vlan": null,
@@ -37733,8 +36618,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2026-01-06T11:18:38.834038+01:00",
-              "updated_at": "2026-01-06T11:18:38.834045+01:00",
+              "created_at": "2026-07-02T15:54:54.134003+02:00",
+              "updated_at": "2026-07-02T15:54:54.134071+02:00",
               "ipaddress": "10.0.2.4",
               "host": 30
             }
@@ -37743,8 +36628,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2026-01-06T11:18:38.812713+01:00",
-              "updated_at": "2026-01-06T11:18:38.812721+01:00",
+              "created_at": "2026-07-02T15:54:53.987493+02:00",
+              "updated_at": "2026-07-02T15:54:53.987547+02:00",
               "txt": "v=spf1 -all",
               "host": 30
             }
@@ -37762,29 +36647,17 @@
           "contacts": [
             {
               "email": "tinyhost@example.org",
-              "created_at": "2025-12-20T12:44:56.834028+01:00",
-              "updated_at": "2025-12-20T12:44:56.834038+01:00"
+              "created_at": "2026-07-02T15:54:54.007194+02:00",
+              "updated_at": "2026-07-02T15:54:54.007260+02:00"
             }
           ],
-          "created_at": "2025-12-20T12:45:24.774283+01:00",
-          "updated_at": "2025-12-20T12:45:24.774296+01:00",
+          "created_at": "2026-07-02T15:54:53.975037+02:00",
+          "updated_at": "2026-07-02T15:54:53.975104+02:00",
           "name": "tinyhost.example.org",
           "ttl": null,
           "comment": "",
           "zone": 1,
           "contact": "tinyhost@example.org"
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/ipaddresses/?macaddress=11%3A22%3A33%3Aaa%3Abb%3Acc&ordering=ipaddress",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
         }
       },
       {
@@ -37802,68 +36675,61 @@
         "status": 200,
         "response": {
           "macaddress": "11:22:33:aa:bb:cc",
-          "created_at": "2026-01-06T11:18:38.834038+01:00",
-          "updated_at": "2026-01-06T11:18:38.929856+01:00",
+          "created_at": "2026-07-02T15:54:54.134003+02:00",
+          "updated_at": "2026-07-02T15:54:54.387441+02:00",
           "ipaddress": "10.0.2.4",
           "host": 30
         }
       },
       {
         "method": "GET",
-        "url": "/api/v1/hosts/?id=30",
+        "url": "/api/v1/hosts/tinyhost.example.org",
         "data": {},
         "status": 200,
         "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
+          "ipaddresses": [
             {
-              "ipaddresses": [
-                {
-                  "macaddress": "11:22:33:aa:bb:cc",
-                  "created_at": "2026-01-06T11:18:38.834038+01:00",
-                  "updated_at": "2026-01-06T11:18:38.929856+01:00",
-                  "ipaddress": "10.0.2.4",
-                  "host": 30
-                }
-              ],
-              "cnames": [],
-              "mxs": [],
-              "txts": [
-                {
-                  "created_at": "2026-01-06T11:18:38.812713+01:00",
-                  "updated_at": "2026-01-06T11:18:38.812721+01:00",
-                  "txt": "v=spf1 -all",
-                  "host": 30
-                }
-              ],
-              "ptr_overrides": [],
-              "srvs": [],
-              "naptrs": [],
-              "sshfps": [],
-              "hostgroups": [],
-              "roles": [],
-              "hinfo": null,
-              "loc": null,
-              "bacnetid": null,
-              "communities": [],
-              "contacts": [
-                {
-                  "email": "tinyhost@example.org",
-                  "created_at": "2025-12-20T12:44:56.834028+01:00",
-                  "updated_at": "2025-12-20T12:44:56.834038+01:00"
-                }
-              ],
-              "created_at": "2025-12-20T12:45:24.774283+01:00",
-              "updated_at": "2025-12-20T12:45:24.774296+01:00",
-              "name": "tinyhost.example.org",
-              "ttl": null,
-              "comment": "",
-              "zone": 1,
-              "contact": "tinyhost@example.org"
+              "macaddress": "11:22:33:aa:bb:cc",
+              "created_at": "2026-07-02T15:54:54.134003+02:00",
+              "updated_at": "2026-07-02T15:54:54.387441+02:00",
+              "ipaddress": "10.0.2.4",
+              "host": 30
             }
-          ]
+          ],
+          "cnames": [],
+          "mxs": [],
+          "txts": [
+            {
+              "created_at": "2026-07-02T15:54:53.987493+02:00",
+              "updated_at": "2026-07-02T15:54:53.987547+02:00",
+              "txt": "v=spf1 -all",
+              "host": 30
+            }
+          ],
+          "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "hostgroups": [],
+          "roles": [],
+          "hinfo": null,
+          "loc": null,
+          "bacnetid": null,
+          "communities": [],
+          "contacts": [
+            {
+              "email": "tinyhost@example.org",
+              "created_at": "2026-07-02T15:54:54.007194+02:00",
+              "updated_at": "2026-07-02T15:54:54.007260+02:00"
+            }
+          ],
+          "created_at": "2026-07-02T15:54:53.975037+02:00",
+          "updated_at": "2026-07-02T15:54:53.975104+02:00",
+          "name": "tinyhost.example.org",
+          "ttl": null,
+          "comment": "",
+          "zone": 1,
+          "contact": "tinyhost@example.org"
         }
       },
       {
@@ -37883,12 +36749,12 @@
               }
             ],
             "community_template_pattern": null,
-            "created_at": "2026-01-06T11:18:36.027535+01:00",
-            "updated_at": "2026-01-06T11:18:38.444850+01:00"
+            "created_at": "2026-07-02T15:54:47.922981+02:00",
+            "updated_at": "2026-07-02T15:54:53.117952+02:00"
           },
           "communities": [],
-          "created_at": "2026-01-06T11:18:35.632035+01:00",
-          "updated_at": "2026-01-06T11:18:37.621965+01:00",
+          "created_at": "2026-07-02T15:54:47.041620+02:00",
+          "updated_at": "2026-07-02T15:54:51.272226+02:00",
           "network": "10.0.2.0/28",
           "description": "TinyNet",
           "vlan": null,
@@ -38149,8 +37015,8 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2026-01-06T11:18:38.834038+01:00",
-              "updated_at": "2026-01-06T11:18:38.929856+01:00",
+              "created_at": "2026-07-02T16:32:37.277756+02:00",
+              "updated_at": "2026-07-02T16:32:37.539498+02:00",
               "ipaddress": "10.0.2.4",
               "host": 30
             }
@@ -38159,8 +37025,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2026-01-06T11:18:38.812713+01:00",
-              "updated_at": "2026-01-06T11:18:38.812721+01:00",
+              "created_at": "2026-07-02T16:32:37.113632+02:00",
+              "updated_at": "2026-07-02T16:32:37.113685+02:00",
               "txt": "v=spf1 -all",
               "host": 30
             }
@@ -38178,12 +37044,12 @@
           "contacts": [
             {
               "email": "tinyhost@example.org",
-              "created_at": "2025-12-18T11:57:29.449620+01:00",
-              "updated_at": "2025-12-18T11:57:29.449630+01:00"
+              "created_at": "2026-07-02T16:32:37.137556+02:00",
+              "updated_at": "2026-07-02T16:32:37.137627+02:00"
             }
           ],
-          "created_at": "2025-12-18T11:57:55.421184+01:00",
-          "updated_at": "2025-12-18T11:57:55.421190+01:00",
+          "created_at": "2026-07-02T16:32:37.097897+02:00",
+          "updated_at": "2026-07-02T16:32:37.098017+02:00",
           "name": "tinyhost.example.org",
           "ttl": null,
           "comment": "",
@@ -38208,8 +37074,8 @@
               }
             ],
             "community_template_pattern": null,
-            "created_at": "2026-01-06T11:18:36.027535+01:00",
-            "updated_at": "2026-01-06T11:18:38.444850+01:00"
+            "created_at": "2026-07-02T16:32:30.850053+02:00",
+            "updated_at": "2026-07-02T16:32:36.266993+02:00"
           },
           "communities": [
             {
@@ -38218,8 +37084,8 @@
               "network": 10,
               "hosts": [],
               "global_name": "community01",
-              "created_at": "2026-01-06T11:18:39.096410+01:00",
-              "updated_at": "2026-01-06T11:18:39.096424+01:00"
+              "created_at": "2026-07-02T16:32:37.844838+02:00",
+              "updated_at": "2026-07-02T16:32:37.844913+02:00"
             },
             {
               "name": "lab",
@@ -38227,12 +37093,12 @@
               "network": 10,
               "hosts": [],
               "global_name": "community02",
-              "created_at": "2026-01-06T11:18:39.222299+01:00",
-              "updated_at": "2026-01-06T11:18:39.222314+01:00"
+              "created_at": "2026-07-02T16:32:37.986998+02:00",
+              "updated_at": "2026-07-02T16:32:37.987071+02:00"
             }
           ],
-          "created_at": "2026-01-06T11:18:35.632035+01:00",
-          "updated_at": "2026-01-06T11:18:37.621965+01:00",
+          "created_at": "2026-07-02T16:32:29.907171+02:00",
+          "updated_at": "2026-07-02T16:32:34.333997+02:00",
           "network": "10.0.2.0/28",
           "description": "TinyNet",
           "vlan": null,
@@ -38242,66 +37108,6 @@
           "frozen": false,
           "reserved": 3,
           "max_communities": null
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/?id=10",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
-            {
-              "excluded_ranges": [],
-              "policy": {
-                "name": "insecurepolicy",
-                "description": "Insecure policy for a network",
-                "attributes": [
-                  {
-                    "name": "baz",
-                    "value": true
-                  }
-                ],
-                "community_template_pattern": null,
-                "created_at": "2026-01-06T11:18:36.027535+01:00",
-                "updated_at": "2026-01-06T11:18:38.444850+01:00"
-              },
-              "communities": [
-                {
-                  "name": "guests",
-                  "description": "Guest hosts.",
-                  "network": 10,
-                  "hosts": [],
-                  "global_name": "community01",
-                  "created_at": "2025-12-18T11:57:55.676394+01:00",
-                  "updated_at": "2025-12-18T11:57:55.676402+01:00"
-                },
-                {
-                  "name": "lab",
-                  "description": "Lab hosts.",
-                  "network": 10,
-                  "hosts": [],
-                  "global_name": "community02",
-                  "created_at": "2026-01-06T11:18:39.222299+01:00",
-                  "updated_at": "2026-01-06T11:18:39.222314+01:00"
-                }
-              ],
-              "created_at": "2026-01-06T11:18:35.632035+01:00",
-              "updated_at": "2026-01-06T11:18:37.621965+01:00",
-              "network": "10.0.2.0/28",
-              "description": "TinyNet",
-              "vlan": null,
-              "dns_delegated": false,
-              "category": "",
-              "location": "",
-              "frozen": false,
-              "reserved": 3,
-              "max_communities": null
-            }
-          ]
         }
       },
       {
@@ -38316,8 +37122,8 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2026-01-06T11:18:38.834038+01:00",
-              "updated_at": "2026-01-06T11:18:38.929856+01:00",
+              "created_at": "2026-07-02T16:32:37.277756+02:00",
+              "updated_at": "2026-07-02T16:32:37.539498+02:00",
               "ipaddress": "10.0.2.4",
               "host": 30
             }
@@ -38326,8 +37132,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-12-18T11:57:55.422966+01:00",
-              "updated_at": "2025-12-18T11:57:55.422972+01:00",
+              "created_at": "2026-07-02T16:32:37.113632+02:00",
+              "updated_at": "2026-07-02T16:32:37.113685+02:00",
               "txt": "v=spf1 -all",
               "host": 30
             }
@@ -38352,20 +37158,20 @@
                   "tinyhost.example.org"
                 ],
                 "global_name": "community01",
-                "created_at": "2026-01-06T11:18:39.096410+01:00",
-                "updated_at": "2026-01-06T11:18:39.096424+01:00"
+                "created_at": "2026-07-02T16:32:37.844838+02:00",
+                "updated_at": "2026-07-02T16:32:37.844913+02:00"
               }
             }
           ],
           "contacts": [
             {
               "email": "tinyhost@example.org",
-              "created_at": "2025-12-18T11:57:29.449620+01:00",
-              "updated_at": "2025-12-18T11:57:29.449630+01:00"
+              "created_at": "2026-07-02T16:32:37.137556+02:00",
+              "updated_at": "2026-07-02T16:32:37.137627+02:00"
             }
           ],
-          "created_at": "2025-12-18T11:57:55.421184+01:00",
-          "updated_at": "2025-12-18T11:57:55.421190+01:00",
+          "created_at": "2026-07-02T16:32:37.097897+02:00",
+          "updated_at": "2026-07-02T16:32:37.098017+02:00",
           "name": "tinyhost.example.org",
           "ttl": null,
           "comment": "",
@@ -38533,68 +37339,6 @@
     "output": [],
     "api_requests": [
       {
-        "method": "GET",
-        "url": "/api/v1/networks/?id=10",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
-            {
-              "excluded_ranges": [],
-              "policy": {
-                "name": "insecurepolicy",
-                "description": "Insecure policy for a network",
-                "attributes": [
-                  {
-                    "name": "baz",
-                    "value": true
-                  }
-                ],
-                "community_template_pattern": null,
-                "created_at": "2026-01-06T11:18:36.027535+01:00",
-                "updated_at": "2026-01-06T11:18:38.444850+01:00"
-              },
-              "communities": [
-                {
-                  "name": "guests",
-                  "description": "Guest hosts.",
-                  "network": 10,
-                  "hosts": [
-                    "tinyhost.example.org"
-                  ],
-                  "global_name": "community01",
-                  "created_at": "2026-01-06T11:18:39.096410+01:00",
-                  "updated_at": "2026-01-06T11:18:39.096424+01:00"
-                },
-                {
-                  "name": "lab",
-                  "description": "Lab hosts.",
-                  "network": 10,
-                  "hosts": [],
-                  "global_name": "community02",
-                  "created_at": "2026-01-06T11:18:39.222299+01:00",
-                  "updated_at": "2026-01-06T11:18:39.222314+01:00"
-                }
-              ],
-              "created_at": "2026-01-06T11:18:35.632035+01:00",
-              "updated_at": "2026-01-06T11:18:37.621965+01:00",
-              "network": "10.0.2.0/28",
-              "description": "TinyNet",
-              "vlan": null,
-              "dns_delegated": false,
-              "category": "",
-              "location": "",
-              "frozen": false,
-              "reserved": 3,
-              "max_communities": null
-            }
-          ]
-        }
-      },
-      {
         "method": "POST",
         "url": "/api/v1/networks/10.0.2.0/28/communities/2/hosts/",
         "data": {
@@ -38606,8 +37350,8 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2026-01-06T11:18:38.834038+01:00",
-              "updated_at": "2026-01-06T11:18:38.929856+01:00",
+              "created_at": "2026-07-02T16:32:37.277756+02:00",
+              "updated_at": "2026-07-02T16:32:37.539498+02:00",
               "ipaddress": "10.0.2.4",
               "host": 30
             }
@@ -38616,8 +37360,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2026-01-06T11:18:38.812713+01:00",
-              "updated_at": "2026-01-06T11:18:38.812721+01:00",
+              "created_at": "2026-07-02T16:32:37.113632+02:00",
+              "updated_at": "2026-07-02T16:32:37.113685+02:00",
               "txt": "v=spf1 -all",
               "host": 30
             }
@@ -38642,20 +37386,20 @@
                   "tinyhost.example.org"
                 ],
                 "global_name": "community02",
-                "created_at": "2025-12-18T11:57:55.724589+01:00",
-                "updated_at": "2025-12-18T11:57:55.724598+01:00"
+                "created_at": "2026-07-02T16:32:37.986998+02:00",
+                "updated_at": "2026-07-02T16:32:37.987071+02:00"
               }
             }
           ],
           "contacts": [
             {
               "email": "tinyhost@example.org",
-              "created_at": "2025-12-18T11:57:29.449620+01:00",
-              "updated_at": "2025-12-18T11:57:29.449630+01:00"
+              "created_at": "2026-07-02T16:32:37.137556+02:00",
+              "updated_at": "2026-07-02T16:32:37.137627+02:00"
             }
           ],
-          "created_at": "2025-12-18T11:57:55.421184+01:00",
-          "updated_at": "2025-12-18T11:57:55.421190+01:00",
+          "created_at": "2026-07-02T16:32:37.097897+02:00",
+          "updated_at": "2026-07-02T16:32:37.098017+02:00",
           "name": "tinyhost.example.org",
           "ttl": null,
           "comment": "",
@@ -39699,8 +38443,8 @@
               }
             ],
             "community_template_pattern": null,
-            "created_at": "2026-01-06T11:18:36.027535+01:00",
-            "updated_at": "2026-01-06T11:18:38.444850+01:00"
+            "created_at": "2026-07-02T15:54:47.922981+02:00",
+            "updated_at": "2026-07-02T15:54:53.117952+02:00"
           },
           "communities": [
             {
@@ -39709,8 +38453,8 @@
               "network": 10,
               "hosts": [],
               "global_name": "community01",
-              "created_at": "2026-01-06T11:18:39.096410+01:00",
-              "updated_at": "2026-01-06T11:18:39.096424+01:00"
+              "created_at": "2026-07-02T15:54:54.756047+02:00",
+              "updated_at": "2026-07-02T15:54:54.756114+02:00"
             },
             {
               "name": "lab",
@@ -39720,12 +38464,12 @@
                 "tinyhost.example.org"
               ],
               "global_name": "community02",
-              "created_at": "2026-01-06T11:18:39.222299+01:00",
-              "updated_at": "2026-01-06T11:18:39.222314+01:00"
+              "created_at": "2026-07-02T15:54:54.986863+02:00",
+              "updated_at": "2026-07-02T15:54:54.986923+02:00"
             }
           ],
-          "created_at": "2026-01-06T11:18:35.632035+01:00",
-          "updated_at": "2026-01-06T11:18:37.621965+01:00",
+          "created_at": "2026-07-02T15:54:47.041620+02:00",
+          "updated_at": "2026-07-02T15:54:51.272226+02:00",
           "network": "10.0.2.0/28",
           "description": "TinyNet",
           "vlan": null,
@@ -39739,62 +38483,33 @@
       },
       {
         "method": "GET",
-        "url": "/api/v1/networks/?id=10",
+        "url": "/api/v1/networks/10.0.2.0/28/communities/",
         "data": {},
         "status": 200,
         "response": {
-          "count": 1,
+          "count": 2,
           "next": null,
           "previous": null,
           "results": [
             {
-              "excluded_ranges": [],
-              "policy": {
-                "name": "insecurepolicy",
-                "description": "Insecure policy for a network",
-                "attributes": [
-                  {
-                    "name": "baz",
-                    "value": true
-                  }
-                ],
-                "community_template_pattern": null,
-                "created_at": "2026-01-06T11:18:36.027535+01:00",
-                "updated_at": "2026-01-06T11:18:38.444850+01:00"
-              },
-              "communities": [
-                {
-                  "name": "guests",
-                  "description": "Guest hosts.",
-                  "network": 10,
-                  "hosts": [],
-                  "global_name": "community01",
-                  "created_at": "2026-01-06T11:18:39.096410+01:00",
-                  "updated_at": "2026-01-06T11:18:39.096424+01:00"
-                },
-                {
-                  "name": "lab",
-                  "description": "Lab hosts.",
-                  "network": 10,
-                  "hosts": [
-                    "tinyhost.example.org"
-                  ],
-                  "global_name": "community02",
-                  "created_at": "2026-01-06T11:18:39.222299+01:00",
-                  "updated_at": "2026-01-06T11:18:39.222314+01:00"
-                }
+              "name": "guests",
+              "description": "Guest hosts.",
+              "network": 10,
+              "hosts": [],
+              "global_name": "community01",
+              "created_at": "2026-07-02T15:54:54.756047+02:00",
+              "updated_at": "2026-07-02T15:54:54.756114+02:00"
+            },
+            {
+              "name": "lab",
+              "description": "Lab hosts.",
+              "network": 10,
+              "hosts": [
+                "tinyhost.example.org"
               ],
-              "created_at": "2026-01-06T11:18:35.632035+01:00",
-              "updated_at": "2026-01-06T11:18:37.621965+01:00",
-              "network": "10.0.2.0/28",
-              "description": "TinyNet",
-              "vlan": null,
-              "dns_delegated": false,
-              "category": "",
-              "location": "",
-              "frozen": false,
-              "reserved": 3,
-              "max_communities": null
+              "global_name": "community02",
+              "created_at": "2026-07-02T15:54:54.986863+02:00",
+              "updated_at": "2026-07-02T15:54:54.986923+02:00"
             }
           ]
         }
@@ -39814,87 +38529,8 @@
             "tinyhost.example.org"
           ],
           "global_name": "community02",
-          "created_at": "2026-01-06T11:18:39.222299+01:00",
-          "updated_at": "2026-01-06T11:18:40.708690+01:00"
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/?id=10",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
-            {
-              "excluded_ranges": [],
-              "policy": {
-                "name": "insecurepolicy",
-                "description": "Insecure policy for a network",
-                "attributes": [
-                  {
-                    "name": "baz",
-                    "value": true
-                  }
-                ],
-                "community_template_pattern": null,
-                "created_at": "2026-01-06T11:18:36.027535+01:00",
-                "updated_at": "2026-01-06T11:18:38.444850+01:00"
-              },
-              "communities": [
-                {
-                  "name": "guests",
-                  "description": "Guest hosts.",
-                  "network": 10,
-                  "hosts": [],
-                  "global_name": "community01",
-                  "created_at": "2026-01-06T11:18:39.096410+01:00",
-                  "updated_at": "2026-01-06T11:18:39.096424+01:00"
-                },
-                {
-                  "name": "labequipment",
-                  "description": "Lab hosts.",
-                  "network": 10,
-                  "hosts": [
-                    "tinyhost.example.org"
-                  ],
-                  "global_name": "community02",
-                  "created_at": "2026-01-06T11:18:39.222299+01:00",
-                  "updated_at": "2026-01-06T11:18:40.708690+01:00"
-                }
-              ],
-              "created_at": "2026-01-06T11:18:35.632035+01:00",
-              "updated_at": "2026-01-06T11:18:37.621965+01:00",
-              "network": "10.0.2.0/28",
-              "description": "TinyNet",
-              "vlan": null,
-              "dns_delegated": false,
-              "category": "",
-              "location": "",
-              "frozen": false,
-              "reserved": 3,
-              "max_communities": null
-            }
-          ]
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/10.0.2.0/28/communities/2",
-        "data": {},
-        "status": 200,
-        "response": {
-          "name": "labequipment",
-          "description": "Lab hosts.",
-          "network": 10,
-          "hosts": [
-            "tinyhost.example.org"
-          ],
-          "global_name": "community02",
-          "created_at": "2026-01-06T11:18:39.222299+01:00",
-          "updated_at": "2026-01-06T11:18:40.708690+01:00"
+          "created_at": "2026-07-02T15:54:54.986863+02:00",
+          "updated_at": "2026-07-02T15:54:59.038965+02:00"
         }
       }
     ],
@@ -39929,8 +38565,8 @@
               }
             ],
             "community_template_pattern": null,
-            "created_at": "2026-01-06T11:18:36.027535+01:00",
-            "updated_at": "2026-01-06T11:18:38.444850+01:00"
+            "created_at": "2026-07-02T15:54:47.922981+02:00",
+            "updated_at": "2026-07-02T15:54:53.117952+02:00"
           },
           "communities": [
             {
@@ -39939,8 +38575,8 @@
               "network": 10,
               "hosts": [],
               "global_name": "community01",
-              "created_at": "2026-01-06T11:18:39.096410+01:00",
-              "updated_at": "2026-01-06T11:18:39.096424+01:00"
+              "created_at": "2026-07-02T15:54:54.756047+02:00",
+              "updated_at": "2026-07-02T15:54:54.756114+02:00"
             },
             {
               "name": "labequipment",
@@ -39950,12 +38586,12 @@
                 "tinyhost.example.org"
               ],
               "global_name": "community02",
-              "created_at": "2026-01-06T11:18:39.222299+01:00",
-              "updated_at": "2026-01-06T11:18:40.708690+01:00"
+              "created_at": "2026-07-02T15:54:54.986863+02:00",
+              "updated_at": "2026-07-02T15:54:59.038965+02:00"
             }
           ],
-          "created_at": "2026-01-06T11:18:35.632035+01:00",
-          "updated_at": "2026-01-06T11:18:37.621965+01:00",
+          "created_at": "2026-07-02T15:54:47.041620+02:00",
+          "updated_at": "2026-07-02T15:54:51.272226+02:00",
           "network": "10.0.2.0/28",
           "description": "TinyNet",
           "vlan": null,
@@ -39965,6 +38601,39 @@
           "frozen": false,
           "reserved": 3,
           "max_communities": null
+        }
+      },
+      {
+        "method": "GET",
+        "url": "/api/v1/networks/10.0.2.0/28/communities/",
+        "data": {},
+        "status": 200,
+        "response": {
+          "count": 2,
+          "next": null,
+          "previous": null,
+          "results": [
+            {
+              "name": "guests",
+              "description": "Guest hosts.",
+              "network": 10,
+              "hosts": [],
+              "global_name": "community01",
+              "created_at": "2026-07-02T15:54:54.756047+02:00",
+              "updated_at": "2026-07-02T15:54:54.756114+02:00"
+            },
+            {
+              "name": "labequipment",
+              "description": "Lab hosts.",
+              "network": 10,
+              "hosts": [
+                "tinyhost.example.org"
+              ],
+              "global_name": "community02",
+              "created_at": "2026-07-02T15:54:54.986863+02:00",
+              "updated_at": "2026-07-02T15:54:59.038965+02:00"
+            }
+          ]
         }
       },
       {
@@ -39982,87 +38651,8 @@
             "tinyhost.example.org"
           ],
           "global_name": "community02",
-          "created_at": "2026-01-06T11:18:39.222299+01:00",
-          "updated_at": "2026-01-06T11:18:40.828796+01:00"
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/?id=10",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
-            {
-              "excluded_ranges": [],
-              "policy": {
-                "name": "insecurepolicy",
-                "description": "Insecure policy for a network",
-                "attributes": [
-                  {
-                    "name": "baz",
-                    "value": true
-                  }
-                ],
-                "community_template_pattern": null,
-                "created_at": "2026-01-06T11:18:36.027535+01:00",
-                "updated_at": "2026-01-06T11:18:38.444850+01:00"
-              },
-              "communities": [
-                {
-                  "name": "guests",
-                  "description": "Guest hosts.",
-                  "network": 10,
-                  "hosts": [],
-                  "global_name": "community01",
-                  "created_at": "2026-01-06T11:18:39.096410+01:00",
-                  "updated_at": "2026-01-06T11:18:39.096424+01:00"
-                },
-                {
-                  "name": "labequipment",
-                  "description": "Lab equipment (expensive)",
-                  "network": 10,
-                  "hosts": [
-                    "tinyhost.example.org"
-                  ],
-                  "global_name": "community02",
-                  "created_at": "2026-01-06T11:18:39.222299+01:00",
-                  "updated_at": "2026-01-06T11:18:40.828796+01:00"
-                }
-              ],
-              "created_at": "2026-01-06T11:18:35.632035+01:00",
-              "updated_at": "2026-01-06T11:18:37.621965+01:00",
-              "network": "10.0.2.0/28",
-              "description": "TinyNet",
-              "vlan": null,
-              "dns_delegated": false,
-              "category": "",
-              "location": "",
-              "frozen": false,
-              "reserved": 3,
-              "max_communities": null
-            }
-          ]
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/10.0.2.0/28/communities/2",
-        "data": {},
-        "status": 200,
-        "response": {
-          "name": "labequipment",
-          "description": "Lab equipment (expensive)",
-          "network": 10,
-          "hosts": [
-            "tinyhost.example.org"
-          ],
-          "global_name": "community02",
-          "created_at": "2026-01-06T11:18:39.222299+01:00",
-          "updated_at": "2026-01-06T11:18:40.828796+01:00"
+          "created_at": "2026-07-02T15:54:54.986863+02:00",
+          "updated_at": "2026-07-02T15:54:59.299091+02:00"
         }
       }
     ],
@@ -40370,8 +38960,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-12-18T11:57:57.124127+01:00",
-              "updated_at": "2025-12-18T11:57:57.124134+01:00",
+              "created_at": "2026-07-02T16:32:42.137261+02:00",
+              "updated_at": "2026-07-02T16:32:42.137314+02:00",
               "ipaddress": "10.0.2.5",
               "host": 31
             }
@@ -40380,8 +38970,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-12-18T11:57:57.103311+01:00",
-              "updated_at": "2025-12-18T11:57:57.103317+01:00",
+              "created_at": "2026-07-02T16:32:42.007457+02:00",
+              "updated_at": "2026-07-02T16:32:42.007510+02:00",
               "txt": "v=spf1 -all",
               "host": 31
             }
@@ -40399,79 +38989,17 @@
           "contacts": [
             {
               "email": "tinierhost@example.org",
-              "created_at": "2025-12-18T11:57:57.105609+01:00",
-              "updated_at": "2025-12-18T11:57:57.105619+01:00"
+              "created_at": "2026-07-02T16:32:42.025558+02:00",
+              "updated_at": "2026-07-02T16:32:42.025618+02:00"
             }
           ],
-          "created_at": "2025-12-18T11:57:57.101570+01:00",
-          "updated_at": "2025-12-18T11:57:57.101577+01:00",
+          "created_at": "2026-07-02T16:32:41.995467+02:00",
+          "updated_at": "2026-07-02T16:32:41.995523+02:00",
           "name": "tinierhost.example.org",
           "ttl": null,
           "comment": "",
           "zone": 1,
           "contact": "tinierhost@example.org"
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/?id=10",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
-            {
-              "excluded_ranges": [],
-              "policy": {
-                "name": "insecurepolicy",
-                "description": "Insecure policy for a network",
-                "attributes": [
-                  {
-                    "name": "baz",
-                    "value": true
-                  }
-                ],
-                "community_template_pattern": null,
-                "created_at": "2025-12-18T11:57:53.334586+01:00",
-                "updated_at": "2025-12-18T11:57:55.166139+01:00"
-              },
-              "communities": [
-                {
-                  "name": "guests",
-                  "description": "Guest hosts.",
-                  "network": 10,
-                  "hosts": [],
-                  "global_name": "community01",
-                  "created_at": "2025-12-18T11:57:55.676394+01:00",
-                  "updated_at": "2025-12-18T11:57:55.676402+01:00"
-                },
-                {
-                  "name": "labequipment",
-                  "description": "Lab equipment (expensive)",
-                  "network": 10,
-                  "hosts": [
-                    "tinyhost.example.org"
-                  ],
-                  "global_name": "community02",
-                  "created_at": "2025-12-18T11:57:55.724589+01:00",
-                  "updated_at": "2025-12-18T11:57:56.924912+01:00"
-                }
-              ],
-              "created_at": "2025-12-18T11:57:52.757525+01:00",
-              "updated_at": "2025-12-18T11:57:54.592984+01:00",
-              "network": "10.0.2.0/28",
-              "description": "TinyNet",
-              "vlan": null,
-              "dns_delegated": false,
-              "category": "",
-              "location": "",
-              "frozen": false,
-              "reserved": 3,
-              "max_communities": null
-            }
-          ]
         }
       },
       {
@@ -40707,8 +39235,8 @@
       "              10.0.0.4   11:22:34:aa:bb:cd   ",
       "TTL:          (Default)",
       "TXT:          v=spf1 -all",
-      "Created:      Sat Dec 20 12:45:27 2025",
-      "Updated:      Sat Dec 20 12:45:27 2025"
+      "Created:      Thu Jul  2 15:55:00 2026",
+      "Updated:      Thu Jul  2 15:55:00 2026"
     ],
     "api_requests": [
       {
@@ -40764,18 +39292,18 @@
           "zone": {
             "nameservers": [
               {
-                "created_at": "2025-12-20T12:44:56.292305+01:00",
-                "updated_at": "2025-12-20T12:44:56.292318+01:00",
+                "created_at": "2026-07-02T15:53:25.620694+02:00",
+                "updated_at": "2026-07-02T15:53:25.620774+02:00",
                 "name": "ns2.example.org",
                 "ttl": null
               }
             ],
-            "created_at": "2025-12-20T12:44:56.003483+01:00",
-            "updated_at": "2025-12-20T12:45:27.447702+01:00",
+            "created_at": "2026-07-02T15:53:23.929576+02:00",
+            "updated_at": "2026-07-02T15:54:59.835182+02:00",
             "updated": true,
             "primary_ns": "ns2.example.org",
             "email": "hostperson@example.org",
-            "serialno_updated_at": "2025-12-20T12:44:56.349179+01:00",
+            "serialno_updated_at": "2026-07-02T15:53:27.305422+02:00",
             "refresh": 360,
             "retry": 1800,
             "expire": 2400,
@@ -40794,8 +39322,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-12-20T12:45:27.683424+01:00",
-          "updated_at": "2025-12-20T12:45:27.683437+01:00",
+          "created_at": "2026-07-02T15:55:00.592858+02:00",
+          "updated_at": "2026-07-02T15:55:00.592939+02:00",
           "network": "10.0.0.0/24",
           "description": "MediumNet",
           "vlan": null,
@@ -40828,8 +39356,8 @@
           "ipaddresses": [
             {
               "macaddress": "",
-              "created_at": "2025-12-20T12:45:27.866636+01:00",
-              "updated_at": "2025-12-20T12:45:27.866643+01:00",
+              "created_at": "2026-07-02T15:55:01.117623+02:00",
+              "updated_at": "2026-07-02T15:55:01.117684+02:00",
               "ipaddress": "10.0.0.4",
               "host": 32
             }
@@ -40838,8 +39366,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-12-20T12:45:27.846274+01:00",
-              "updated_at": "2025-12-20T12:45:27.846280+01:00",
+              "created_at": "2026-07-02T15:55:00.970400+02:00",
+              "updated_at": "2026-07-02T15:55:00.970456+02:00",
               "txt": "v=spf1 -all",
               "host": 32
             }
@@ -40857,29 +39385,17 @@
           "contacts": [
             {
               "email": "mediumhost@example.org",
-              "created_at": "2025-12-20T12:45:27.848765+01:00",
-              "updated_at": "2025-12-20T12:45:27.848773+01:00"
+              "created_at": "2026-07-02T15:55:00.992074+02:00",
+              "updated_at": "2026-07-02T15:55:00.992142+02:00"
             }
           ],
-          "created_at": "2025-12-20T12:45:27.844240+01:00",
-          "updated_at": "2025-12-20T12:45:27.844249+01:00",
+          "created_at": "2026-07-02T15:55:00.957236+02:00",
+          "updated_at": "2026-07-02T15:55:00.957304+02:00",
           "name": "mediumhost.example.org",
           "ttl": null,
           "comment": "",
           "zone": 1,
           "contact": "mediumhost@example.org"
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/ipaddresses/?macaddress=11%3A22%3A34%3Aaa%3Abb%3Acd&ordering=ipaddress",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 0,
-          "next": null,
-          "previous": null,
-          "results": []
         }
       },
       {
@@ -40897,68 +39413,61 @@
         "status": 200,
         "response": {
           "macaddress": "11:22:34:aa:bb:cd",
-          "created_at": "2025-12-20T12:45:27.866636+01:00",
-          "updated_at": "2025-12-20T12:45:28.005231+01:00",
+          "created_at": "2026-07-02T15:55:01.117623+02:00",
+          "updated_at": "2026-07-02T15:55:01.354455+02:00",
           "ipaddress": "10.0.0.4",
           "host": 32
         }
       },
       {
         "method": "GET",
-        "url": "/api/v1/hosts/?id=32",
+        "url": "/api/v1/hosts/mediumhost.example.org",
         "data": {},
         "status": 200,
         "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
+          "ipaddresses": [
             {
-              "ipaddresses": [
-                {
-                  "macaddress": "11:22:34:aa:bb:cd",
-                  "created_at": "2025-12-20T12:45:27.866636+01:00",
-                  "updated_at": "2025-12-20T12:45:28.005231+01:00",
-                  "ipaddress": "10.0.0.4",
-                  "host": 32
-                }
-              ],
-              "cnames": [],
-              "mxs": [],
-              "txts": [
-                {
-                  "created_at": "2025-12-20T12:45:27.846274+01:00",
-                  "updated_at": "2025-12-20T12:45:27.846280+01:00",
-                  "txt": "v=spf1 -all",
-                  "host": 32
-                }
-              ],
-              "ptr_overrides": [],
-              "srvs": [],
-              "naptrs": [],
-              "sshfps": [],
-              "hostgroups": [],
-              "roles": [],
-              "hinfo": null,
-              "loc": null,
-              "bacnetid": null,
-              "communities": [],
-              "contacts": [
-                {
-                  "email": "mediumhost@example.org",
-                  "created_at": "2025-12-20T12:45:27.848765+01:00",
-                  "updated_at": "2025-12-20T12:45:27.848773+01:00"
-                }
-              ],
-              "created_at": "2025-12-20T12:45:27.844240+01:00",
-              "updated_at": "2025-12-20T12:45:27.844249+01:00",
-              "name": "mediumhost.example.org",
-              "ttl": null,
-              "comment": "",
-              "zone": 1,
-              "contact": "mediumhost@example.org"
+              "macaddress": "11:22:34:aa:bb:cd",
+              "created_at": "2026-07-02T15:55:01.117623+02:00",
+              "updated_at": "2026-07-02T15:55:01.354455+02:00",
+              "ipaddress": "10.0.0.4",
+              "host": 32
             }
-          ]
+          ],
+          "cnames": [],
+          "mxs": [],
+          "txts": [
+            {
+              "created_at": "2026-07-02T15:55:00.970400+02:00",
+              "updated_at": "2026-07-02T15:55:00.970456+02:00",
+              "txt": "v=spf1 -all",
+              "host": 32
+            }
+          ],
+          "ptr_overrides": [],
+          "srvs": [],
+          "naptrs": [],
+          "sshfps": [],
+          "hostgroups": [],
+          "roles": [],
+          "hinfo": null,
+          "loc": null,
+          "bacnetid": null,
+          "communities": [],
+          "contacts": [
+            {
+              "email": "mediumhost@example.org",
+              "created_at": "2026-07-02T15:55:00.992074+02:00",
+              "updated_at": "2026-07-02T15:55:00.992142+02:00"
+            }
+          ],
+          "created_at": "2026-07-02T15:55:00.957236+02:00",
+          "updated_at": "2026-07-02T15:55:00.957304+02:00",
+          "name": "mediumhost.example.org",
+          "ttl": null,
+          "comment": "",
+          "zone": 1,
+          "contact": "mediumhost@example.org"
         }
       },
       {
@@ -40970,8 +39479,8 @@
           "excluded_ranges": [],
           "policy": null,
           "communities": [],
-          "created_at": "2025-12-20T12:45:27.683424+01:00",
-          "updated_at": "2025-12-20T12:45:27.683437+01:00",
+          "created_at": "2026-07-02T15:55:00.592858+02:00",
+          "updated_at": "2026-07-02T15:55:00.592939+02:00",
           "network": "10.0.0.0/24",
           "description": "MediumNet",
           "vlan": null,
@@ -40993,63 +39502,11 @@
     "command_issued": "network community_host_add mediumhost labequipment # fails, community not found in network",
     "ok": [],
     "warning": [
-      "Community 'labequipment' not found."
+      "Community 'labequipment' does not exist for network 10.0.0.0/24"
     ],
     "error": [],
     "output": [],
-    "api_requests": [
-      {
-        "method": "GET",
-        "url": "/api/v1/hosts/mediumhost.example.org",
-        "data": {},
-        "status": 200,
-        "response": {
-          "ipaddresses": [
-            {
-              "macaddress": "11:22:34:aa:bb:cd",
-              "created_at": "2025-12-18T11:57:57.507688+01:00",
-              "updated_at": "2025-12-18T11:57:57.601613+01:00",
-              "ipaddress": "10.0.0.4",
-              "host": 32
-            }
-          ],
-          "cnames": [],
-          "mxs": [],
-          "txts": [
-            {
-              "created_at": "2025-12-18T11:57:57.488709+01:00",
-              "updated_at": "2025-12-18T11:57:57.488715+01:00",
-              "txt": "v=spf1 -all",
-              "host": 32
-            }
-          ],
-          "ptr_overrides": [],
-          "srvs": [],
-          "naptrs": [],
-          "sshfps": [],
-          "hostgroups": [],
-          "roles": [],
-          "hinfo": null,
-          "loc": null,
-          "bacnetid": null,
-          "communities": [],
-          "contacts": [
-            {
-              "email": "mediumhost@example.org",
-              "created_at": "2025-12-18T11:57:57.490862+01:00",
-              "updated_at": "2025-12-18T11:57:57.490870+01:00"
-            }
-          ],
-          "created_at": "2025-12-18T11:57:57.487057+01:00",
-          "updated_at": "2025-12-18T11:57:57.487064+01:00",
-          "name": "mediumhost.example.org",
-          "ttl": null,
-          "comment": "",
-          "zone": 1,
-          "contact": "mediumhost@example.org"
-        }
-      }
-    ],
+    "api_requests": [],
     "time": null
   },
   {
@@ -41146,8 +39603,8 @@
               }
             ],
             "community_template_pattern": null,
-            "created_at": "2025-12-18T11:57:53.334586+01:00",
-            "updated_at": "2025-12-18T11:57:55.166139+01:00"
+            "created_at": "2026-07-02T16:49:04.917311+02:00",
+            "updated_at": "2026-07-02T16:49:10.522449+02:00"
           },
           "communities": [
             {
@@ -41156,8 +39613,8 @@
               "network": 10,
               "hosts": [],
               "global_name": "community01",
-              "created_at": "2025-12-18T11:57:55.676394+01:00",
-              "updated_at": "2025-12-18T11:57:55.676402+01:00"
+              "created_at": "2026-07-02T16:49:12.150363+02:00",
+              "updated_at": "2026-07-02T16:49:12.150450+02:00"
             },
             {
               "name": "labequipment",
@@ -41167,12 +39624,12 @@
                 "tinyhost.example.org"
               ],
               "global_name": "community02",
-              "created_at": "2025-12-18T11:57:55.724589+01:00",
-              "updated_at": "2025-12-18T11:57:56.924912+01:00"
+              "created_at": "2026-07-02T16:49:12.288892+02:00",
+              "updated_at": "2026-07-02T16:49:16.146442+02:00"
             }
           ],
-          "created_at": "2025-12-18T11:57:52.757525+01:00",
-          "updated_at": "2025-12-18T11:57:54.592984+01:00",
+          "created_at": "2026-07-02T16:49:03.924028+02:00",
+          "updated_at": "2026-07-02T16:49:08.694317+02:00",
           "network": "10.0.2.0/28",
           "description": "TinyNet",
           "vlan": null,
@@ -41182,68 +39639,6 @@
           "frozen": false,
           "reserved": 3,
           "max_communities": null
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/?id=10",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
-            {
-              "excluded_ranges": [],
-              "policy": {
-                "name": "insecurepolicy",
-                "description": "Insecure policy for a network",
-                "attributes": [
-                  {
-                    "name": "baz",
-                    "value": true
-                  }
-                ],
-                "community_template_pattern": null,
-                "created_at": "2025-12-18T11:57:53.334586+01:00",
-                "updated_at": "2025-12-18T11:57:55.166139+01:00"
-              },
-              "communities": [
-                {
-                  "name": "guests",
-                  "description": "Guest hosts.",
-                  "network": 10,
-                  "hosts": [],
-                  "global_name": "community01",
-                  "created_at": "2025-12-18T11:57:55.676394+01:00",
-                  "updated_at": "2025-12-18T11:57:55.676402+01:00"
-                },
-                {
-                  "name": "labequipment",
-                  "description": "Lab equipment (expensive)",
-                  "network": 10,
-                  "hosts": [
-                    "tinyhost.example.org"
-                  ],
-                  "global_name": "community02",
-                  "created_at": "2025-12-18T11:57:55.724589+01:00",
-                  "updated_at": "2025-12-18T11:57:56.924912+01:00"
-                }
-              ],
-              "created_at": "2025-12-18T11:57:52.757525+01:00",
-              "updated_at": "2025-12-18T11:57:54.592984+01:00",
-              "network": "10.0.2.0/28",
-              "description": "TinyNet",
-              "vlan": null,
-              "dns_delegated": false,
-              "category": "",
-              "location": "",
-              "frozen": false,
-              "reserved": 3,
-              "max_communities": null
-            }
-          ]
         }
       },
       {
@@ -41260,8 +39655,8 @@
               "ipaddresses": [
                 {
                   "macaddress": "11:22:33:aa:bb:cc",
-                  "created_at": "2025-12-18T11:57:55.442237+01:00",
-                  "updated_at": "2025-12-18T11:57:55.531359+01:00",
+                  "created_at": "2026-07-02T16:49:11.562623+02:00",
+                  "updated_at": "2026-07-02T16:49:11.809411+02:00",
                   "ipaddress": "10.0.2.4",
                   "host": 30
                 }
@@ -41270,8 +39665,8 @@
               "mxs": [],
               "txts": [
                 {
-                  "created_at": "2025-12-18T11:57:55.422966+01:00",
-                  "updated_at": "2025-12-18T11:57:55.422972+01:00",
+                  "created_at": "2026-07-02T16:49:11.425658+02:00",
+                  "updated_at": "2026-07-02T16:49:11.425712+02:00",
                   "txt": "v=spf1 -all",
                   "host": 30
                 }
@@ -41296,20 +39691,20 @@
                       "tinyhost.example.org"
                     ],
                     "global_name": "community02",
-                    "created_at": "2025-12-18T11:57:55.724589+01:00",
-                    "updated_at": "2025-12-18T11:57:56.924912+01:00"
+                    "created_at": "2026-07-02T16:49:12.288892+02:00",
+                    "updated_at": "2026-07-02T16:49:16.146442+02:00"
                   }
                 }
               ],
               "contacts": [
                 {
                   "email": "tinyhost@example.org",
-                  "created_at": "2025-12-18T11:57:29.449620+01:00",
-                  "updated_at": "2025-12-18T11:57:29.449630+01:00"
+                  "created_at": "2026-07-02T16:49:11.444548+02:00",
+                  "updated_at": "2026-07-02T16:49:11.444608+02:00"
                 }
               ],
-              "created_at": "2025-12-18T11:57:55.421184+01:00",
-              "updated_at": "2025-12-18T11:57:55.421190+01:00",
+              "created_at": "2026-07-02T16:49:11.413648+02:00",
+              "updated_at": "2026-07-02T16:49:11.413704+02:00",
               "name": "tinyhost.example.org",
               "ttl": null,
               "comment": "",
@@ -41343,8 +39738,8 @@
           "ipaddresses": [
             {
               "macaddress": "11:22:33:aa:bb:cc",
-              "created_at": "2025-12-18T11:57:55.442237+01:00",
-              "updated_at": "2025-12-18T11:57:55.531359+01:00",
+              "created_at": "2026-07-02T16:49:11.562623+02:00",
+              "updated_at": "2026-07-02T16:49:11.809411+02:00",
               "ipaddress": "10.0.2.4",
               "host": 30
             }
@@ -41353,8 +39748,8 @@
           "mxs": [],
           "txts": [
             {
-              "created_at": "2025-12-18T11:57:55.422966+01:00",
-              "updated_at": "2025-12-18T11:57:55.422972+01:00",
+              "created_at": "2026-07-02T16:49:11.425658+02:00",
+              "updated_at": "2026-07-02T16:49:11.425712+02:00",
               "txt": "v=spf1 -all",
               "host": 30
             }
@@ -41379,25 +39774,113 @@
                   "tinyhost.example.org"
                 ],
                 "global_name": "community02",
-                "created_at": "2025-12-18T11:57:55.724589+01:00",
-                "updated_at": "2025-12-18T11:57:56.924912+01:00"
+                "created_at": "2026-07-02T16:49:12.288892+02:00",
+                "updated_at": "2026-07-02T16:49:16.146442+02:00"
               }
             }
           ],
           "contacts": [
             {
               "email": "tinyhost@example.org",
-              "created_at": "2025-12-18T11:57:29.449620+01:00",
-              "updated_at": "2025-12-18T11:57:29.449630+01:00"
+              "created_at": "2026-07-02T16:49:11.444548+02:00",
+              "updated_at": "2026-07-02T16:49:11.444608+02:00"
             }
           ],
-          "created_at": "2025-12-18T11:57:55.421184+01:00",
-          "updated_at": "2025-12-18T11:57:55.421190+01:00",
+          "created_at": "2026-07-02T16:49:11.413648+02:00",
+          "updated_at": "2026-07-02T16:49:11.413704+02:00",
           "name": "tinyhost.example.org",
           "ttl": null,
           "comment": "",
           "zone": 1,
           "contact": "tinyhost@example.org"
+        }
+      },
+      {
+        "method": "GET",
+        "url": "/api/v1/networks/ip/10.0.2.4",
+        "data": {},
+        "status": 200,
+        "response": {
+          "excluded_ranges": [],
+          "policy": {
+            "name": "insecurepolicy",
+            "description": "Insecure policy for a network",
+            "attributes": [
+              {
+                "name": "baz",
+                "value": true
+              }
+            ],
+            "community_template_pattern": null,
+            "created_at": "2026-07-02T16:49:04.917311+02:00",
+            "updated_at": "2026-07-02T16:49:10.522449+02:00"
+          },
+          "communities": [
+            {
+              "name": "guests",
+              "description": "Guest hosts.",
+              "network": 10,
+              "hosts": [],
+              "global_name": "community01",
+              "created_at": "2026-07-02T16:49:12.150363+02:00",
+              "updated_at": "2026-07-02T16:49:12.150450+02:00"
+            },
+            {
+              "name": "labequipment",
+              "description": "Lab equipment (expensive)",
+              "network": 10,
+              "hosts": [
+                "tinyhost.example.org"
+              ],
+              "global_name": "community02",
+              "created_at": "2026-07-02T16:49:12.288892+02:00",
+              "updated_at": "2026-07-02T16:49:16.146442+02:00"
+            }
+          ],
+          "created_at": "2026-07-02T16:49:03.924028+02:00",
+          "updated_at": "2026-07-02T16:49:08.694317+02:00",
+          "network": "10.0.2.0/28",
+          "description": "TinyNet",
+          "vlan": null,
+          "dns_delegated": false,
+          "category": "",
+          "location": "",
+          "frozen": false,
+          "reserved": 3,
+          "max_communities": null
+        }
+      },
+      {
+        "method": "GET",
+        "url": "/api/v1/networks/10.0.2.0/28/communities/",
+        "data": {},
+        "status": 200,
+        "response": {
+          "count": 2,
+          "next": null,
+          "previous": null,
+          "results": [
+            {
+              "name": "guests",
+              "description": "Guest hosts.",
+              "network": 10,
+              "hosts": [],
+              "global_name": "community01",
+              "created_at": "2026-07-02T16:49:12.150363+02:00",
+              "updated_at": "2026-07-02T16:49:12.150450+02:00"
+            },
+            {
+              "name": "labequipment",
+              "description": "Lab equipment (expensive)",
+              "network": 10,
+              "hosts": [
+                "tinyhost.example.org"
+              ],
+              "global_name": "community02",
+              "created_at": "2026-07-02T16:49:12.288892+02:00",
+              "updated_at": "2026-07-02T16:49:16.146442+02:00"
+            }
+          ]
         }
       },
       {
@@ -41438,8 +39921,8 @@
               }
             ],
             "community_template_pattern": null,
-            "created_at": "2026-01-06T11:18:36.027535+01:00",
-            "updated_at": "2026-01-06T11:18:38.444850+01:00"
+            "created_at": "2026-07-02T16:49:04.917311+02:00",
+            "updated_at": "2026-07-02T16:49:10.522449+02:00"
           },
           "communities": [
             {
@@ -41448,8 +39931,8 @@
               "network": 10,
               "hosts": [],
               "global_name": "community01",
-              "created_at": "2026-01-06T11:18:39.096410+01:00",
-              "updated_at": "2026-01-06T11:18:39.096424+01:00"
+              "created_at": "2026-07-02T16:49:12.150363+02:00",
+              "updated_at": "2026-07-02T16:49:12.150450+02:00"
             },
             {
               "name": "labequipment",
@@ -41457,12 +39940,12 @@
               "network": 10,
               "hosts": [],
               "global_name": "community02",
-              "created_at": "2026-01-06T11:18:39.222299+01:00",
-              "updated_at": "2026-01-06T11:18:40.828796+01:00"
+              "created_at": "2026-07-02T16:49:12.288892+02:00",
+              "updated_at": "2026-07-02T16:49:16.146442+02:00"
             }
           ],
-          "created_at": "2026-01-06T11:18:35.632035+01:00",
-          "updated_at": "2026-01-06T11:18:37.621965+01:00",
+          "created_at": "2026-07-02T16:49:03.924028+02:00",
+          "updated_at": "2026-07-02T16:49:08.694317+02:00",
           "network": "10.0.2.0/28",
           "description": "TinyNet",
           "vlan": null,
@@ -41472,66 +39955,6 @@
           "frozen": false,
           "reserved": 3,
           "max_communities": null
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/?id=10",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
-            {
-              "excluded_ranges": [],
-              "policy": {
-                "name": "insecurepolicy",
-                "description": "Insecure policy for a network",
-                "attributes": [
-                  {
-                    "name": "baz",
-                    "value": true
-                  }
-                ],
-                "community_template_pattern": null,
-                "created_at": "2026-01-06T11:18:36.027535+01:00",
-                "updated_at": "2026-01-06T11:18:38.444850+01:00"
-              },
-              "communities": [
-                {
-                  "name": "guests",
-                  "description": "Guest hosts.",
-                  "network": 10,
-                  "hosts": [],
-                  "global_name": "community01",
-                  "created_at": "2026-01-06T11:18:39.096410+01:00",
-                  "updated_at": "2026-01-06T11:18:39.096424+01:00"
-                },
-                {
-                  "name": "labequipment",
-                  "description": "Lab equipment (expensive)",
-                  "network": 10,
-                  "hosts": [],
-                  "global_name": "community02",
-                  "created_at": "2026-01-06T11:18:39.222299+01:00",
-                  "updated_at": "2026-01-06T11:18:40.828796+01:00"
-                }
-              ],
-              "created_at": "2026-01-06T11:18:35.632035+01:00",
-              "updated_at": "2026-01-06T11:18:37.621965+01:00",
-              "network": "10.0.2.0/28",
-              "description": "TinyNet",
-              "vlan": null,
-              "dns_delegated": false,
-              "category": "",
-              "location": "",
-              "frozen": false,
-              "reserved": 3,
-              "max_communities": null
-            }
-          ]
         }
       },
       {
@@ -41584,8 +40007,8 @@
               }
             ],
             "community_template_pattern": null,
-            "created_at": "2026-01-06T11:18:36.027535+01:00",
-            "updated_at": "2026-01-06T11:18:38.444850+01:00"
+            "created_at": "2026-07-02T16:49:04.917311+02:00",
+            "updated_at": "2026-07-02T16:49:10.522449+02:00"
           },
           "communities": [
             {
@@ -41594,12 +40017,12 @@
               "network": 10,
               "hosts": [],
               "global_name": "community01",
-              "created_at": "2026-01-06T11:18:39.096410+01:00",
-              "updated_at": "2026-01-06T11:18:39.096424+01:00"
+              "created_at": "2026-07-02T16:49:12.150363+02:00",
+              "updated_at": "2026-07-02T16:49:12.150450+02:00"
             }
           ],
-          "created_at": "2026-01-06T11:18:35.632035+01:00",
-          "updated_at": "2026-01-06T11:18:37.621965+01:00",
+          "created_at": "2026-07-02T16:49:03.924028+02:00",
+          "updated_at": "2026-07-02T16:49:08.694317+02:00",
           "network": "10.0.2.0/28",
           "description": "TinyNet",
           "vlan": null,
@@ -41609,57 +40032,6 @@
           "frozen": false,
           "reserved": 3,
           "max_communities": null
-        }
-      },
-      {
-        "method": "GET",
-        "url": "/api/v1/networks/?id=10",
-        "data": {},
-        "status": 200,
-        "response": {
-          "count": 1,
-          "next": null,
-          "previous": null,
-          "results": [
-            {
-              "excluded_ranges": [],
-              "policy": {
-                "name": "insecurepolicy",
-                "description": "Insecure policy for a network",
-                "attributes": [
-                  {
-                    "name": "baz",
-                    "value": true
-                  }
-                ],
-                "community_template_pattern": null,
-                "created_at": "2026-01-06T11:18:36.027535+01:00",
-                "updated_at": "2026-01-06T11:18:38.444850+01:00"
-              },
-              "communities": [
-                {
-                  "name": "guests",
-                  "description": "Guest hosts.",
-                  "network": 10,
-                  "hosts": [],
-                  "global_name": "community01",
-                  "created_at": "2026-01-06T11:18:39.096410+01:00",
-                  "updated_at": "2026-01-06T11:18:39.096424+01:00"
-                }
-              ],
-              "created_at": "2026-01-06T11:18:35.632035+01:00",
-              "updated_at": "2026-01-06T11:18:37.621965+01:00",
-              "network": "10.0.2.0/28",
-              "description": "TinyNet",
-              "vlan": null,
-              "dns_delegated": false,
-              "category": "",
-              "location": "",
-              "frozen": false,
-              "reserved": 3,
-              "max_communities": null
-            }
-          ]
         }
       },
       {
@@ -41690,7 +40062,7 @@
     "command_issued": "network community_delete 10.0.2.0/28 guests -force",
     "ok": [],
     "warning": [
-      "Community 'guests' not found."
+      "Community 'guests' does not exist for network 10.0.2.0/28"
     ],
     "error": [],
     "output": [],
@@ -41712,12 +40084,12 @@
               }
             ],
             "community_template_pattern": null,
-            "created_at": "2026-01-06T11:18:36.027535+01:00",
-            "updated_at": "2026-01-06T11:18:38.444850+01:00"
+            "created_at": "2026-07-02T19:27:34.613230+02:00",
+            "updated_at": "2026-07-02T19:27:41.528291+02:00"
           },
           "communities": [],
-          "created_at": "2026-01-06T11:18:35.632035+01:00",
-          "updated_at": "2026-01-06T11:18:37.621965+01:00",
+          "created_at": "2026-07-02T19:27:33.351381+02:00",
+          "updated_at": "2026-07-02T19:27:39.277219+02:00",
           "network": "10.0.2.0/28",
           "description": "TinyNet",
           "vlan": null,

--- a/mreg_cli/cli.py
+++ b/mreg_cli/cli.py
@@ -35,6 +35,7 @@ from mreg_cli.commands.policy import PolicyCommands
 from mreg_cli.commands.recording import RecordingCommmands
 from mreg_cli.commands.root import RootCommmands
 from mreg_cli.commands.zone import ZoneCommands
+from mreg_cli.client import get_client
 from mreg_cli.config import MregCliConfig
 
 # Import other mreg_cli modules
@@ -279,7 +280,7 @@ class Command(Completer):
     def record_responses(self) -> None:
         """Record API responses for the last executed command."""
         output = OutputManager()
-        client = mreg_api.MregClient()
+        client = get_client()
         for response in client.get_client_history():
             output.recording_request(response)
         client.clear_client_history()
@@ -300,7 +301,7 @@ class Command(Completer):
         # Create and set the corrolation id, using the cleaned command
         # as the suffix. This is used to track the command in the logs
         # on the server side.
-        mreg_api.MregClient().set_correlation_id(cmd)
+        get_client().set_correlation_id(cmd)
         # Run the command
         cli.parse(cmd, interactive=interactive)
         # Render the output

--- a/mreg_cli/cli.py
+++ b/mreg_cli/cli.py
@@ -21,6 +21,8 @@ from prompt_toolkit import HTML, document, print_formatted_text
 from prompt_toolkit.completion import CompleteEvent, Completer, Completion
 from prompt_toolkit.history import FileHistory
 
+from mreg_cli.client import get_client
+
 # Import all the commands
 from mreg_cli.commands.cache import CacheCommands
 from mreg_cli.commands.dhcp import DHCPCommands
@@ -35,7 +37,6 @@ from mreg_cli.commands.policy import PolicyCommands
 from mreg_cli.commands.recording import RecordingCommmands
 from mreg_cli.commands.root import RootCommmands
 from mreg_cli.commands.zone import ZoneCommands
-from mreg_cli.client import get_client
 from mreg_cli.config import MregCliConfig
 
 # Import other mreg_cli modules

--- a/mreg_cli/cli.py
+++ b/mreg_cli/cli.py
@@ -159,8 +159,13 @@ class Command(Completer):
                 args["metavar"] = f.metavar
             if f.action:
                 args["action"] = f.action
+
+            # `hidden` is marked by overriding help field.
+            # Ensure we do this as the very last step, so other
+            # parameters do not override the suppression.
             if f.hidden:
                 args["help"] = argparse.SUPPRESS
+
             parser.add_argument(f.name, **args)
         parser.set_defaults(func=callback)
 

--- a/mreg_cli/cli.py
+++ b/mreg_cli/cli.py
@@ -159,6 +159,8 @@ class Command(Completer):
                 args["metavar"] = f.metavar
             if f.action:
                 args["action"] = f.action
+            if f.hidden:
+                args["help"] = argparse.SUPPRESS
             parser.add_argument(f.name, **args)
         parser.set_defaults(func=callback)
 

--- a/mreg_cli/client.py
+++ b/mreg_cli/client.py
@@ -1,0 +1,27 @@
+"""Global MregClient accessor for mreg-cli.
+
+The client is constructed once in main() and stored here via set_client().
+All other modules retrieve it via get_client() instead of instantiating MregClient directly.
+"""
+
+from __future__ import annotations
+
+from mreg_api import MregClient
+
+_client: MregClient | None = None
+
+
+def set_client(client: MregClient | None) -> None:
+    """Store the global client instance (pass None to reset, e.g. in tests)."""
+    global _client
+    _client = client
+
+
+def get_client() -> MregClient:
+    """Return the global client instance.
+
+    :raises RuntimeError: If set_client() has not been called yet.
+    """
+    if _client is None:
+        raise RuntimeError("MregClient not initialized — call set_client() first.")
+    return _client

--- a/mreg_cli/client.py
+++ b/mreg_cli/client.py
@@ -6,22 +6,51 @@ All other modules retrieve it via get_client() instead of instantiating MregClie
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from mreg_api import MregClient
+from mreg_api.cache import CacheConfig
+
+from mreg_cli.__about__ import __version__
+
+if TYPE_CHECKING:
+    from mreg_cli.config import MregCliConfig
 
 _client: MregClient | None = None
 
 
-def set_client(client: MregClient | None) -> None:
-    """Store the global client instance (pass None to reset, e.g. in tests)."""
+def init_client(config: MregCliConfig) -> MregClient:
+    """Initialize the global client instance given the config."""
     global _client
-    _client = client
+    if _client is None:
+        _client = MregClient(
+            url=config.url,
+            domain=config.domain,
+            timeout=config.http_timeout,
+            user_agent=f"mreg-cli/{__version__}",
+            cache=CacheConfig(
+                enable=config.cache,
+                ttl=config.cache_ttl,
+                # other cache settings from config should go here
+            ),
+        )
+    return _client
+
+
+# NOTE: maybe add some protection here to prevent calling this in the main loop
+# some sort of global state that only allows this to be called in tests?
+# That begs the question why we even have this function.
+def _reset_client() -> None:  # pyright: ignore[reportUnusedFunction] # in tests
+    """Reset the global client instance (for testing)."""
+    global _client
+    _client = None
 
 
 def get_client() -> MregClient:
     """Return the global client instance.
 
-    :raises RuntimeError: If set_client() has not been called yet.
+    :raises RuntimeError: If init_client() has not been called yet.
     """
     if _client is None:
-        raise RuntimeError("MregClient not initialized — call set_client() first.")
+        raise RuntimeError("MregClient not initialized — call init_client() first.")
     return _client

--- a/mreg_cli/commands/cache.py
+++ b/mreg_cli/commands/cache.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 import argparse
 from typing import Any
 
-from mreg_api import MregClient
 from mreg_api.exceptions import CacheError
 
+from mreg_cli.client import get_client
 from mreg_cli.commands.base import BaseCommand
 from mreg_cli.commands.registry import CommandRegistry
 from mreg_cli.exceptions import CliError
@@ -31,7 +31,7 @@ class CacheCommands(BaseCommand):
 def cache_clear(_: argparse.Namespace) -> None:
     """Clear the cache."""
     try:
-        client = MregClient()
+        client = get_client()
         items_removed = client.clear_cache()
         OutputManager().add_ok(f"Cleared cache, {items_removed} items removed")
     except CacheError as e:
@@ -44,7 +44,7 @@ def cache_clear(_: argparse.Namespace) -> None:
 )
 def cache_info(_: argparse.Namespace) -> None:
     """Show cache information."""
-    client = MregClient()
+    client = get_client()
     if not client.cache.is_enabled:
         OutputManager().add_line("Cache is disabled.")
         return
@@ -63,7 +63,7 @@ def cache_info(_: argparse.Namespace) -> None:
 )
 def cache_enable(_: argparse.Namespace) -> None:
     """Enable caching."""
-    client = MregClient()
+    client = get_client()
     if client.cache.is_enabled:
         OutputManager().add_line("Cache is already enabled")
         return
@@ -76,7 +76,7 @@ def cache_enable(_: argparse.Namespace) -> None:
 )
 def cache_disable(_: argparse.Namespace) -> None:
     """Disable caching."""
-    client = MregClient()
+    client = get_client()
     if not client.cache.is_enabled:
         OutputManager().add_line("Cache is already disabled")
         return

--- a/mreg_cli/commands/dhcp.py
+++ b/mreg_cli/commands/dhcp.py
@@ -5,14 +5,16 @@ from __future__ import annotations
 import argparse
 from typing import Any
 
-from mreg_api.models import Host, IPAddress, NetworkOrIP
+from mreg_api.models import IPAddress, NetworkOrIP
 from mreg_api.models.fields import MacAddress
 
+from mreg_cli.client import get_client
 from mreg_cli.commands.base import BaseCommand
 from mreg_cli.commands.registry import CommandRegistry
 from mreg_cli.exceptions import EntityOwnershipMismatch, InputFailure
 from mreg_cli.outputmanager import OutputManager
 from mreg_cli.types import Flag
+from mreg_cli.utilities.resolution import resolve_host
 
 command_registry = CommandRegistry()
 
@@ -38,7 +40,8 @@ def ipaddress_from_ip_arg(arg: str) -> IPAddress | None:
     if not (addr := NetworkOrIP.parse(arg, mode="ip")):
         return None
 
-    ipobjs = IPAddress.get_by_ip(addr)
+    client = get_client()
+    ipobjs = client.ipaddress.list_by_ip(str(addr))
     if not ipobjs:
         raise InputFailure(f"IP address {arg} does not exist.")
     elif len(ipobjs) > 1:
@@ -70,15 +73,28 @@ def assoc(args: argparse.Namespace) -> None:
     mac: str = args.mac
     force: bool = args.force
 
+    client = get_client()
+
     mac = MacAddress.parse_or_raise(mac)
-    IPAddress.ensure_associable(mac, force=force)
 
     ipaddress = ipaddress_from_ip_arg(name)
     if not ipaddress:
-        host = Host.get_by_any_means_or_raise(name)
-        ipaddress = host.get_associatable_ip()
+        host = resolve_host(client, name)
+        # Find an IP without a MAC address to associate with.
+        # This replicates the old host.get_associatable_ip() logic.
+        ips_without_mac = [ip for ip in host.ipaddresses if ip.macaddress is None]
+        if not ips_without_mac:
+            raise InputFailure(
+                f"Host {host.name} has no IP addresses available for MAC association."
+            )
+        if len(ips_without_mac) > 1:
+            raise InputFailure(
+                f"Host {host.name} has multiple IP addresses without a MAC address. "
+                "Specify an IP address instead of a hostname."
+            )
+        ipaddress = ips_without_mac[0]
 
-    ipaddress.associate_mac(mac, force=force)
+    client.ipaddress.associate_mac(ipaddress, mac, force=force)
     OutputManager().add_ok(f"Associated mac address {mac} with ip {ipaddress.ipaddress}")
 
 
@@ -102,28 +118,34 @@ def disassoc(args: argparse.Namespace) -> None:
     """
     name: str = args.name
 
+    client = get_client()
+
     ipaddress = ipaddress_from_ip_arg(name)
     if not ipaddress:
-        host = Host.get_by_any_means_or_raise(name)
+        host = resolve_host(client, name)
+        # Check if name itself looks like a MAC address and find the matching IP.
+        # This replicates the old host.has_ip_with_mac(mac) logic.
         if mac := MacAddress.parse(name):
-            ipaddress = host.has_ip_with_mac(mac)
+            matching = [ip for ip in host.ipaddresses if ip.macaddress == mac]
+            ipaddress = matching[0] if matching else None
 
         if not ipaddress:
-            ips_with_mac = host.ips_with_macaddresses()
+            # Replicates host.ips_with_macaddresses()
+            ips_with_mac = [ip for ip in host.ipaddresses if ip.macaddress is not None]
 
             if not ips_with_mac:
                 raise InputFailure(
-                    f"Host {host} does not have any IP addresses with MAC addresses."
+                    f"Host {host.name} does not have any IP addresses with MAC addresses."
                 ) from None
 
             if len(ips_with_mac) > 1:
                 raise InputFailure(
-                    f"Host {host} has multiple IP addresses with MAC addresses."
+                    f"Host {host.name} has multiple IP addresses with MAC addresses."
                 ) from None
 
             ipaddress = ips_with_mac[0]
 
-    ipaddress.disassociate_mac()
+    client.ipaddress.disassociate_mac(ipaddress)
     OutputManager().add_ok(
         f"Disassociated mac address {ipaddress.macaddress} from ip {ipaddress.ipaddress}"
     )

--- a/mreg_cli/commands/dhcp.py
+++ b/mreg_cli/commands/dhcp.py
@@ -3,18 +3,28 @@
 from __future__ import annotations
 
 import argparse
+import logging
 from typing import Any
 
-from mreg_api.models import IPAddress, NetworkOrIP
+from mreg_api import MregClient
+from mreg_api.models import Host, IPAddress, NetworkOrIP
 from mreg_api.models.fields import MacAddress
 
 from mreg_cli.client import get_client
 from mreg_cli.commands.base import BaseCommand
 from mreg_cli.commands.registry import CommandRegistry
-from mreg_cli.exceptions import EntityOwnershipMismatch, InputFailure
+from mreg_cli.exceptions import (
+    EntityAlreadyExists,
+    EntityNotFound,
+    EntityOwnershipMismatch,
+    InputFailure,
+    MultipleEntitiesFound,
+)
 from mreg_cli.outputmanager import OutputManager
 from mreg_cli.types import Flag
 from mreg_cli.utilities.resolution import resolve_host
+
+logger = logging.getLogger(__name__)
 
 command_registry = CommandRegistry()
 
@@ -27,7 +37,7 @@ class DHCPCommands(BaseCommand):
         super().__init__(cli, command_registry, "dhcp", "Manage DHCP associations.", "Manage DHCP")
 
 
-def ipaddress_from_ip_arg(arg: str) -> IPAddress | None:
+def ipaddress_from_ip_arg(arg: str, client: MregClient) -> IPAddress | None:
     """Get an IPAddress object from an IP address argument.
 
     :param arg: IP address argument.
@@ -40,13 +50,88 @@ def ipaddress_from_ip_arg(arg: str) -> IPAddress | None:
     if not (addr := NetworkOrIP.parse(arg, mode="ip")):
         return None
 
-    client = get_client()
     ipobjs = client.ipaddress.list_by_ip(str(addr))
     if not ipobjs:
         raise InputFailure(f"IP address {arg} does not exist.")
     elif len(ipobjs) > 1:
         raise EntityOwnershipMismatch(f"IP {arg} is in use by {len(ipobjs)} hosts.")
     return ipobjs[0]
+
+
+def ensure_macaddress_associable(mac: MacAddress, force: bool, client: MregClient) -> None:
+    """Ensure that a MAC address can be associated with an IP address.
+
+    :param mac: MacAddress object.
+    :param force: Whether to force the association.
+    :param client: MregClient object.
+
+    :raises EntityAlreadyExists: If the MAC address is already associated with an IP address and force is not set.
+    :raises MultipleEntitiesFound: If the MAC address is associated with multiple IP addresses and force
+    """
+    if force:
+        return
+
+    ips = client.ipaddress.list_by_mac(mac)
+    if not ips:
+        return
+
+    if len(ips) == 1:
+        raise EntityAlreadyExists(
+            f"MAC address {mac} is already associated with IP address {ips[0].ipaddress}, must force."
+        )
+    else:
+        ips_str = ", ".join([str(ip.ipaddress) for ip in ips])
+        raise MultipleEntitiesFound(
+            f"MAC address {mac} is already associated with multiple IP addresses: {ips_str}, must force."
+        )
+
+
+def get_associable_ip(host: Host, client: MregClient) -> IPAddress:
+    """Get an IP address from a host that can be associated with a MAC address.
+
+    :param host: Host object.
+
+    :returns: IPAddress object that can be associated with a MAC address.
+
+    :raises InputFailure: If the host has no IP addresses or multiple IP addresses.
+    """
+    if len(host.ipaddresses) == 0:
+        raise EntityNotFound(f"Host {host.name} has no IP addresses.")
+
+    if len(host.ipaddresses) == 1:
+        return host.ipaddresses[0]
+
+    ipv4s = host.ipv4_addresses()
+    ipv6s = host.ipv6_addresses()
+
+    if len(ipv4s) == 1 and len(ipv6s) == 1:
+        ipv4_address = ipv4s[0]
+        ipv6_address = ipv6s[0]
+        ipv4_network = client.network.get_by_ip(ipv4_address.ipaddress)
+        ipv6_network = client.network.get_by_ip(ipv6_address.ipaddress)
+
+        if ipv4_network and ipv6_network:
+            if ipv4_network.vlan == ipv6_network.vlan:
+                return ipv4_address
+        elif ipv4_network:  # only IPv4 is in mreg
+            logger.warning(
+                "Host '%s' has IPv6 address not in MREG: %s",
+                host.name,
+                str(ipv6_address.ipaddress),
+            )
+            return ipv4_address
+        elif ipv6_network:  # only IPv6 is in mreg
+            logger.warning(
+                "Host '%s' has IPv4 address not in MREG: %s",
+                host.name,
+                str(ipv4_address.ipaddress),
+            )
+            return ipv6_address
+
+    ips = ", ".join(str(ip.ipaddress) for ip in host.ipaddresses)
+    raise EntityOwnershipMismatch(
+        f"Host {host.name} has multiple IPs, cannot determine which one to use: {ips}."
+    )
 
 
 @command_registry.register_command(
@@ -75,24 +160,15 @@ def assoc(args: argparse.Namespace) -> None:
 
     client = get_client()
 
+    # Validate and check if mac is in use
     mac = MacAddress.parse_or_raise(mac)
+    ensure_macaddress_associable(mac, force, client)
 
-    ipaddress = ipaddress_from_ip_arg(name)
+    # Parse Name as an IP address first, if not found, resolve as a host name
+    ipaddress = ipaddress_from_ip_arg(name, client)
     if not ipaddress:
         host = resolve_host(client, name)
-        # Find an IP without a MAC address to associate with.
-        # This replicates the old host.get_associatable_ip() logic.
-        ips_without_mac = [ip for ip in host.ipaddresses if ip.macaddress is None]
-        if not ips_without_mac:
-            raise InputFailure(
-                f"Host {host.name} has no IP addresses available for MAC association."
-            )
-        if len(ips_without_mac) > 1:
-            raise InputFailure(
-                f"Host {host.name} has multiple IP addresses without a MAC address. "
-                "Specify an IP address instead of a hostname."
-            )
-        ipaddress = ips_without_mac[0]
+        ipaddress = get_associable_ip(host, client)
 
     client.ipaddress.associate_mac(ipaddress, mac, force=force)
     OutputManager().add_ok(f"Associated mac address {mac} with ip {ipaddress.ipaddress}")
@@ -120,18 +196,18 @@ def disassoc(args: argparse.Namespace) -> None:
 
     client = get_client()
 
-    ipaddress = ipaddress_from_ip_arg(name)
+    ipaddress = ipaddress_from_ip_arg(name, client)
+
+    # Name is not an IP -> resolve as host
     if not ipaddress:
         host = resolve_host(client, name)
         # Check if name itself looks like a MAC address and find the matching IP.
         # This replicates the old host.has_ip_with_mac(mac) logic.
         if mac := MacAddress.parse(name):
-            matching = [ip for ip in host.ipaddresses if ip.macaddress == mac]
-            ipaddress = matching[0] if matching else None
+            ipaddress = host.get_ip_by_mac(mac)
 
         if not ipaddress:
-            # Replicates host.ips_with_macaddresses()
-            ips_with_mac = [ip for ip in host.ipaddresses if ip.macaddress is not None]
+            ips_with_mac = host.ips_with_macaddresses()
 
             if not ips_with_mac:
                 raise InputFailure(

--- a/mreg_cli/commands/group.py
+++ b/mreg_cli/commands/group.py
@@ -5,15 +5,15 @@ from __future__ import annotations
 import argparse
 from typing import Any
 
-from mreg_api.models import Host, HostGroup
-
+from mreg_cli.client import get_client
 from mreg_cli.commands.base import BaseCommand
 from mreg_cli.commands.registry import CommandRegistry
-from mreg_cli.exceptions import CreateError, DeleteError, EntityNotFound, ForceMissing
+from mreg_cli.exceptions import DeleteError, EntityNotFound, ForceMissing
 from mreg_cli.output.group import output_hostgroup, output_hostgroup_members, output_hostgroups
 from mreg_cli.output.history import output_hostgroup_history
 from mreg_cli.outputmanager import OutputManager
 from mreg_cli.types import Flag
+from mreg_cli.utilities.resolution import resolve_host
 
 command_registry = CommandRegistry()
 
@@ -40,11 +40,9 @@ def create(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name, description)
     """
-    HostGroup.get_by_field_and_raise("name", args.name)
-    newgroup = HostGroup.create(data={"name": args.name, "description": args.description})
-    if not newgroup:
-        raise CreateError("Failed to create new group '{args.name}'")
-
+    client = get_client()
+    client.hostgroup.ensure_absent(args.name)
+    newgroup = client.hostgroup.create(name=args.name, description=args.description)
     OutputManager().add_ok(f"Created new group {newgroup.name}")
 
 
@@ -61,8 +59,9 @@ def info(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name)
     """
+    client = get_client()
     for name in args.name:
-        hg = HostGroup.get_by_name_or_raise(name)
+        hg = client.hostgroup.get_by_name(name, required=True)
         output_hostgroup(hg)
 
 
@@ -83,7 +82,8 @@ def find(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name)
     """
-    groups = HostGroup.get_list_by_name_regex(args.name)
+    client = get_client()
+    groups = client.hostgroup.list_by_name_regex(args.name)
     if not groups:
         raise EntityNotFound("No host groups matching the query were found.")
 
@@ -104,9 +104,10 @@ def rename(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (oldname, newname)
     """
-    group = HostGroup.get_by_name_or_raise(args.oldname)
-    HostGroup.get_by_name_and_raise(args.newname)
-    group.rename(args.newname)
+    client = get_client()
+    group = client.hostgroup.get_by_name(args.oldname, required=True)
+    client.hostgroup.ensure_absent(args.newname)
+    client.hostgroup.rename(group, args.newname)
     OutputManager().add_ok(f"Renamed group {args.oldname!r} to {args.newname!r}")
 
 
@@ -124,7 +125,8 @@ def group_list(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name, expand)
     """
-    group = HostGroup.get_by_name_or_raise(args.name)
+    client = get_client()
+    group = client.hostgroup.get_by_name(args.name, required=True)
     output_hostgroup_members(group, expand=args.expand)
 
 
@@ -142,13 +144,12 @@ def group_delete(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name, force)
     """
-    group = HostGroup.get_by_name_or_raise(args.name)
+    client = get_client()
+    group = client.hostgroup.get_by_name(args.name, required=True)
     if (group.hosts or group.groups) and not args.force:
         raise ForceMissing("Group contains hosts or groups, must force")
 
-    if not group.delete():
-        raise DeleteError(f"Failed to delete group {args.name}")
-
+    client.hostgroup.delete(group)
     OutputManager().add_ok(f"Deleted group {args.name!r}")
 
 
@@ -166,11 +167,12 @@ def group_add(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (dstgroup, srcgroup)
     """
-    sourcegroups = [HostGroup.get_by_name_or_raise(name) for name in args.srcgroup]
-    destgroup = HostGroup.get_by_name_or_raise(args.dstgroup)
+    client = get_client()
+    sourcegroups = [client.hostgroup.get_by_name(name, required=True) for name in args.srcgroup]
+    destgroup = client.hostgroup.get_by_name(args.dstgroup, required=True)
 
     for src in sourcegroups:
-        destgroup.add_group(src.name)
+        client.hostgroup.add_group(destgroup, src.name)
         OutputManager().add_ok(f"Added group {src.name!r} to {destgroup.name!r}")
 
 
@@ -188,14 +190,15 @@ def group_remove(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (dstgroup, srcgroup)
     """
-    ownergroup = HostGroup.get_by_name_or_raise(args.dstgroup)
+    client = get_client()
+    ownergroup = client.hostgroup.get_by_name(args.dstgroup, required=True)
 
     for name in args.srcgroup:
         if not ownergroup.has_group(name):
             raise EntityNotFound(f"Group {name!r} not a member in {ownergroup.name!r}")
 
     for name in args.srcgroup:
-        ownergroup.remove_group(name)
+        client.hostgroup.remove_group(ownergroup, name)
         OutputManager().add_ok(f"Removed group {name!r} from {ownergroup.name!r}")
 
 
@@ -213,12 +216,13 @@ def host_add(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (group, hosts)
     """
-    hostgroup = HostGroup.get_by_name_or_raise(args.group)
+    client = get_client()
+    hostgroup = client.hostgroup.get_by_name(args.group, required=True)
 
     for name in args.hosts:
-        host = Host.get_by_any_means_or_raise(name)
+        host = resolve_host(client, name)
         fqname = host.name
-        hostgroup.add_host(fqname)
+        client.hostgroup.add_host(hostgroup, fqname)
         OutputManager().add_ok(f"Added host {fqname!r} to {args.group!r}")
 
 
@@ -236,18 +240,19 @@ def host_remove(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (group, hosts)
     """
-    hostgroup = HostGroup.get_by_name_or_raise(args.group)
+    client = get_client()
+    hostgroup = client.hostgroup.get_by_name(args.group, required=True)
 
     to_remove: set[str] = set()
     for name in args.hosts:
-        host = Host.get_by_any_means_or_raise(name)
+        host = resolve_host(client, name)
         fqname = host.name
         if not hostgroup.has_host(fqname):
             raise EntityNotFound(f"Host {name!r} ({fqname!r}) not a member in {args.group!r}")
         to_remove.add(fqname)
 
     for name in to_remove:
-        hostgroup.remove_host(name)
+        client.hostgroup.remove_host(hostgroup, name)
         OutputManager().add_ok(f"Removed host {name!r} from {args.group!r}")
 
 
@@ -270,8 +275,9 @@ def host_list(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (host, traverse-hostgroups)
     """
-    host = Host.get_by_any_means_or_raise(args.host)
-    hostgroups = host.get_hostgroups(traverse=args.traverse_hostgroups)
+    client = get_client()
+    host = resolve_host(client, args.host)
+    hostgroups = client.hostgroup.list_by_host(host, traverse=args.traverse_hostgroups)
     output_hostgroups(hostgroups, multiline=True)
 
 
@@ -289,10 +295,11 @@ def owner_add(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (group, owners)
     """
-    hostgroup = HostGroup.get_by_name_or_raise(args.group)
+    client = get_client()
+    hostgroup = client.hostgroup.get_by_name(args.group, required=True)
 
     for name in args.owners:
-        hostgroup.add_owner(name)
+        client.hostgroup.add_owner(hostgroup, name)
         OutputManager().add_ok(f"Added owner {name!r} to {args.group!r}")
 
 
@@ -310,14 +317,15 @@ def owner_remove(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (group, owners)
     """
-    hostgroup = HostGroup.get_by_name_or_raise(args.group)
+    client = get_client()
+    hostgroup = client.hostgroup.get_by_name(args.group, required=True)
 
     for name in args.owners:
         if not hostgroup.has_owner(name):
             raise EntityNotFound(f"Owner {name!r} not a member in {args.group!r}")
 
     for name in args.owners:
-        hostgroup.remove_owner(name)
+        client.hostgroup.remove_owner(hostgroup, name)
         OutputManager().add_ok(f"Removed owner {name!r} from {args.group!r}")
 
 
@@ -335,7 +343,9 @@ def set_description(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name, description)
     """
-    HostGroup.get_by_name_or_raise(args.name).set_description(args.description)
+    client = get_client()
+    group = client.hostgroup.get_by_name(args.name, required=True)
+    client.hostgroup.set_description(group, args.description)
     OutputManager().add_ok(f"Updated description to {args.description!r} for {args.name!r}")
 
 

--- a/mreg_cli/commands/group.py
+++ b/mreg_cli/commands/group.py
@@ -44,7 +44,7 @@ def create(args: argparse.Namespace) -> None:
     name: str = args.name
     description: str = args.description
 
-    client.hostgroup.ensure_absent(name)
+    client.hostgroup.assert_absent(name)
     newgroup = client.hostgroup.create(name=name, description=description)
     if newgroup:
         OutputManager().add_ok(f"Created new group {newgroup.name}")
@@ -113,7 +113,7 @@ def rename(args: argparse.Namespace) -> None:
 
     client = get_client()
     group = client.hostgroup.get_by_name(oldname)
-    client.hostgroup.ensure_absent(newname)
+    client.hostgroup.assert_absent(newname)
     client.hostgroup.rename(group, newname)
     OutputManager().add_ok(f"Renamed group {oldname!r} to {newname!r}")
 

--- a/mreg_cli/commands/group.py
+++ b/mreg_cli/commands/group.py
@@ -8,7 +8,7 @@ from typing import Any
 from mreg_cli.client import get_client
 from mreg_cli.commands.base import BaseCommand
 from mreg_cli.commands.registry import CommandRegistry
-from mreg_cli.exceptions import DeleteError, EntityNotFound, ForceMissing
+from mreg_cli.exceptions import EntityNotFound, ForceMissing
 from mreg_cli.output.group import output_hostgroup, output_hostgroup_members, output_hostgroups
 from mreg_cli.output.history import output_hostgroup_history
 from mreg_cli.outputmanager import OutputManager
@@ -41,9 +41,13 @@ def create(args: argparse.Namespace) -> None:
     :param args: argparse.Namespace (name, description)
     """
     client = get_client()
-    client.hostgroup.ensure_absent(args.name)
-    newgroup = client.hostgroup.create(name=args.name, description=args.description)
-    OutputManager().add_ok(f"Created new group {newgroup.name}")
+    name: str = args.name
+    description: str = args.description
+
+    client.hostgroup.ensure_absent(name)
+    newgroup = client.hostgroup.create(name=name, description=description)
+    if newgroup:
+        OutputManager().add_ok(f"Created new group {newgroup.name}")
 
 
 @command_registry.register_command(
@@ -104,11 +108,14 @@ def rename(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (oldname, newname)
     """
+    oldname: str = args.oldname
+    newname: str = args.newname
+
     client = get_client()
-    group = client.hostgroup.get_by_name(args.oldname, required=True)
-    client.hostgroup.ensure_absent(args.newname)
-    client.hostgroup.rename(group, args.newname)
-    OutputManager().add_ok(f"Renamed group {args.oldname!r} to {args.newname!r}")
+    group = client.hostgroup.get_by_name(oldname, required=True)
+    client.hostgroup.ensure_absent(newname)
+    client.hostgroup.rename(group, newname)
+    OutputManager().add_ok(f"Renamed group {oldname!r} to {newname!r}")
 
 
 @command_registry.register_command(

--- a/mreg_cli/commands/group.py
+++ b/mreg_cli/commands/group.py
@@ -65,7 +65,7 @@ def info(args: argparse.Namespace) -> None:
     """
     client = get_client()
     for name in args.name:
-        hg = client.hostgroup.get_by_name(name, required=True)
+        hg = client.hostgroup.get_by_name(name)
         output_hostgroup(hg)
 
 
@@ -112,7 +112,7 @@ def rename(args: argparse.Namespace) -> None:
     newname: str = args.newname
 
     client = get_client()
-    group = client.hostgroup.get_by_name(oldname, required=True)
+    group = client.hostgroup.get_by_name(oldname)
     client.hostgroup.ensure_absent(newname)
     client.hostgroup.rename(group, newname)
     OutputManager().add_ok(f"Renamed group {oldname!r} to {newname!r}")
@@ -133,7 +133,7 @@ def group_list(args: argparse.Namespace) -> None:
     :param args: argparse.Namespace (name, expand)
     """
     client = get_client()
-    group = client.hostgroup.get_by_name(args.name, required=True)
+    group = client.hostgroup.get_by_name(args.name)
     output_hostgroup_members(group, expand=args.expand)
 
 
@@ -152,7 +152,7 @@ def group_delete(args: argparse.Namespace) -> None:
     :param args: argparse.Namespace (name, force)
     """
     client = get_client()
-    group = client.hostgroup.get_by_name(args.name, required=True)
+    group = client.hostgroup.get_by_name(args.name)
     if (group.hosts or group.groups) and not args.force:
         raise ForceMissing("Group contains hosts or groups, must force")
 
@@ -175,8 +175,8 @@ def group_add(args: argparse.Namespace) -> None:
     :param args: argparse.Namespace (dstgroup, srcgroup)
     """
     client = get_client()
-    sourcegroups = [client.hostgroup.get_by_name(name, required=True) for name in args.srcgroup]
-    destgroup = client.hostgroup.get_by_name(args.dstgroup, required=True)
+    sourcegroups = [client.hostgroup.get_by_name(name) for name in args.srcgroup]
+    destgroup = client.hostgroup.get_by_name(args.dstgroup)
 
     for src in sourcegroups:
         client.hostgroup.add_group(destgroup, src.name)
@@ -198,7 +198,7 @@ def group_remove(args: argparse.Namespace) -> None:
     :param args: argparse.Namespace (dstgroup, srcgroup)
     """
     client = get_client()
-    ownergroup = client.hostgroup.get_by_name(args.dstgroup, required=True)
+    ownergroup = client.hostgroup.get_by_name(args.dstgroup)
 
     for name in args.srcgroup:
         if not ownergroup.has_group(name):
@@ -224,7 +224,7 @@ def host_add(args: argparse.Namespace) -> None:
     :param args: argparse.Namespace (group, hosts)
     """
     client = get_client()
-    hostgroup = client.hostgroup.get_by_name(args.group, required=True)
+    hostgroup = client.hostgroup.get_by_name(args.group)
 
     for name in args.hosts:
         host = resolve_host(client, name)
@@ -248,7 +248,7 @@ def host_remove(args: argparse.Namespace) -> None:
     :param args: argparse.Namespace (group, hosts)
     """
     client = get_client()
-    hostgroup = client.hostgroup.get_by_name(args.group, required=True)
+    hostgroup = client.hostgroup.get_by_name(args.group)
 
     to_remove: set[str] = set()
     for name in args.hosts:
@@ -303,7 +303,7 @@ def owner_add(args: argparse.Namespace) -> None:
     :param args: argparse.Namespace (group, owners)
     """
     client = get_client()
-    hostgroup = client.hostgroup.get_by_name(args.group, required=True)
+    hostgroup = client.hostgroup.get_by_name(args.group)
 
     for name in args.owners:
         client.hostgroup.add_owner(hostgroup, name)
@@ -325,7 +325,7 @@ def owner_remove(args: argparse.Namespace) -> None:
     :param args: argparse.Namespace (group, owners)
     """
     client = get_client()
-    hostgroup = client.hostgroup.get_by_name(args.group, required=True)
+    hostgroup = client.hostgroup.get_by_name(args.group)
 
     for name in args.owners:
         if not hostgroup.has_owner(name):
@@ -351,7 +351,7 @@ def set_description(args: argparse.Namespace) -> None:
     :param args: argparse.Namespace (name, description)
     """
     client = get_client()
-    group = client.hostgroup.get_by_name(args.name, required=True)
+    group = client.hostgroup.get_by_name(args.name)
     client.hostgroup.set_description(group, args.description)
     OutputManager().add_ok(f"Updated description to {args.description!r} for {args.name!r}")
 

--- a/mreg_cli/commands/host_submodules/a_aaaa.py
+++ b/mreg_cli/commands/host_submodules/a_aaaa.py
@@ -128,10 +128,10 @@ def _ip_change(name: str, old: str, new: str, force: bool, ipversion: IP_Version
     new_ip = NetworkOrIP.validate(new)
     network = None
     if new_ip.is_network():
-        network = client.network.get(str(new_ip.ip_or_network), required=True)
+        network = client.network.get(str(new_ip.ip_or_network))
         new_ip = client.network.get_first_available_ip(network)
     else:
-        network = client.network.get_by_ip(str(new_ip.as_ip()))
+        network = client.network.get_by_ip(str(new_ip.as_ip()), required=False)
         new_ip = new_ip.as_ip()
 
     if old_ip.version != ipversion:
@@ -271,10 +271,10 @@ def _ip_add(
     ip = None
     network = None
     if ip_or_net.is_network():
-        network = client.network.get(str(ip_or_net.ip_or_network), required=True)
+        network = client.network.get(str(ip_or_net.ip_or_network))
         ip = client.network.get_first_available_ip(network)
     else:
-        network = client.network.get_by_ip(str(ip_or_net.as_ip()))
+        network = client.network.get_by_ip(str(ip_or_net.as_ip()), required=False)
         ip = ip_or_net.as_ip()
 
     check_ip_constraints(ip, network, host, IPOperation.ADD, force)

--- a/mreg_cli/commands/host_submodules/a_aaaa.py
+++ b/mreg_cli/commands/host_submodules/a_aaaa.py
@@ -144,7 +144,7 @@ def _ip_change(name: str, old: str, new: str, force: bool, ipversion: IP_Version
 
     # Find the IPAddress object for the old IP
     host_ip = next(
-        (h_ip for h_ip in host.ipaddresses if h_ip.ipaddress == old_ip.as_ip()),
+        (h_ip for h_ip in host.ipaddresses if h_ip.ipaddress == old_ip),
         None,
     )
     if not host_ip:
@@ -167,16 +167,14 @@ def _ip_move(ipaddr: str, fromhost: str, tohost: str, ipversion: IP_Version) -> 
     """
     client = get_client()
 
-    ip = NetworkOrIP.parse_or_raise(ipaddr, mode="ip")
-    if ip.version != ipversion:
+    ip_addr = NetworkOrIP.parse_or_raise(ipaddr, mode="ip")
+    if ip_addr.version != ipversion:
         raise InputFailure(
-            f"IP version {ip.version} does not match the requested version {ipversion}"
+            f"IP version {ip_addr.version} does not match the requested version {ipversion}"
         )
 
     from_host = resolve_host(client, fromhost)
     to_host = resolve_host(client, tohost)
-
-    ip_addr = ip.as_ip()
 
     # Find the IPAddress object on from_host
     host_ip = next(
@@ -191,11 +189,11 @@ def _ip_move(ipaddr: str, fromhost: str, tohost: str, ipversion: IP_Version) -> 
     )
 
     if not host_ip and not ptr:
-        raise EntityNotFound(f"Host {from_host} has no IP or PTR with address {ip}")
+        raise EntityNotFound(f"Host {from_host} has no IP or PTR with address {ipaddr}")
 
     msg = ""
     if host_ip:
-        client.patch(f"/api/v1/ipaddresses/{host_ip.id}/", json={"host": to_host.id})
+        client.ipaddress.update(host_ip, host=to_host)
         msg = f"Moved ipaddress {ipaddr}"
     else:
         msg += "No ipaddresses matched. "
@@ -218,19 +216,18 @@ def _ip_remove(name: str, ipaddr: str, ipversion: IP_Version, force: bool = Fals
 
     # TODO: use event suppression ctx manager to avoid printing cname and PTR resolution here
     host = resolve_host(client, name)
-    ip = NetworkOrIP.parse_or_raise(ipaddr, mode="ip")
-    if ip.version != ipversion:
+    ip_addr = NetworkOrIP.parse_or_raise(ipaddr, mode="ip")
+    if ip_addr.version != ipversion:
         raise InputFailure(
-            f"IP version {ip.version} does not match the requested version {ipversion}"
+            f"IP version {ip_addr.version} does not match the requested version {ipversion}"
         )
 
-    ip_addr = ip.as_ip()
     host_ip = next(
         (h_ip for h_ip in host.ipaddresses if h_ip.ipaddress == ip_addr),
         None,
     )
     if not host_ip:
-        raise EntityNotFound(f"Host {host} does not have IP {ip}")
+        raise EntityNotFound(f"Host {host} does not have IP {ipaddr}")
 
     # Check if we fetched the host via a CNAME.
     if not force and host.cnames:
@@ -286,7 +283,7 @@ def _ip_add(
     if macaddress:
         mac = MacAddress.parse_or_raise(macaddress)
 
-    client.ipaddress.create(host=host, ipaddress=ip, macaddress=mac or None)
+    client.ipaddress.create(host=host, ipaddress=ip, macaddress=mac)
     OutputManager().add_ok(f"Added ipaddress {ip} to {host}")
 
     # Resolve and return the updated host

--- a/mreg_cli/commands/host_submodules/a_aaaa.py
+++ b/mreg_cli/commands/host_submodules/a_aaaa.py
@@ -18,12 +18,12 @@ from __future__ import annotations
 import argparse
 from enum import Enum, auto
 
-from mreg_api.models import CNAME, Host, HostList, Network, NetworkOrIP
-from mreg_api.models.fields import HostName, MacAddress
+from mreg_api.models import Host, Network, NetworkOrIP
+from mreg_api.models.fields import MacAddress
 
+from mreg_cli.client import get_client
 from mreg_cli.commands.host import registry as command_registry
 from mreg_cli.exceptions import (
-    DeleteError,
     EntityAlreadyExists,
     EntityNotFound,
     ForceMissing,
@@ -32,6 +32,7 @@ from mreg_cli.exceptions import (
 from mreg_cli.output import output_host_ipaddresses
 from mreg_cli.outputmanager import OutputManager
 from mreg_cli.types import Flag, IP_AddressT, IP_Version
+from mreg_cli.utilities.resolution import resolve_host
 
 
 class IPOperation(Enum):
@@ -48,9 +49,10 @@ def _bail_if_ip_in_use_and_not_force(ip: IP_AddressT) -> None:
 
     :param ip: The IP address to check.
     """
-    hosts_using_ip = HostList.get_by_ip(ip)
+    client = get_client()
+    hosts_using_ip = client.host.list_by_ip(str(ip))
     if hosts_using_ip:
-        hostnames = ", ".join(hosts_using_ip.hostnames())
+        hostnames = ", ".join(str(h.name) for h in hosts_using_ip)
         raise ForceMissing(f"IP {ip} in use by {hostnames}, must force.")
 
 
@@ -95,8 +97,11 @@ def check_ip_constraints(
         raise ForceMissing(f"Network for {ip} not found, must force")
     if network and network.frozen:
         raise ForceMissing(f"Network {network.network} is frozen, must force")
-    if host.has_ip(ip):
+
+    # Check if host already has this IP
+    if any(h_ip.ipaddress == ip for h_ip in host.ipaddresses):
         raise EntityAlreadyExists(f"Host {host} already has IP {ip}")
+
     if operation == IPOperation.ADD and len(host.ipaddresses) > 0:
         raise ForceMissing(f"Host {host} already has one or more ip addresses, must force")
 
@@ -116,15 +121,17 @@ def _ip_change(name: str, old: str, new: str, force: bool, ipversion: IP_Version
     if old == new:
         raise EntityAlreadyExists("New and old IP are equal")
 
+    client = get_client()
+
     old_ip = NetworkOrIP.parse_or_raise(old, mode="ip")
 
     new_ip = NetworkOrIP.validate(new)
     network = None
     if new_ip.is_network():
-        network = Network.get_by_network_or_raise(str(new_ip.ip_or_network))
-        new_ip = network.get_first_available_ip()
+        network = client.network.get(str(new_ip.ip_or_network), required=True)
+        new_ip = client.network.get_first_available_ip(network)
     else:
-        network = Network.get_by_ip(new_ip.as_ip())
+        network = client.network.get_by_ip(str(new_ip.as_ip()))
         new_ip = new_ip.as_ip()
 
     if old_ip.version != ipversion:
@@ -133,15 +140,19 @@ def _ip_change(name: str, old: str, new: str, force: bool, ipversion: IP_Version
     if new_ip.version != ipversion:
         raise InputFailure("New IP version does not match the requested version")
 
-    host = Host.get_by_any_means_or_raise(name)
+    host = resolve_host(client, name)
 
-    host_ip = host.get_ip(old_ip)
+    # Find the IPAddress object for the old IP
+    host_ip = next(
+        (h_ip for h_ip in host.ipaddresses if h_ip.ipaddress == old_ip.as_ip()),
+        None,
+    )
     if not host_ip:
         raise EntityNotFound(f"Host {host} does not have IP {old_ip}")
 
     check_ip_constraints(new_ip, network, host, IPOperation.CHANGE, force)
 
-    host_ip.patch(data={"ipaddress": str(new_ip)})
+    client.ipaddress.update(host_ip, ipaddress=new_ip)
 
     OutputManager().add_ok(f"changed ip {old} to {new_ip} for {host}")
 
@@ -154,30 +165,43 @@ def _ip_move(ipaddr: str, fromhost: str, tohost: str, ipversion: IP_Version) -> 
     :param tohost: Name of destination host
     :param ipversion: 4 or 6
     """
+    client = get_client()
+
     ip = NetworkOrIP.parse_or_raise(ipaddr, mode="ip")
     if ip.version != ipversion:
         raise InputFailure(
             f"IP version {ip.version} does not match the requested version {ipversion}"
         )
 
-    from_host = Host.get_by_any_means_or_raise(fromhost)
-    to_host = Host.get_by_any_means_or_raise(tohost)
+    from_host = resolve_host(client, fromhost)
+    to_host = resolve_host(client, tohost)
 
-    host_ip = from_host.get_ip(ip)
+    ip_addr = ip.as_ip()
 
-    ptr = from_host.get_ptr_override(ip)
+    # Find the IPAddress object on from_host
+    host_ip = next(
+        (h_ip for h_ip in from_host.ipaddresses if h_ip.ipaddress == ip_addr),
+        None,
+    )
+
+    # Find PTR override on from_host
+    ptr = next(
+        (p for p in from_host.ptr_overrides if p.ipaddress == ip_addr),
+        None,
+    )
+
     if not host_ip and not ptr:
         raise EntityNotFound(f"Host {from_host} has no IP or PTR with address {ip}")
 
     msg = ""
     if host_ip:
-        host_ip.patch(data={"host": to_host.id})
+        client.patch(f"/api/v1/ipaddresses/{host_ip.id}/", json={"host": to_host.id})
         msg = f"Moved ipaddress {ipaddr}"
     else:
         msg += "No ipaddresses matched. "
 
     if ptr:
-        ptr.patch(data={"host": to_host.id})
+        client.ptroverride.update(ptr, host=to_host)
         msg += "Moved PTR override."
 
     OutputManager().add_line(msg)
@@ -190,30 +214,34 @@ def _ip_remove(name: str, ipaddr: str, ipversion: IP_Version, force: bool = Fals
     :param ipaddr: IP to remove.
     :param ipversion: 4 or 6
     """
-    host = Host.get_by_any_means_or_raise(name, inform_as_cname=False, inform_as_ptr=False)
+    client = get_client()
+
+    # TODO: use event suppression ctx manager to avoid printing cname and PTR resolution here
+    host = resolve_host(client, name)
     ip = NetworkOrIP.parse_or_raise(ipaddr, mode="ip")
     if ip.version != ipversion:
         raise InputFailure(
             f"IP version {ip.version} does not match the requested version {ipversion}"
         )
 
-    host_ip = host.get_ip(ip)
+    ip_addr = ip.as_ip()
+    host_ip = next(
+        (h_ip for h_ip in host.ipaddresses if h_ip.ipaddress == ip_addr),
+        None,
+    )
     if not host_ip:
         raise EntityNotFound(f"Host {host} does not have IP {ip}")
 
     # Check if we fetched the host via a CNAME.
     if not force and host.cnames:
-        # Ensure arg is a valid host name with a domain
-        # (e.g. "foo" -> "foo.example.com")
-        name_hostname = HostName.parse_or_raise(name)
-        cname = CNAME.get_by_field("name", name_hostname)
+        # Expand the name to a FQDN and check for CNAME
+        fqdn_name = client.fqdn(name)
+        cname = client.cname.get_by_name(fqdn_name)
         if cname:
             raise ForceMissing(f"{cname.name} is a CNAME for {host.name}, must force.")
 
-    if host_ip.delete():
-        OutputManager().add_ok(f"Removed ipaddress {ipaddr} from {host}")
-    else:
-        raise DeleteError(f"Failed to remove ipaddress {ipaddr} from {host}")
+    client.ipaddress.delete(host_ip)
+    OutputManager().add_ok(f"Removed ipaddress {ipaddr} from {host}")
 
 
 def _ip_add(
@@ -225,14 +253,17 @@ def _ip_add(
 ) -> Host:
     """Add a new IP address to a host.
 
-    :param host: Name of the host to add the IP to.
+    :param name: Name of the host to add the IP to.
     :param ipaddr: The IP address to add.
     :param macaddress: The MAC address to add.
     :param force: Whether to force the addition.
+    :param ipversion: 4 or 6
 
     :return: The updated host object.
     """
-    host = Host.get_by_any_means_or_raise(name)
+    client = get_client()
+
+    host = resolve_host(client, name)
     ip_or_net = NetworkOrIP.validate(ipaddr)
 
     if ipversion == 4 and (ip_or_net.is_ipv6() or ip_or_net.is_ipv6_network()):
@@ -243,10 +274,10 @@ def _ip_add(
     ip = None
     network = None
     if ip_or_net.is_network():
-        network = Network.get_by_network_or_raise(str(ip_or_net.ip_or_network))
-        ip = network.get_first_available_ip()
+        network = client.network.get(str(ip_or_net.ip_or_network), required=True)
+        ip = client.network.get_first_available_ip(network)
     else:
-        network = Network.get_by_ip(ip_or_net.as_ip())
+        network = client.network.get_by_ip(str(ip_or_net.as_ip()))
         ip = ip_or_net.as_ip()
 
     check_ip_constraints(ip, network, host, IPOperation.ADD, force)
@@ -255,9 +286,12 @@ def _ip_add(
     if macaddress:
         mac = MacAddress.parse_or_raise(macaddress)
 
-    host = host.add_ip(ip, mac)  # returns the refetched host
+    client.ipaddress.create(host=host, ipaddress=ip, macaddress=mac or None)
     OutputManager().add_ok(f"Added ipaddress {ip} to {host}")
-    return host
+
+    # Resolve and return the updated host
+    updated_host = resolve_host(client, str(host.name))
+    return updated_host
 
 
 @command_registry.register_command(
@@ -408,7 +442,8 @@ def a_show(args: argparse.Namespace) -> None:
     :param args: argparse.Namespace (name)
     """
     name: str = args.name
-    host = Host.get_by_any_means_or_raise(name)
+    client = get_client()
+    host = resolve_host(client, name)
     output_host_ipaddresses(host, only=4)
 
 
@@ -554,5 +589,6 @@ def aaaa_show(args: argparse.Namespace) -> None:
     """
     name: str = args.name
 
-    host = Host.get_by_any_means_or_raise(name)
+    client = get_client()
+    host = resolve_host(client, name)
     output_host_ipaddresses(host, only=6)

--- a/mreg_cli/commands/host_submodules/bacnet.py
+++ b/mreg_cli/commands/host_submodules/bacnet.py
@@ -11,12 +11,12 @@ from __future__ import annotations
 
 import argparse
 
-from mreg_api.models import BacnetID, Host
+from mreg_api.models import BacnetID
 
+from mreg_cli.client import get_client
 from mreg_cli.commands.host import registry as command_registry
 from mreg_cli.exceptions import (
     CreateError,
-    DeleteError,
     EntityAlreadyExists,
     EntityNotFound,
     EntityOwnershipMismatch,
@@ -25,6 +25,8 @@ from mreg_cli.exceptions import (
 from mreg_cli.output import output_bacnetids
 from mreg_cli.outputmanager import OutputManager
 from mreg_cli.types import Flag
+from mreg_cli.utilities.resolution import resolve_host
+from mreg_cli.utilities.shared import string_to_int
 
 
 @command_registry.register_command(
@@ -41,21 +43,20 @@ def bacnetid_add(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name, id)
     """
-    host = Host.get_by_any_means_or_raise(args.name)
-    host_bacnet = host.bacnet()
+    client = get_client()
+    host = resolve_host(client, args.name)
+    host_bacnet = client.bacnetid.get_by_host(host)
     if host_bacnet is not None:
         raise EntityAlreadyExists(f"{host.name} already has BACnet ID {host_bacnet.id}.")
 
-    existing = BacnetID.get(args.id)
+    existing = client.bacnetid.first(id=args.id)
     if existing:
         raise EntityOwnershipMismatch(
             f"BACnet ID {existing.id} is already in use by {existing.hostname}."
         )
 
-    BacnetID.create(data={"hostname": host.name, "id": args.id})
-
-    validator = BacnetID.get(args.id)
-    if validator and validator.hostname == host.name:
+    validator = client.bacnetid.create(host=host, id=args.id)
+    if validator and validator.hostname == str(host.name):
         OutputManager().add_ok(f"Assigned BACnet ID {validator.id} to {validator.hostname}.")
     else:
         raise CreateError(f"Failed to assign BACnet ID {args.id} to {host.name}.")
@@ -74,15 +75,14 @@ def bacnetid_remove(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name)
     """
-    host = Host.get_by_any_means_or_raise(args.name)
-    host_bacnet = host.bacnet()
+    client = get_client()
+    host = resolve_host(client, args.name)
+    host_bacnet = client.bacnetid.get_by_host(host)
     if host_bacnet is None:
         raise EntityNotFound(f"{host.name} does not have a BACnet ID assigned.")
 
-    if host_bacnet.delete():
-        OutputManager().add_ok(f"Unassigned BACnet ID {host_bacnet.id} from {host.name}.")
-    else:
-        raise DeleteError(f"Failed to unassign BACnet ID {host_bacnet.id} from {host.name}.")
+    client.bacnetid.delete(host_bacnet)
+    OutputManager().add_ok(f"Unassigned BACnet ID {host_bacnet.id} from {host.name}.")
 
 
 @command_registry.register_command(
@@ -95,12 +95,14 @@ def bacnetid_remove(args: argparse.Namespace) -> None:
             description=f"Minimum ID value (0-{BacnetID.MAX_ID()})",
             flag_type=int,
             metavar="MIN",
+            default=0,
         ),
         Flag(
             "-max",
             description=f"Maximum ID value (0-{BacnetID.MAX_ID()})",
             flag_type=int,
             metavar="MAX",
+            default=BacnetID.MAX_ID(),
         ),
     ],
 )
@@ -109,19 +111,21 @@ def bacnetid_list(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (min, max)
     """
-    min_id = args.min if args.min is not None else 0
-    max_id = args.max if args.max is not None else BacnetID.MAX_ID()
+    client = get_client()
+
+    min_id = string_to_int(args.min, "Minimum ID")
+    max_id = string_to_int(args.max, "Maximum ID")
 
     if min_id < 0:
         raise InputFailure("Minimum ID value cannot be less than 0.")
 
-    if min_id is not None and max_id is not None and min_id > max_id:
+    if min_id > max_id:
         raise InputFailure("Minimum ID value cannot be greater than maximum ID value.")
 
-    if max_id is not None and max_id > BacnetID.MAX_ID():
+    if max_id > BacnetID.MAX_ID():
         raise InputFailure(f"The maximum ID value is {BacnetID.MAX_ID()}.")
 
-    bacnetids = BacnetID.get_in_range(min_id, max_id)
+    bacnetids = client.bacnetid.list_in_range(min_id, max_id)
     if not bacnetids:
         raise EntityNotFound("No BACnet IDs found in the specified range.")
 

--- a/mreg_cli/commands/host_submodules/cname.py
+++ b/mreg_cli/commands/host_submodules/cname.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import argparse
 
-from mreg_api.models import CNAME, ForwardZone, Host
 from mreg_api.models.fields import HostName
 
+from mreg_cli.client import get_client
 from mreg_cli.commands.host import registry as command_registry
 from mreg_cli.exceptions import (
     CreateError,
@@ -20,6 +20,7 @@ from mreg_cli.exceptions import (
 from mreg_cli.output.host import output_cnames
 from mreg_cli.outputmanager import OutputManager
 from mreg_cli.types import Flag
+from mreg_cli.utilities.resolution import resolve_host
 
 
 @command_registry.register_command(
@@ -40,14 +41,15 @@ def cname_add(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name, alias, force)
     """
+    client = get_client()
     name: str = args.name
     alias: str = args.alias
 
     # Get host info or raise exception
-    host = Host.get_by_any_means_or_raise(name)
+    host = resolve_host(client, name)
     alias = HostName.parse_or_raise(alias)
 
-    alias_in_use = Host.get_by_any_means(alias, inform_as_cname=False)
+    alias_in_use = resolve_host(client, alias, required=False)
     if alias_in_use:
         if alias_in_use.id == host.id:
             raise EntityAlreadyExists(f"The alias {alias} is already active for {host}.")
@@ -62,12 +64,12 @@ def cname_add(args: argparse.Namespace) -> None:
             "The alias name is in use by an existing host. Find a new alias."
         )
 
-    zone = ForwardZone.get_from_hostname(alias)
+    zone = client.zone.get_from_host(alias)
     if not zone:
         raise EntityNotFound(f"Could not find a zone for the alias {alias}.")
 
-    CNAME.create(data={"host": str(host.id), "name": alias})
-    cname = CNAME.get_by_host_and_name(host.name, alias)
+    client.cname.create(host=host, name=alias)
+    cname = client.cname.get_by_host_and_name(host, alias)
 
     if cname:
         OutputManager().add_ok(f"Added CNAME {cname.name} for {host.name}.")
@@ -89,23 +91,24 @@ def cname_remove(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name, alias)
     """
+    client = get_client()
     name: str = args.name
     alias: str = args.alias
 
-    host = Host.get_by_any_means_or_raise(name)
+    host = resolve_host(client, name)
     alias = HostName.parse_or_raise(alias)
 
-    alias_as_host = Host.get_by_field("name", alias)
+    alias_as_host = client.host.get_by_name(alias)
     if alias_as_host:
         raise InputFailure(f"The alias {alias} is a host, did you mix up the arguments?")
 
-    cname = CNAME.get_by_field("name", alias)
+    cname = client.cname.get_by_name(alias)
     if not cname:
         raise EntityNotFound(f"No CNAME record found for {alias}.")
 
     # Handle situation where the CNAME is not associated with the host we are removing it from.
     if cname.host != host.id:
-        cname_host = Host.get_by_id(cname.host)
+        cname_host = client.host.get_by_id(cname.host)
         if not cname_host:
             raise EntityNotFound(f"Could not find the host for the CNAME {alias}.")
         actual = cname_host.name
@@ -114,10 +117,8 @@ def cname_remove(args: argparse.Namespace) -> None:
             f"The CNAME {cname.name} is associated with {actual}, NOT {desired}."
         )
 
-    if cname.delete():
-        OutputManager().add_line(f"Removed CNAME {cname.name} for {host.name}.")
-    else:
-        raise DeleteError(f"Failed to remove CNAME {cname.name} for {host.name}.")
+    client.cname.delete(cname)
+    OutputManager().add_line(f"Removed CNAME {cname.name} for {host.name}.")
 
 
 @command_registry.register_command(
@@ -134,21 +135,22 @@ def cname_replace(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (cname, host)
     """
+    client = get_client()
     cname: str = args.cname
     host_arg: str = args.host
 
     cname = HostName.parse_or_raise(cname)
-    host = Host.get_by_any_means_or_raise(host_arg)
+    host = resolve_host(client, host_arg)
 
-    cname_obj = CNAME.get_by_name(cname)
+    cname_obj = client.cname.get_by_name(cname)
     if not cname_obj:
         raise EntityNotFound(f"No CNAME record found for {cname}.")
 
-    old_host = Host.get_by_id(cname_obj.host)
+    old_host = client.host.get_by_id(cname_obj.host)
     if not old_host:
         raise EntityNotFound(f"Could not find the host for the CNAME {cname}.")
 
-    updated_cname = cname_obj.patch({"host": host.id})
+    updated_cname = client.cname.update(cname_obj, host=host)
     if updated_cname:
         OutputManager().add_ok(f"Moved CNAME alias {cname}: {old_host.name} -> {host.name}.")
     else:
@@ -172,5 +174,6 @@ def cname_show(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name)
     """
-    host = Host.get_by_any_means_or_raise(args.name)
+    client = get_client()
+    host = resolve_host(client, args.name)
     output_cnames(host.cnames, host=host)

--- a/mreg_cli/commands/host_submodules/cname.py
+++ b/mreg_cli/commands/host_submodules/cname.py
@@ -4,13 +4,10 @@ from __future__ import annotations
 
 import argparse
 
-from mreg_api.models.fields import HostName
-
 from mreg_cli.client import get_client
 from mreg_cli.commands.host import registry as command_registry
 from mreg_cli.exceptions import (
     CreateError,
-    DeleteError,
     EntityAlreadyExists,
     EntityNotFound,
     EntityOwnershipMismatch,

--- a/mreg_cli/commands/host_submodules/cname.py
+++ b/mreg_cli/commands/host_submodules/cname.py
@@ -47,7 +47,7 @@ def cname_add(args: argparse.Namespace) -> None:
 
     # Get host info or raise exception
     host = resolve_host(client, name)
-    alias = HostName.parse_or_raise(alias)
+    alias = client.fqdn(alias)
 
     alias_in_use = resolve_host(client, alias, required=False)
     if alias_in_use:
@@ -96,7 +96,7 @@ def cname_remove(args: argparse.Namespace) -> None:
     alias: str = args.alias
 
     host = resolve_host(client, name)
-    alias = HostName.parse_or_raise(alias)
+    alias = client.fqdn(alias)
 
     alias_as_host = client.host.get_by_name(alias)
     if alias_as_host:
@@ -139,7 +139,7 @@ def cname_replace(args: argparse.Namespace) -> None:
     cname: str = args.cname
     host_arg: str = args.host
 
-    cname = HostName.parse_or_raise(cname)
+    cname = client.fqdn(cname)
     host = resolve_host(client, host_arg)
 
     cname_obj = client.cname.get_by_name(cname)

--- a/mreg_cli/commands/host_submodules/cname.py
+++ b/mreg_cli/commands/host_submodules/cname.py
@@ -98,17 +98,17 @@ def cname_remove(args: argparse.Namespace) -> None:
     host = resolve_host(client, name)
     alias = client.fqdn(alias)
 
-    alias_as_host = client.host.get_by_name(alias)
+    alias_as_host = client.host.get_by_name(alias, required=False)
     if alias_as_host:
         raise InputFailure(f"The alias {alias} is a host, did you mix up the arguments?")
 
-    cname = client.cname.get_by_name(alias)
+    cname = client.cname.get_by_name(alias, required=False)
     if not cname:
         raise EntityNotFound(f"No CNAME record found for {alias}.")
 
     # Handle situation where the CNAME is not associated with the host we are removing it from.
     if cname.host != host.id:
-        cname_host = client.host.get_by_id(cname.host)
+        cname_host = client.host.get_by_id(cname.host, required=False)
         if not cname_host:
             raise EntityNotFound(f"Could not find the host for the CNAME {alias}.")
         actual = cname_host.name
@@ -142,11 +142,11 @@ def cname_replace(args: argparse.Namespace) -> None:
     cname = client.fqdn(cname)
     host = resolve_host(client, host_arg)
 
-    cname_obj = client.cname.get_by_name(cname)
+    cname_obj = client.cname.get_by_name(cname, required=False)
     if not cname_obj:
         raise EntityNotFound(f"No CNAME record found for {cname}.")
 
-    old_host = client.host.get_by_id(cname_obj.host)
+    old_host = client.host.get_by_id(cname_obj.host, required=False)
     if not old_host:
         raise EntityNotFound(f"Could not find the host for the CNAME {cname}.")
 

--- a/mreg_cli/commands/host_submodules/core.py
+++ b/mreg_cli/commands/host_submodules/core.py
@@ -201,9 +201,9 @@ def add(args: argparse.Namespace) -> None:
     host = client.host.create(
         name=str(data["name"]),
         comment=str(data["comment"]) if data.get("comment") else "",
-        contacts=data.get("contacts") if data.get("contacts") else None,  # type: ignore[arg-type]
-        ipaddress=data.get("ipaddress"),  # type: ignore[arg-type]
-        network=data.get("network"),  # type: ignore[arg-type]
+        contacts=data.get("contacts") if data.get("contacts") else None,  # pyright: ignore[reportArgumentType]
+        ipaddress=data.get("ipaddress"),  # pyright: ignore[reportArgumentType]
+        network=data.get("network"),  # pyright: ignore[reportArgumentType]
     )
     if not host:
         raise CreateError("Failed to add host.")
@@ -567,8 +567,8 @@ def find(args: argparse.Namespace) -> None:
         if value:
             _add_param(param, value)
 
-    hosts = client.host.list(**params)
-    output_hostlist(HostList(results=hosts))
+    hosts = client.host.list(limit=500, **params)
+    output_hostlist(hosts)
 
 
 @command_registry.register_command(
@@ -797,5 +797,6 @@ def history(args: argparse.Namespace) -> None:
     """
     name: str = args.name
 
+    client = get_client()
     hostname = client.fqdn(name)
     output_host_history(hostname)

--- a/mreg_cli/commands/host_submodules/core.py
+++ b/mreg_cli/commands/host_submodules/core.py
@@ -23,7 +23,6 @@ from mreg_api.models import (
     MX,
     NAPTR,
     Host,
-    HostList,
     NetworkOrIP,
     PTR_override,
     Srv,

--- a/mreg_cli/commands/host_submodules/core.py
+++ b/mreg_cli/commands/host_submodules/core.py
@@ -28,7 +28,7 @@ from mreg_api.models import (
     Srv,
 )
 from mreg_api.models.fields import HostName, MacAddress
-from typing_extensions import override
+from typing_extensions import NotRequired, TypedDict, override
 
 from mreg_cli.client import get_client
 from mreg_cli.commands.host import registry as command_registry
@@ -107,6 +107,7 @@ def add(args: argparse.Namespace) -> None:
     macaddress: str | None = args.macaddress
     force: bool = args.force
     contact: list[str] = args.contact or []
+    comment: str | None = args.comment
 
     if macaddress is not None:
         macaddress = MacAddress.parse_or_raise(macaddress)
@@ -140,7 +141,7 @@ def add(args: argparse.Namespace) -> None:
     if "*" in hname and not force:
         raise ForceMissing("Wildcards must be forced.")
 
-    data = _host_create_payload(hname, contact, args.comment)
+    data = _host_create_payload(hname, contact, comment)
 
     if network_or_ip:
         autodetect = False
@@ -198,11 +199,11 @@ def add(args: argparse.Namespace) -> None:
         net_or_ip = None
 
     host = client.host.create(
-        name=str(data["name"]),
-        comment=str(data["comment"]) if data.get("comment") else "",
-        contacts=data.get("contacts") if data.get("contacts") else None,  # pyright: ignore[reportArgumentType]
-        ipaddress=data.get("ipaddress"),  # pyright: ignore[reportArgumentType]
-        network=data.get("network"),  # pyright: ignore[reportArgumentType]
+        name=data["name"],
+        comment=data["comment"],
+        contacts=data.get("contacts"),
+        ipaddress=data.get("ipaddress"),
+        network=data.get("network"),
     )
     if not host:
         raise CreateError("Failed to add host.")
@@ -233,15 +234,27 @@ def add(args: argparse.Namespace) -> None:
     output_host(host)
 
 
-def _host_create_payload(hname: HostName, contact: list[str], comment: str | None) -> JsonMapping:
+class HostCreatePayload(TypedDict):
+    """Payload for creating a host."""
+
+    name: HostName
+    comment: str  # TODO: mark NotRequired after API parity!
+    contacts: NotRequired[list[str]]
+    ipaddress: NotRequired[str]
+    network: NotRequired[str]
+
+
+def _host_create_payload(
+    hname: HostName, contact: list[str], comment: str | None
+) -> HostCreatePayload:
     """Build the API payload for creating a host."""
     # Note: The JSON test results relies on the order of these keys to produce consistent diffs.
-    data: dict[str, Json] = {
+    data: HostCreatePayload = {
         "name": hname,
+        "comment": comment or "",
     }
     if contact:
         data["contacts"] = contact
-    data["comment"] = comment or None
 
     return data
 

--- a/mreg_cli/commands/host_submodules/core.py
+++ b/mreg_cli/commands/host_submodules/core.py
@@ -103,7 +103,7 @@ def add(args: argparse.Namespace) -> None:
     """
     client = get_client()
 
-    hname = HostName.parse_or_raise(args.name)
+    hname = client.fqdn(args.name)
     network_or_ip: str = args.ip
     macaddress: str | None = args.macaddress
     force: bool = args.force
@@ -607,7 +607,7 @@ def rename(args: argparse.Namespace) -> None:
     new_name: str = args.new_name
 
     old_host = resolve_host(client, old_name)
-    new_name = HostName.parse_or_raise(new_name)
+    new_name = client.fqdn(new_name)
 
     new_host = resolve_host(client, new_name, required=False, inform_if_cname=True)
     if new_host:
@@ -797,5 +797,5 @@ def history(args: argparse.Namespace) -> None:
     """
     name: str = args.name
 
-    hostname = HostName.parse_or_raise(name)
+    hostname = client.fqdn(name)
     output_host_history(hostname)

--- a/mreg_cli/commands/host_submodules/core.py
+++ b/mreg_cli/commands/host_submodules/core.py
@@ -22,11 +22,8 @@ from mreg_api.models import (
     CNAME,
     MX,
     NAPTR,
-    ForwardZone,
     Host,
     HostList,
-    IPAddress,
-    Network,
     NetworkOrIP,
     PTR_override,
     Srv,
@@ -34,6 +31,7 @@ from mreg_api.models import (
 from mreg_api.models.fields import HostName, MacAddress
 from typing_extensions import override
 
+from mreg_cli.client import get_client
 from mreg_cli.commands.host import registry as command_registry
 from mreg_cli.exceptions import (
     APIError,
@@ -51,6 +49,7 @@ from mreg_cli.output import output_host, output_hostlist, output_hosts
 from mreg_cli.output.history import output_host_history
 from mreg_cli.outputmanager import OutputManager
 from mreg_cli.types import Flag, Json, JsonMapping, QueryParams
+from mreg_cli.utilities.resolution import resolve_host
 from mreg_cli.utilities.shared import convert_wildcard_to_regex
 
 
@@ -102,6 +101,8 @@ def add(args: argparse.Namespace) -> None:
     :param args: argparse.Namespace (name, ip, contact, comment, force, macaddress)
 
     """
+    client = get_client()
+
     hname = HostName.parse_or_raise(args.name)
     network_or_ip: str = args.ip
     macaddress: str | None = args.macaddress
@@ -110,16 +111,28 @@ def add(args: argparse.Namespace) -> None:
 
     if macaddress is not None:
         macaddress = MacAddress.parse_or_raise(macaddress)
-        IPAddress.ensure_associable(macaddress, force=force)
+        if not force:
+            existing_ips = client.ipaddress.list_by_mac(macaddress)
+            if len(existing_ips) == 1:
+                raise EntityAlreadyExists(
+                    f"MAC address {macaddress} is already associated with IP address "
+                    f"{existing_ips[0].ipaddress}, must force."
+                )
+            elif len(existing_ips) > 1:
+                ips_str = ", ".join(str(ip.ipaddress) for ip in existing_ips)
+                raise EntityAlreadyExists(
+                    f"MAC address {macaddress} is already associated with multiple IP addresses: "
+                    f"{ips_str}, must force."
+                )
 
-    host = Host.get_by_any_means(hname)
+    host = resolve_host(client, hname, required=False)
     if host:
         if host.name != hname:
             raise EntityOwnershipMismatch(f"{hname} is a CNAME pointing to {host.name}")
         else:
             raise EntityAlreadyExists(f"Host {hname} already exists.")
 
-    zone = ForwardZone.get_from_hostname(hname)
+    zone = client.zone.get_from_host(hname)
     if not zone and not force:
         raise ForceMissing(f"{hname} isn't in a zone controlled by MREG, must force")
     if zone and zone.is_delegated() and not force:
@@ -148,7 +161,7 @@ def add(args: argparse.Namespace) -> None:
         if net_or_ip.is_ip() and not autodetect:
             ipaddr = net_or_ip.as_ip()
             try:
-                network = Network.get_by_ip(ipaddr)
+                network = client.network.get_by_ip(str(ipaddr))
                 if network:
                     if ipaddr == network.network_address and not force:
                         raise InvalidIPAddress(
@@ -165,9 +178,9 @@ def add(args: argparse.Namespace) -> None:
 
         elif net_or_ip.is_network() or autodetect:
             network = (
-                Network.get_by_ip(net_or_ip.as_ip())
+                client.network.get_by_ip(str(net_or_ip.as_ip()))
                 if autodetect
-                else Network.get_by_network(str(network_or_ip))
+                else client.network.get(str(network_or_ip))
             )
             if network:
                 data["network"] = str(network.network)
@@ -185,14 +198,24 @@ def add(args: argparse.Namespace) -> None:
     else:
         net_or_ip = None
 
-    host = Host.create(data)
+    host = client.host.create(
+        name=str(data["name"]),
+        comment=str(data["comment"]) if data.get("comment") else "",
+        contacts=data.get("contacts") if data.get("contacts") else None,  # type: ignore[arg-type]
+        ipaddress=data.get("ipaddress"),  # type: ignore[arg-type]
+        network=data.get("network"),  # type: ignore[arg-type]
+    )
     if not host:
         raise CreateError("Failed to add host.")
     OutputManager().add_ok(f"Created host {host.name}")
 
     if macaddress is not None and net_or_ip is not None:
         if net_or_ip.is_ip():
-            host = host.associate_mac_to_ip(macaddress, network_or_ip, force=force)
+            ip_objs = client.ipaddress.list_by_ip(str(network_or_ip))
+            if ip_objs:
+                host_ip = ip_objs[0]
+                client.ipaddress.associate_mac(host_ip, macaddress, force=force)
+                host = resolve_host(client, str(host.name))
         else:
             # We passed a network to create the host, so we need to find the IP
             # that was assigned to the host. We don't get that in the response
@@ -200,9 +223,9 @@ def add(args: argparse.Namespace) -> None:
             # use that. If there are more than one, we can't know which one was
             # assigned to the host during create, so we abort.
             if len(host.ipaddresses) == 1:
-                host = host.associate_mac_to_ip(
-                    macaddress, host.ipaddresses[0].ipaddress, force=force
-                )
+                host_ip = host.ipaddresses[0]
+                client.ipaddress.associate_mac(host_ip, macaddress, force=force)
+                host = resolve_host(client, str(host.name))
             else:
                 OutputManager().add_ok(
                     "Failed to associate MAC address to IP, multiple IP addresses after creation."
@@ -346,8 +369,10 @@ def remove(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name, force, override)
     """
+    client = get_client()
+
     hostname = args.name
-    host = Host.get_by_any_means_or_raise(hostname, inform_as_cname=True)
+    host = resolve_host(client, hostname, inform_if_cname=True)
 
     override_arg = args.override or ""
     overrides: list[Override] = Override.parse_overrides(override_arg)
@@ -386,7 +411,7 @@ def remove(args: argparse.Namespace) -> None:
 
     # Require force if host has multiple A/AAAA records and they are not in the same VLAN.
     if len(host.ipaddresses) > 1:
-        host_vlans = host.vlans()
+        host_vlans = client.host.vlans(host)
         same_vlan = len(host_vlans) == 1
 
         if same_vlan and not forced():
@@ -426,8 +451,7 @@ def remove(args: argparse.Namespace) -> None:
         raise ForceMissing(complete_error_msg)
 
     # Delete the host and any associated records
-    if not host.delete():
-        raise DeleteError(f"failed to remove {host.name}")
+    client.host.delete(host)
 
     # Print messages for associated records that were deleted
     for check in override_checks:
@@ -469,8 +493,28 @@ def host_info(args: argparse.Namespace) -> None:
     Setting traverse hostgroups will show memberships of all parent groups as well as
     direct groups.
     """
-    for host in args.hosts:
-        hosts = Host.get_list_by_any_means_or_raise(host, inform_as_cname=True)
+    client = get_client()
+
+    for host_arg in args.hosts:
+        # Try IP lookup first (may return multiple hosts)
+        hosts: list[Host] = []
+        try:
+            hosts = client.host.list_by_ip(host_arg)
+        except Exception:
+            pass
+
+        # Try MAC lookup if IP lookup returned nothing
+        if not hosts:
+            try:
+                hosts = client.host.list_by_mac(host_arg)
+            except Exception:
+                pass
+
+        # Fall back to single host resolution by name/CNAME
+        if not hosts:
+            host = resolve_host(client, host_arg, inform_if_cname=True)
+            hosts = [host]
+
         if hosts:
             output_hosts(hosts, traverse_hostgroups=args.traverse_hostgroups)
 
@@ -505,6 +549,7 @@ def find(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name, comment, contact)
     """
+    client = get_client()
 
     def _add_param(param: str, value: str) -> None:
         param, value = convert_wildcard_to_regex(param, value, True)
@@ -522,8 +567,8 @@ def find(args: argparse.Namespace) -> None:
         if value:
             _add_param(param, value)
 
-    hosts = HostList.get(params=params)
-    output_hostlist(hosts)
+    hosts = client.host.list(**params)
+    output_hostlist(HostList(results=hosts))
 
 
 @command_registry.register_command(
@@ -556,25 +601,27 @@ def rename(args: argparse.Namespace) -> None:
 
     :return: The updated Host or None
     """
+    client = get_client()
+
     old_name: str = args.old_name
     new_name: str = args.new_name
 
-    old_host = Host.get_by_any_means_or_raise(old_name)
+    old_host = resolve_host(client, old_name)
     new_name = HostName.parse_or_raise(new_name)
 
-    new_host = Host.get_by_any_means(new_name, inform_as_cname=True)
+    new_host = resolve_host(client, new_name, required=False, inform_if_cname=True)
     if new_host:
         raise EntityAlreadyExists(f"host {new_host} already exists")
 
     # Require force if FQDN not in MREG zone
-    zone = ForwardZone.get_from_hostname(new_name)
+    zone = client.zone.get_from_host(new_name)
     if not zone and not args.force:
         raise ForceMissing(f"{new_name} isn't in a zone controlled by MREG, must force")
 
     if "*" in new_name and not args.force:
         raise ForceMissing("Wildcards must be forced.")
 
-    new_host = old_host.rename(new_name)
+    client.host.update(old_host, name=new_name)
     OutputManager().add_ok(f"renamed {old_host} to {new_name}")
 
 
@@ -599,11 +646,10 @@ def set_comment(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name, comment)
     """
-    host = Host.get_by_any_means_or_raise(args.name, inform_as_cname=True)
-    updated_host = host.set_comment(args.comment)
+    client = get_client()
 
-    if not updated_host:
-        raise PatchError(f"Failed to update comment of {host.name}")
+    host = resolve_host(client, args.name, inform_if_cname=True)
+    client.host.update(host, comment=args.comment)
 
     OutputManager().add_ok(f"Updated comment of {host} to {args.comment}")
 
@@ -625,14 +671,13 @@ def set_contact(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name, contact)
     """
+    client = get_client()
+
     name: str = args.name
     contact: list[str] = args.contact
 
-    host = Host.get_by_any_means_or_raise(name, inform_as_cname=True)
-    updated_host = host.set_contacts(contact)
-
-    if not updated_host:
-        raise PatchError(f"Failed to update contact of {host.name}")
+    host = resolve_host(client, name, inform_if_cname=True)
+    client.host.update(host, contacts=contact)
 
     OutputManager().add_ok(f"Set contact of {host} to {', '.join(contact)}")
 
@@ -653,10 +698,12 @@ def unset_contact(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name, contact)
     """
+    client = get_client()
+
     name: str = args.name
     force: bool = args.force
 
-    host = Host.get_by_any_means_or_raise(name, inform_as_cname=True)
+    host = resolve_host(client, name, inform_if_cname=True)
     if not host.contacts:
         raise DeleteError(f"Host {host.name} has no contacts to remove.")
 
@@ -665,7 +712,7 @@ def unset_contact(args: argparse.Namespace) -> None:
             f"Host {host.name} has multiple contacts, must use -force to remove all contacts."
         )
 
-    updated = host.clear_contacts()
+    updated = client.host.clear_contacts(host)
     if not updated.removed:
         raise PatchError(f"Failed to update contact of {host.name}")
 
@@ -686,11 +733,13 @@ def add_contact(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name, contact)
     """
+    client = get_client()
+
     name: str = args.name
     contact: list[str] = args.contact
 
-    host = Host.get_by_any_means_or_raise(name, inform_as_cname=True)
-    updated = host.add_contacts(contact)
+    host = resolve_host(client, name, inform_if_cname=True)
+    updated = client.host.add_contacts(host, contact)
 
     if not updated.added:
         # TODO: add not_found warning?
@@ -713,15 +762,17 @@ def remove_contact(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name, contact)
     """
+    client = get_client()
+
     name: str = args.name
     contact: list[str] = args.contact
 
     if not contact:
         raise InputFailure("At least one contact must be specified.")
 
-    host = Host.get_by_any_means_or_raise(name, inform_as_cname=True)
+    host = resolve_host(client, name, inform_if_cname=True)
 
-    updated = host.remove_contacts(contact)
+    updated = client.host.remove_contacts(host, contact)
     if not updated.removed:
         if updated.not_found:
             not_found = ", ".join(updated.not_found)

--- a/mreg_cli/commands/host_submodules/rr.py
+++ b/mreg_cli/commands/host_submodules/rr.py
@@ -533,9 +533,7 @@ def ptr_change(args: argparse.Namespace) -> None:
         raise EntityNotFound(f"No PTR records for {old_host}")
 
     ip = NetworkOrIP.parse_or_raise(args.ip, mode="ip")
-    ptr_override = next(
-        (ptr for ptr in old_host.ptr_overrides if ptr.ipaddress == ip), None
-    )
+    ptr_override = next((ptr for ptr in old_host.ptr_overrides if ptr.ipaddress == ip), None)
     if not ptr_override:
         raise EntityNotFound(f"No PTR record for {old_host} with IP {ip}")
 
@@ -562,9 +560,7 @@ def ptr_remove(args: argparse.Namespace) -> None:
     client = get_client()
     host = resolve_host(client, args.name)
     ip = NetworkOrIP.parse_or_raise(args.ip, mode="ip")
-    ptr_override = next(
-        (ptr for ptr in host.ptr_overrides if ptr.ipaddress == ip), None
-    )
+    ptr_override = next((ptr for ptr in host.ptr_overrides if ptr.ipaddress == ip), None)
     if not ptr_override:
         raise EntityNotFound(f"No PTR record for {host} with IP {ip}")
 
@@ -661,7 +657,7 @@ def srv_add(args: argparse.Namespace) -> None:
     client = get_client()
     name: str = args.name
 
-    sname = HostName.parse_or_raise(name)
+    sname = client.fqdn(name)
     host = resolve_host(client, args.host)
 
     szone = client.zone.get_from_host(sname)
@@ -733,7 +729,7 @@ def srv_remove(args: argparse.Namespace) -> None:
     host_arg: str = args.host
 
     host = resolve_host(client, host_arg)
-    sname = HostName.parse_or_raise(name)
+    sname = client.fqdn(name)
 
     srv = client.srv.first(
         name=str(sname),
@@ -767,7 +763,7 @@ def srv_show(args: argparse.Namespace) -> None:
     client = get_client()
     service: str = args.service
 
-    sname = HostName.parse_or_raise(service)
+    sname = client.fqdn(service)
     srvs = client.srv.list(name=str(sname))
 
     if len(srvs) == 0:

--- a/mreg_cli/commands/host_submodules/rr.py
+++ b/mreg_cli/commands/host_submodules/rr.py
@@ -293,6 +293,9 @@ def mx_remove(args: argparse.Namespace) -> None:
     host = resolve_host(client, name)
     mx_obj = client.mx.get_by_all(host, mx_arg, priority)
     client.mx.delete(mx_obj)
+    OutputManager().add_ok(
+        f"Deleted MX {mx_obj.mx} with priority {priority} from {host.name}.",
+    )
 
 
 @command_registry.register_command(
@@ -625,14 +628,16 @@ def ptr_show(args: argparse.Namespace) -> None:
 
     client = get_client()
     ip = NetworkOrIP.parse_or_raise(args.ip, mode="ip")
-    # TODO: use event suppression ctx manager to avoid printing PTR resolution here
-    host = resolve_host(client, str(ip))
-    if not host.ptr_overrides:
-        OutputManager().add_line(f"No PTR records for {host.name}")
 
-    for ptr in host.ptr_overrides:
-        if ip == ptr.ipaddress:
-            output_ptr_override(ptr)
+    # Suppress PTR override events from being printed when we resolve PTR overrides
+    with OutputManager().suppress_events():
+        host = resolve_host(client, str(ip))
+        if not host.ptr_overrides:
+            OutputManager().add_line(f"No PTR records for {host.name}")
+
+        for ptr in host.ptr_overrides:
+            if ip == ptr.ipaddress:
+                output_ptr_override(ptr)
 
 
 @command_registry.register_command(

--- a/mreg_cli/commands/host_submodules/rr.py
+++ b/mreg_cli/commands/host_submodules/rr.py
@@ -45,7 +45,6 @@ from mreg_api.models import (
     NAPTR,
     Srv,
 )
-from mreg_api.models.fields import HostName
 
 from mreg_cli.client import get_client
 from mreg_cli.commands.host import registry as command_registry

--- a/mreg_cli/commands/host_submodules/rr.py
+++ b/mreg_cli/commands/host_submodules/rr.py
@@ -368,6 +368,7 @@ def naptr_add(args: argparse.Namespace) -> None:
         service=args.service,
         regex=args.regex,
         replacement=args.replacement,
+        required=False,
     )
     if existing_naptr:
         raise EntityAlreadyExists(f"{host} already has that NAPTR defined.")
@@ -679,6 +680,7 @@ def srv_add(args: argparse.Namespace) -> None:
         priority=args.priority,
         weight=args.weight,
         port=args.port,
+        required=False,
     )
     if existing_srv:
         raise EntityAlreadyExists(f"{sname} already has that SRV defined.")
@@ -742,6 +744,7 @@ def srv_remove(args: argparse.Namespace) -> None:
         priority=args.priority,
         port=args.port,
         weight=args.weight,
+        required=False,
     )
     if not srv:
         raise EntityNotFound(
@@ -801,6 +804,7 @@ def sshfp_add(args: argparse.Namespace) -> None:
         algorithm=args.algorithm,
         hash_type=args.hash_type,
         fingerprint=args.fingerprint,
+        required=False,
     )
     if existing_sshfp:
         raise EntityAlreadyExists(f"{host} already has that SSHFP defined.")
@@ -929,7 +933,7 @@ def ttl_set(args: argparse.Namespace) -> None:
     target_srv: Srv | None = None
 
     if target_host is None:
-        target_srv = client.srv.first(name=name)
+        target_srv = client.srv.first(name=name, required=False)
 
     if target_host is None and target_srv is None:
         raise EntityNotFound(f"No host or SRV record found for {name}")
@@ -1020,7 +1024,7 @@ def txt_remove(args: argparse.Namespace) -> None:
     """
     client = get_client()
     host = resolve_host(client, args.name)
-    txt = client.txt.first(host=host.id, txt=args.text)
+    txt = client.txt.first(host=host.id, txt=args.text, required=False)
 
     if not txt:
         raise EntityNotFound(f"{host} has no TXT record matching '{args.text}'")

--- a/mreg_cli/commands/host_submodules/rr.py
+++ b/mreg_cli/commands/host_submodules/rr.py
@@ -43,19 +43,11 @@ import argparse
 
 from mreg_api.models import (
     NAPTR,
-    SSHFP,
-    TXT,
-    ForwardZone,
-    HInfo,
-    Host,
-    Location,
-    Network,
-    NetworkOrIP,
-    PTR_override,
     Srv,
 )
 from mreg_api.models.fields import HostName
 
+from mreg_cli.client import get_client
 from mreg_cli.commands.host import registry as command_registry
 from mreg_cli.exceptions import (
     CreateError,
@@ -64,7 +56,6 @@ from mreg_cli.exceptions import (
     EntityNotFound,
     ForceMissing,
     InputFailure,
-    PatchError,
     handle_exception,
 )
 from mreg_cli.output.host import (
@@ -79,7 +70,8 @@ from mreg_cli.output.host import (
     output_txts,
 )
 from mreg_cli.outputmanager import OutputManager
-from mreg_cli.types import Flag, QueryParams
+from mreg_cli.types import Flag
+from mreg_cli.utilities.resolution import resolve_host
 
 
 @command_registry.register_command(
@@ -99,14 +91,15 @@ def hinfo_add(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name, cpu, os)
     """
-    host = Host.get_by_any_means_or_raise(args.name)
+    client = get_client()
+    host = resolve_host(client, args.name)
     if host.hinfo:
         raise EntityAlreadyExists(f"{host} already has hinfo set.")
 
-    HInfo.create({"host": host.id, "cpu": args.cpu, "os": args.os})
-    host = host.refetch()
+    client.hinfo.create(host=host, cpu=args.cpu, os=args.os)
+    hinfo = client.hinfo.get_by_host(host)
 
-    if host.hinfo and host.hinfo.cpu == args.cpu and host.hinfo.os == args.os:
+    if hinfo and hinfo.cpu == args.cpu and hinfo.os == args.os:
         OutputManager().add_ok(f"Added HINFO record for {host.name}.")
     else:
         raise CreateError(f"Failed to add correct HINFO for {host}")
@@ -127,12 +120,14 @@ def hinfo_remove(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name)
     """
-    host = Host.get_by_any_means_or_raise(args.name)
+    client = get_client()
+    host = resolve_host(client, args.name)
     if not host.hinfo:
         raise EntityNotFound(f"{host} already has no hinfo set.")
 
-    hinfo = HInfo.get_by_field("host", host.id)
-    if hinfo and hinfo.delete():
+    hinfo = client.hinfo.get_by_host(host)
+    if hinfo:
+        client.hinfo.delete(hinfo)
         OutputManager().add_ok(f"Removed HINFO record for {host.name}.")
     else:
         raise DeleteError(f"Failed to remove HINFO for {host}")
@@ -153,11 +148,12 @@ def hinfo_show(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name)
     """
-    host = Host.get_by_any_means_or_raise(args.name)
+    client = get_client()
+    host = resolve_host(client, args.name)
     if not host.hinfo:
         OutputManager().add_line(f"No hinfo for {host.name}")
 
-    hinfo = HInfo.get_by_field("host", host.id)
+    hinfo = client.hinfo.get_by_host(host)
     if hinfo:
         output_hinfo(hinfo)
     else:
@@ -179,11 +175,14 @@ def loc_remove(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name)
     """
-    host = Host.get_by_any_means_or_raise(args.name)
+    client = get_client()
+    host = resolve_host(client, args.name)
     if not host.loc:
         raise EntityNotFound(f"{host} already has no loc set.")
 
-    if host.loc.delete():
+    loc = client.location.get_by_host(host)
+    if loc:
+        client.location.delete(loc)
         OutputManager().add_ok(f"Removed LOC for {host.name}.")
     else:
         raise DeleteError(f"Failed to remove LOC for {host}")
@@ -205,15 +204,16 @@ def loc_add(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name, loc)
     """
-    host = Host.get_by_any_means_or_raise(args.name)
+    client = get_client()
+    host = resolve_host(client, args.name)
 
     if host.loc:
         raise EntityAlreadyExists(f"{host} already has loc set.")
 
-    Location.create({"host": host.id, "loc": args.loc})
-    host = host.refetch()
+    client.location.create(host=host, loc=args.loc)
+    loc = client.location.get_by_host(host)
 
-    if host.loc and host.loc.loc == args.loc:
+    if loc and loc.loc == args.loc:
         OutputManager().add_ok(f"Added LOC record for {host.name}.")
     else:
         CreateError(f"Failed to set LOC for {host}")
@@ -234,7 +234,8 @@ def loc_show(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name)
     """
-    host = Host.get_by_any_means_or_raise(args.name)
+    client = get_client()
+    host = resolve_host(client, args.name)
     if not host.loc:
         raise EntityNotFound(f"No loc for {host.name}")
 
@@ -258,12 +259,13 @@ def mx_add(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name, priority, mx)
     """
+    client = get_client()
     mx: str = args.mx
     priority: int = args.priority
     name: str = args.name
 
-    host = Host.get_by_any_means_or_raise(name)
-    host.add_mx(mx, priority)
+    host = resolve_host(client, name)
+    client.mx.create(host=host, mx=mx, priority=priority)
 
     OutputManager().add_ok(f"Added MX record to {host.name}.")
 
@@ -283,12 +285,14 @@ def mx_remove(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name, priority, mx)
     """
+    client = get_client()
     name: str = args.name
     mx_arg: str = args.mx
     priority: int = args.priority
 
-    host = Host.get_by_any_means_or_raise(name)
-    host.remove_mx(mx_arg, priority)
+    host = resolve_host(client, name)
+    mx_obj = client.mx.get_by_all(host, mx_arg, priority)
+    client.mx.delete(mx_obj)
 
 
 @command_registry.register_command(
@@ -304,7 +308,8 @@ def mx_show(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name)
     """
-    host = Host.get_by_any_means_or_raise(args.name)
+    client = get_client()
+    host = resolve_host(client, args.name)
     output_mxs(host.mxs)
 
 
@@ -349,20 +354,30 @@ def naptr_add(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name, preference, order, flag, service, regex, replacement)
     """
-    host = Host.get_by_any_means_or_raise(args.name)
-    params: QueryParams = {
-        "preference": args.preference,
-        "order": args.order,
-        "flag": args.flag,
-        "service": args.service,
-        "regex": args.regex,
-        "replacement": args.replacement,
-        "host": host.id,
-    }
-    existing_naptr = NAPTR.get_by_query_unique(params)
+    client = get_client()
+    host = resolve_host(client, args.name)
+
+    existing_naptr = client.naptr.first(
+        host=host.id,
+        preference=args.preference,
+        order=args.order,
+        flag=args.flag,
+        service=args.service,
+        regex=args.regex,
+        replacement=args.replacement,
+    )
     if existing_naptr:
         raise EntityAlreadyExists(f"{host} already has that NAPTR defined.")
-    NAPTR.create(data=params)
+
+    client.naptr.create(
+        host=host,
+        preference=args.preference,
+        order=args.order,
+        flag=args.flag,
+        service=args.service,
+        regex=args.regex,
+        replacement=args.replacement,
+    )
     OutputManager().add_ok(f"Added NAPTR record to {host.name}.")
 
 
@@ -434,7 +449,8 @@ def naptr_remove(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name, preference, order, flag, service, regex, replacement)
     """
-    host = Host.get_by_any_means_or_raise(args.name)
+    client = get_client()
+    host = resolve_host(client, args.name)
     to_delete = filter_naptrs(
         host.naptrs,
         preference=args.preference,
@@ -458,7 +474,7 @@ def naptr_remove(args: argparse.Namespace) -> None:
     # Best-effort lets us delete as many as possible at the very least.
     for naptr in to_delete:
         try:
-            naptr.delete()
+            client.naptr.delete(naptr)
             OutputManager().add_ok(f"Deleted NAPTR record from {host.name}.")
         except Exception as e:
             handle_exception(e)
@@ -477,7 +493,8 @@ def naptr_show(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name)
     """
-    host = Host.get_by_any_means_or_raise(args.name)
+    client = get_client()
+    host = resolve_host(client, args.name)
     output_naptrs(host.naptrs)
 
 
@@ -503,8 +520,11 @@ def ptr_change(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (ip, old, new, force)
     """
-    old_host = Host.get_by_any_means_or_raise(args.old)
-    new_host = Host.get_by_any_means_or_raise(args.new)
+    from mreg_api.models import NetworkOrIP
+
+    client = get_client()
+    old_host = resolve_host(client, args.old)
+    new_host = resolve_host(client, args.new)
 
     if new_host.ptr_overrides:
         raise InputFailure(f"{new_host} already has a PTR record.")
@@ -513,15 +533,14 @@ def ptr_change(args: argparse.Namespace) -> None:
         raise EntityNotFound(f"No PTR records for {old_host}")
 
     ip = NetworkOrIP.parse_or_raise(args.ip, mode="ip")
-    ptr_override = old_host.get_ptr_override(ip)
+    ptr_override = next(
+        (ptr for ptr in old_host.ptr_overrides if ptr.ipaddress == ip), None
+    )
     if not ptr_override:
         raise EntityNotFound(f"No PTR record for {old_host} with IP {ip}")
 
-    data = {"host": new_host.id}
-    if not ptr_override.patch(data):
-        raise PatchError(f"Failed to move PTR record from {old_host} to {new_host}")
-    else:
-        OutputManager().add_ok(f"Moved PTR record {ip} from {old_host.name} to {new_host.name}.")
+    client.ptroverride.update(ptr_override, host=new_host)
+    OutputManager().add_ok(f"Moved PTR record {ip} from {old_host.name} to {new_host.name}.")
 
 
 @command_registry.register_command(
@@ -538,16 +557,19 @@ def ptr_remove(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (ip, name)
     """
-    host = Host.get_by_any_means_or_raise(args.name)
+    from mreg_api.models import NetworkOrIP
+
+    client = get_client()
+    host = resolve_host(client, args.name)
     ip = NetworkOrIP.parse_or_raise(args.ip, mode="ip")
-    ptr_override = host.get_ptr_override(ip)
+    ptr_override = next(
+        (ptr for ptr in host.ptr_overrides if ptr.ipaddress == ip), None
+    )
     if not ptr_override:
         raise EntityNotFound(f"No PTR record for {host} with IP {ip}")
 
-    if ptr_override.delete():
-        OutputManager().add_ok(f"Removed PTR record {ip} from {host.name}.")
-    else:
-        raise DeleteError(f"Failed to remove PTR record from {host}")
+    client.ptroverride.delete(ptr_override)
+    OutputManager().add_ok(f"Removed PTR record {ip} from {host.name}.")
 
 
 @command_registry.register_command(
@@ -565,23 +587,28 @@ def ptr_add(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (ip, name, force)
     """
+    from mreg_api.models import NetworkOrIP
+
+    client = get_client()
     ip = NetworkOrIP.parse_or_raise(args.ip, mode="ip")
 
-    host = Host.get_by_any_means_or_raise(args.name)
-    existing_ptrs = PTR_override.get_list_by_field("ipaddress", str(ip))
+    host = resolve_host(client, args.name)
+    existing_ptrs = client.ptroverride.list(ipaddress=str(ip))
     if existing_ptrs:
         raise EntityAlreadyExists(f"{ip} already exists in a PTR record.")
 
-    network = Network.get_by_ip(ip)
+    network = client.network.get_by_ip(str(ip))
     if not args.force:
         if host.zone is None:
             raise ForceMissing(f"{host} isn't in a zone controlled by MREG, must force")
         elif not network:
             raise ForceMissing(f"{ip} isn't in a network controlled by MREG, must force")
-        elif network and network.is_reserved_ip(ip):
-            raise ForceMissing(f"{ip} is reserved, must force")
+        elif network:
+            reserved_ips = client.network.get_reserved_ips(network)
+            if ip in reserved_ips:
+                raise ForceMissing(f"{ip} is reserved, must force")
 
-    PTR_override.create({"host": host.id, "ipaddress": str(ip)})
+    client.ptroverride.create(host=host, ipaddress=ip)
     OutputManager().add_ok(f"Added PTR record {ip} to {host.name}.")
 
 
@@ -598,8 +625,12 @@ def ptr_show(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (ip)
     """
+    from mreg_api.models import NetworkOrIP
+
+    client = get_client()
     ip = NetworkOrIP.parse_or_raise(args.ip, mode="ip")
-    host = Host.get_by_any_means_or_raise(str(ip), inform_as_ptr=False)
+    # TODO: use event suppression ctx manager to avoid printing PTR resolution here
+    host = resolve_host(client, str(ip))
     if not host.ptr_overrides:
         OutputManager().add_line(f"No PTR records for {host.name}")
 
@@ -627,32 +658,38 @@ def srv_add(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name, priority, weight, port, host, ttl, force)
     """
+    client = get_client()
     name: str = args.name
 
     sname = HostName.parse_or_raise(name)
-    host = Host.get_by_any_means_or_raise(args.host)
+    host = resolve_host(client, args.host)
 
-    szone = ForwardZone.get_from_hostname(sname)
+    szone = client.zone.get_from_host(sname)
     if not szone:
         raise EntityNotFound(f"{sname} isn't in a zone controlled by MREG")
 
-    hzone = ForwardZone.get_from_hostname(host.name)
+    hzone = client.zone.get_from_host(host.name)
     if not hzone:
         raise EntityNotFound(f"{host} isn't in a zone controlled by MREG")
 
-    data: QueryParams = {
-        "name": sname,
-        "priority": args.priority,
-        "weight": args.weight,
-        "port": args.port,
-        "ttl": args.ttl,
-        "host": host.id,
-    }
-
-    existing_srv = Srv.get_by_query_unique(data)
+    existing_srv = client.srv.first(
+        name=str(sname),
+        host=host.id,
+        priority=args.priority,
+        weight=args.weight,
+        port=args.port,
+    )
     if existing_srv:
         raise EntityAlreadyExists(f"{sname} already has that SRV defined.")
-    Srv.create(data)
+
+    client.srv.create(
+        host=host,
+        name=str(sname),
+        priority=args.priority,
+        weight=args.weight,
+        port=args.port,
+        ttl=args.ttl if args.ttl is not None else None,
+    )
     OutputManager().add_ok(f"Added SRV record {sname} with target {host}.")
 
 
@@ -691,30 +728,27 @@ def srv_remove(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name, priority, weight, port, host)
     """
+    client = get_client()
     name: str = args.name
     host_arg: str = args.host
 
-    host = Host.get_by_any_means_or_raise(host_arg)
+    host = resolve_host(client, host_arg)
     sname = HostName.parse_or_raise(name)
 
-    data: QueryParams = {
-        "name": sname,
-        "host": host.id,
-        "priority": args.priority,
-        "port": args.port,
-        "weight": args.weight,
-    }
-
-    srv = Srv.get_by_query_unique(data)
+    srv = client.srv.first(
+        name=str(sname),
+        host=host.id,
+        priority=args.priority,
+        port=args.port,
+        weight=args.weight,
+    )
     if not srv:
         raise EntityNotFound(
             f"No SRV record for {sname} with target {host} matching the given values."
         )
 
-    if srv.delete():
-        OutputManager().add_ok(f"Removed SRV record {sname} from {host.name}.")
-    else:
-        raise DeleteError(f"Failed to remove SRV for {sname}")
+    client.srv.delete(srv)
+    OutputManager().add_ok(f"Removed SRV record {sname} from {host.name}.")
 
 
 @command_registry.register_command(
@@ -730,10 +764,11 @@ def srv_show(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (service)
     """
+    client = get_client()
     service: str = args.service
 
     sname = HostName.parse_or_raise(service)
-    srvs = Srv.get_list_by_field("name", sname)
+    srvs = client.srv.list(name=str(sname))
 
     if len(srvs) == 0:
         raise EntityNotFound(f"No SRV records for {sname}")
@@ -757,20 +792,24 @@ def sshfp_add(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name, algorithm, hash_type, fingerprint)
     """
-    host = Host.get_by_any_means_or_raise(args.name)
+    client = get_client()
+    host = resolve_host(client, args.name)
 
-    data: QueryParams = {
-        "algorithm": args.algorithm,
-        "hash_type": args.hash_type,
-        "fingerprint": args.fingerprint,
-        "host": host.id,
-    }
-
-    existing_sshfp = SSHFP.get_by_query_unique(data)
+    existing_sshfp = client.sshfp.first(
+        host=host.id,
+        algorithm=args.algorithm,
+        hash_type=args.hash_type,
+        fingerprint=args.fingerprint,
+    )
     if existing_sshfp:
         raise EntityAlreadyExists(f"{host} already has that SSHFP defined.")
 
-    SSHFP.create(data)
+    client.sshfp.create(
+        host=host,
+        algorithm=args.algorithm,
+        hash_type=args.hash_type,
+        fingerprint=args.fingerprint,
+    )
     OutputManager().add_ok(f"Added SSHFP record for {host.name}.")
 
 
@@ -797,13 +836,13 @@ def sshfp_remove(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name, fingerprint)
     """
-    host = Host.get_by_any_means_or_raise(args.name)
+    client = get_client()
+    host = resolve_host(client, args.name)
     sshfps = None
 
     if args.fingerprint:
-        sshfps = [
-            SSHFP.get_by_query_unique_or_raise({"fingerprint": args.fingerprint, "host": host.id})
-        ]
+        sshfp = client.sshfp.first(required=True, fingerprint=args.fingerprint, host=host.id)
+        sshfps = [sshfp]
     else:
         sshfps = host.sshfps
 
@@ -811,11 +850,9 @@ def sshfp_remove(args: argparse.Namespace) -> None:
         raise EntityNotFound(f"No matching SSHFP records for {host}")
     else:
         for sshfp in sshfps:
-            if not sshfp.delete():
-                raise DeleteError(f"Failed to remove SSHFP for {host}")
-            else:
-                fp = sshfp.fingerprint
-                OutputManager().add_ok(f"Removed SSHFP record with fingerprint {fp} for {host}.")
+            fp = sshfp.fingerprint
+            client.sshfp.delete(sshfp)
+            OutputManager().add_ok(f"Removed SSHFP record with fingerprint {fp} for {host}.")
 
 
 @command_registry.register_command(
@@ -831,7 +868,8 @@ def sshfp_show(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name)
     """
-    host = Host.get_by_any_means_or_raise(args.name)
+    client = get_client()
+    host = resolve_host(client, args.name)
     sshfps = host.sshfps
 
     if not sshfps:
@@ -879,22 +917,31 @@ def ttl_set(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name, ttl)
     """
+    client = get_client()
     name: str = args.name
     ttl: str = args.ttl
 
-    target = Host.get_by_any_means(name)
-    if not target:
-        target = Srv.get_by_field("name", name)
+    # Convert "default" to None (API uses None for default TTL)
+    ttl_value: int | None = None if ttl == "default" else int(ttl)
 
-    if not target:
+    target_host = resolve_host(client, name, required=False)
+    target_srv: Srv | None = None
+
+    if target_host is None:
+        target_srv = client.srv.first(name=name)
+
+    if target_host is None and target_srv is None:
         raise EntityNotFound(f"No host or SRV record found for {name}")
 
-    result = target.set_ttl(ttl)
-    new_ttl = result.ttl or ttl  # prefer the actual value if it exists
-    if result:
-        OutputManager().add_ok(f"Set TTL for {target} to {new_ttl}.")
+    if target_host is not None:
+        result = client.host.update(target_host, ttl=ttl_value)
+        new_ttl = result.ttl if result.ttl is not None else ttl
+        OutputManager().add_ok(f"Set TTL for {target_host} to {new_ttl}.")
     else:
-        raise PatchError(f"Failed to set TTL for {target}")
+        assert target_srv is not None
+        result = client.srv.update(target_srv, ttl=ttl_value)
+        new_ttl = result.ttl if result.ttl is not None else ttl
+        OutputManager().add_ok(f"Set TTL for {target_srv} to {new_ttl}.")
 
 
 @command_registry.register_command(
@@ -912,7 +959,8 @@ def ttl_show(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name)
     """
-    host = Host.get_by_any_means_or_raise(args.name)
+    client = get_client()
+    host = resolve_host(client, args.name)
     output_host_ttl(host)
 
 
@@ -939,11 +987,14 @@ def txt_add(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name, text)
     """
-    host = Host.get_by_any_means_or_raise(args.name)
-    if host.has_txt(args.text):
+    client = get_client()
+    host = resolve_host(client, args.name)
+
+    existing_txt = next((t for t in host.txts if t.txt == args.text), None)
+    if existing_txt:
         raise EntityAlreadyExists(f"{host} already has that TXT defined.")
 
-    TXT.create({"host": host.id, "txt": args.text})
+    client.txt.create(host=host, txt=args.text)
     OutputManager().add_ok(f"Added TXT record to {host}.")
 
 
@@ -966,16 +1017,15 @@ def txt_remove(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name, text)
     """
-    host = Host.get_by_any_means_or_raise(args.name)
-    txt = TXT.get_by_query_unique({"host": host.id, "txt": args.text})
+    client = get_client()
+    host = resolve_host(client, args.name)
+    txt = client.txt.first(host=host.id, txt=args.text)
 
     if not txt:
         raise EntityNotFound(f"{host} has no TXT record matching '{args.text}'")
 
-    if txt.delete():
-        OutputManager().add_ok(f"Removed TXT record '{args.text}' from {host}.")
-    else:
-        raise DeleteError(f"Failed to remove TXT with '{args.text}' for {host}")
+    client.txt.delete(txt)
+    OutputManager().add_ok(f"Removed TXT record '{args.text}' from {host}.")
 
 
 @command_registry.register_command(
@@ -991,7 +1041,8 @@ def txt_show(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name)
     """
-    host = Host.get_by_any_means_or_raise(args.name)
+    client = get_client()
+    host = resolve_host(client, args.name)
     txts = host.txts
 
     if not txts:

--- a/mreg_cli/commands/label.py
+++ b/mreg_cli/commands/label.py
@@ -5,11 +5,10 @@ from __future__ import annotations
 import argparse
 from typing import Any
 
-from mreg_api.models import Label
-
+from mreg_cli.client import get_client
 from mreg_cli.commands.base import BaseCommand
 from mreg_cli.commands.registry import CommandRegistry
-from mreg_cli.exceptions import EntityNotFound, InputFailure
+from mreg_cli.exceptions import InputFailure
 from mreg_cli.output.policy import output_label
 from mreg_cli.outputmanager import OutputManager
 from mreg_cli.types import Flag
@@ -42,10 +41,11 @@ def label_add(args: argparse.Namespace) -> None:
     if " " in args.name:
         raise InputFailure("The label name can't contain spaces.")
 
+    client = get_client()
     # We can't do a fetch_after_create here because the API is... broken.
     # https://github.com/unioslo/mreg/blob/eed5c154bcc47b1dea474feabad46125ebde0aec/mreg/api/v1/views_labels.py#L30
     # https://github.com/unioslo/mreg/blob/eed5c154bcc47b1dea474feabad46125ebde0aec/mreg/api/v1/views.py#L187
-    Label.create({"name": args.name, "description": args.description}, fetch_after_create=False)
+    client.label.create(name=args.name, description=args.description)
     OutputManager().add_ok(f'Added label "{args.name}"')
 
 
@@ -54,7 +54,8 @@ def label_add(args: argparse.Namespace) -> None:
 )
 def label_list(_: argparse.Namespace) -> None:
     """List labels."""
-    labels = Label.get_all()
+    client = get_client()
+    labels = client.label.list(ordering="name")
     if not labels:
         OutputManager().add_line("No labels")
         return
@@ -78,11 +79,9 @@ def label_delete(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name)
     """
-    label = Label.get_by_name_or_raise(args.name)
-    if not label:
-        raise EntityNotFound(f'Label "{args.name}" does not exist.')
-
-    label.delete()
+    client = get_client()
+    label = client.label.get_by_name(args.name, required=True)
+    client.label.delete(label)
     OutputManager().add_ok(f'Removed label "{args.name}"')
 
 
@@ -97,7 +96,8 @@ def label_info(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name)
     """
-    label = Label.get_by_name_or_raise(args.name)
+    client = get_client()
+    label = client.label.get_by_name(args.name, required=True)
     output_label(label)
 
 
@@ -119,7 +119,9 @@ def label_rename(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (oldname, newname)
     """
-    Label.get_by_name_or_raise(args.oldname).rename(args.newname)
+    client = get_client()
+    label = client.label.get_by_name(args.oldname, required=True)
+    client.label.rename(label, args.newname)
     OutputManager().add_ok(f'Renamed label "{args.oldname}" to "{args.newname}"')
 
 
@@ -145,5 +147,7 @@ def label_redesc(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name, desc)
     """
-    Label.get_by_name_or_raise(args.name).set_description(args.desc)
+    client = get_client()
+    label = client.label.get_by_name(args.name, required=True)
+    client.label.set_description(label, args.desc)
     OutputManager().add_ok(f'Set description for label "{args.name}" to "{args.desc}"')

--- a/mreg_cli/commands/label.py
+++ b/mreg_cli/commands/label.py
@@ -80,7 +80,7 @@ def label_delete(args: argparse.Namespace) -> None:
     :param args: argparse.Namespace (name)
     """
     client = get_client()
-    label = client.label.get_by_name(args.name, required=True)
+    label = client.label.get_by_name(args.name)
     client.label.delete(label)
     OutputManager().add_ok(f'Removed label "{args.name}"')
 
@@ -97,7 +97,7 @@ def label_info(args: argparse.Namespace) -> None:
     :param args: argparse.Namespace (name)
     """
     client = get_client()
-    label = client.label.get_by_name(args.name, required=True)
+    label = client.label.get_by_name(args.name)
     output_label(label)
 
 
@@ -120,7 +120,7 @@ def label_rename(args: argparse.Namespace) -> None:
     :param args: argparse.Namespace (oldname, newname)
     """
     client = get_client()
-    label = client.label.get_by_name(args.oldname, required=True)
+    label = client.label.get_by_name(args.oldname)
     client.label.rename(label, args.newname)
     OutputManager().add_ok(f'Renamed label "{args.oldname}" to "{args.newname}"')
 
@@ -148,6 +148,6 @@ def label_redesc(args: argparse.Namespace) -> None:
     :param args: argparse.Namespace (name, desc)
     """
     client = get_client()
-    label = client.label.get_by_name(args.name, required=True)
+    label = client.label.get_by_name(args.name)
     client.label.set_description(label, args.desc)
     OutputManager().add_ok(f'Set description for label "{args.name}" to "{args.desc}"')

--- a/mreg_cli/commands/network.py
+++ b/mreg_cli/commands/network.py
@@ -1368,24 +1368,81 @@ def community_set_description(args: argparse.Namespace) -> None:
     OutputManager().add_ok(f"Set new description for community {community!r}")
 
 
-def _check_host_ip(host: Host, ip: str | None) -> IPAddress:
-    """Ensure host has an IP that can be added to/removed from a community."""
+def _get_host_ip_to_add(host: Host, ip: str | None) -> IPAddress:
+    """Get the IP address to add to a community for a host.
+
+    Requires `ip` to be specified if the host has multiple IP addresses.
+
+    :param host: Host object
+    :param ip: Optional IP address string
+    :return: IPAddress object
+
+    :raises EntityNotFound: If the host has no IP addresses.
+    :raises EntityNotFound: If the given IP address is not associated with the host.
+    :raises InputFailure: If the host has multiple IP addresses and no IP is specified.
+    """
     if not host.ipaddresses:
         raise EntityNotFound(f"Host {host.name!r} is not associated with any networks.")
-    elif not ip and len(host.ipaddresses) > 1:
+
+    if not ip and len(host.ipaddresses) > 1:
         raise InputFailure(
             f"Host {host.name!r} is associated with multiple IP addresses. Must specify IP."
         )
 
+    # Disambiguate or choose the first IP address if only one is present
     if ip:
-        ip_t = NetworkOrIP.parse_or_raise(ip, mode="ip")
-        ipaddr = host.get_ip(ip_t)
-        if not ipaddr:
-            raise EntityNotFound(f"Host {host.name!r} is not associated with IP {ip_t}")
+        ipaddr = _get_host_ip(host, ip)
     else:
         ipaddr = host.ipaddresses[0]
 
+    # NOTE: no check if the IP address is already associated with a community
+
     return ipaddr
+
+
+def _get_host_ip(host: Host, ip: str) -> IPAddress:
+    """Thin wrapper over Host.get_ip() that raises an exception if the IP address is not found."""
+    ip_t = NetworkOrIP.parse_or_raise(ip, mode="ip")
+    ipaddr = host.get_ip(ip_t)
+    if not ipaddr:
+        raise EntityNotFound(f"Host {host.name!r} is not associated with IP {ip_t}")
+    return ipaddr
+
+
+def _get_host_community_and_ip_to_remove(
+    host: Host, community: str, ip: str | None
+) -> tuple[Community, IPAddress]:
+    """Retrieve the Community and IPaddress object for a host given a community name."""
+    # NOTE: all this scaffolding presents a very compelling argument for
+    # adding server-side functionality for removing a host from a community
+    # given a hostname and a community name.
+
+    associations = host.get_community_associations(community)
+
+    # Disambiguate by IP if specified
+    if ip:
+        ipaddr = _get_host_ip(host, ip)
+        associations = [assoc for assoc in associations if assoc[1].id == ipaddr.id]
+
+    # Require a single matching HostCommunity:
+
+    # No matches
+    if len(associations) == 0:
+        msg = f"Host {host.name!r} is not part of community {community!r}"
+        if ip:
+            msg += f" on IP {ip}"
+        raise EntityNotFound(msg)
+    # Too many matches
+    elif len(associations) > 1:
+        # Try to get the IP address objects associated with the ipaddress IDs
+        # of the HostCommunity objects.
+        ips_str = ", ".join(str(assoc[1].ipaddress) for assoc in associations)
+        raise InputFailure(
+            f"Host is part of community {community!r} on multiple IPs ({ips_str}). Must specify IP."
+        )
+    # Single match
+    else:
+        return associations[0]
 
 
 @command_registry.register_command(
@@ -1409,7 +1466,7 @@ def community_host_add(args: argparse.Namespace) -> None:
     ip: str | None = args.ip
 
     h = resolve_host(client, host)
-    ipaddr = _check_host_ip(h, ip)
+    ipaddr = _get_host_ip_to_add(h, ip)
 
     net = client.network.get_by_ip(str(ipaddr.ipaddress), required=False)
     if not net:
@@ -1442,21 +1499,13 @@ def community_host_remove(args: argparse.Namespace) -> None:
     ip: str | None = args.ip
 
     h = resolve_host(client, host)
-    ipaddr = _check_host_ip(h, ip)
+    com, ipaddr = _get_host_community_and_ip_to_remove(h, community, ip)
 
     net = client.network.get_by_ip(str(ipaddr.ipaddress), required=False)
     if not net:
         raise EntityNotFound(f"{h.name!r} is not in a network controlled by MREG.")
 
-    com = h.get_community(community, ipaddr)
-    if not com:
-        msg = f"Community {community!r}"
-        if ipaddr:
-            msg += f" for IP address {ipaddr}"
-        raise EntityNotFound(f"{msg} not found.")
-
-    com = client.network.community.get_by_name(community, net)
-    client.network.community.remove_host(com, net, h)
+    client.network.community.remove_host(com, net, h, ipaddress=ipaddr.ipaddress)
 
     OutputManager().add_ok(
         f"Removed host {h.name!r} (IP: {ipaddr.ipaddress}) from community {com.name!r}"

--- a/mreg_cli/commands/network.py
+++ b/mreg_cli/commands/network.py
@@ -757,7 +757,7 @@ def policy_create(args: argparse.Namespace) -> None:
     attribute: list[str] = args.attribute or []
     pattern: str | None = args.pattern
 
-    client.networkpolicy.ensure_absent(name)
+    client.networkpolicy.assert_absent(name)
 
     attrs: list[NetworkPolicyAttributeValue] = []
     for attr_name in attribute:
@@ -1038,7 +1038,7 @@ def policy_attribute_create(args: argparse.Namespace) -> None:
     name: str = args.name
     description: str = args.description
 
-    client.network.policy.attribute.ensure_absent(name)
+    client.network.policy.attribute.assert_absent(name)
 
     client.network.policy.attribute.create(name=name, description=description)
 

--- a/mreg_cli/commands/network.py
+++ b/mreg_cli/commands/network.py
@@ -6,11 +6,14 @@ import argparse
 from typing import Any
 
 from mreg_api.models import (
+    Community,
     Host,
     IPAddress,
+    Network,
     NetworkOrIP,
     NetworkPolicyAttributeValue,
 )
+from typing_extensions import NotRequired, TypedDict
 
 from mreg_cli.choices import CommunitySortOrder
 from mreg_cli.client import get_client
@@ -57,6 +60,17 @@ class NetworkCommands(BaseCommand):
 ##########################################
 
 
+class NetworkCreateKwargs(TypedDict, total=False):
+    """Keyword arguments for creating a network."""
+
+    network: str
+    description: str
+    vlan: int | None
+    category: NotRequired[str]
+    location: NotRequired[str]
+    frozen: bool
+
+
 @command_registry.register_command(
     prog="create",
     description="Create a new network",
@@ -84,19 +98,21 @@ def create(args: argparse.Namespace) -> None:
     client = get_client()
     network: str = args.network
     desc: str = args.desc
-    vlan: str | None = args.vlan
+    vlan_arg: str | None = args.vlan
     category: str | None = args.category
     location: str | None = args.location
     frozen: bool = args.frozen
     policy: str | None = args.policy
 
-    if vlan:
-        # Validate as int, but still pass str to API
-        string_to_int(vlan, "VLAN")
+    if vlan_arg:
+        vlan = string_to_int(vlan_arg, "VLAN")
+    else:
+        vlan = None
+
     if category and not is_valid_category_tag(category):
-        raise InputFailure("Not a valid category tag")
+        raise InputFailure(f"Not a valid category tag: {category!r}")
     if location and not is_valid_location_tag(location):
-        raise InputFailure("Not a valid location tag")
+        raise InputFailure(f"Not a valid location tag: {location!r}")
     if policy:
         policy_obj = client.networkpolicy.get_by_name(policy, required=True)
     else:
@@ -110,14 +126,20 @@ def create(args: argparse.Namespace) -> None:
                 f"New network {arg_network} overlaps existing network {nw.network}"
             )
 
-    net = client.network.create(
+    kwargs = NetworkCreateKwargs(
         network=network,
         description=desc,
-        vlan=int(vlan) if vlan else None,
-        category=category,
-        location=location,
+        vlan=vlan,
         frozen=frozen,
     )
+    if location is not None:
+        kwargs["location"] = location
+    if category is not None:
+        kwargs["category"] = category
+
+    net = client.network.create(**kwargs)
+
+    # TODO: investigate if we can pass policy directly to create()
     if net and policy_obj:
         client.network.update(net, policy=policy_obj.id)
 
@@ -265,7 +287,7 @@ def find(args: argparse.Namespace) -> None:
         if not params:
             raise InputFailure("Need at least one search criteria")
 
-        networks = client.network.list(**params)
+        networks = client.network.list(limit=500, **params)
 
     if not networks:
         raise EntityNotFound("No networks matching the query were found.")
@@ -739,13 +761,13 @@ def policy_create(args: argparse.Namespace) -> None:
 
     attrs: list[NetworkPolicyAttributeValue] = []
     for attr_name in attribute:
-        attr = client.networkpolicyattribute.get_by_name(attr_name, required=True)
+        attr = client.network.policy.attribute.get_by_name(attr_name, required=True)
         attrs.append(NetworkPolicyAttributeValue(name=attr.name, value=True))
 
-    client.networkpolicy.create(
+    client.network.policy.create(
         name=name,
         description=description,
-        attributes=attrs if attrs else None,
+        attributes=attrs,
         community_template_pattern=pattern,
     )
     OutputManager().add_ok(f"Created network policy {name!r}")
@@ -770,8 +792,8 @@ def policy_delete(args: argparse.Namespace) -> None:
     name: str = args.name
     force: bool = args.force
 
-    pol = client.networkpolicy.get_by_name(name, required=True)
-    networks = client.networkpolicy.networks(pol)
+    pol = client.network.policy.get_by_name(name, required=True)
+    networks = client.network.policy.networks(pol)
 
     if networks and not force:
         nets = ", ".join(f"{net.network!r}" for net in networks)
@@ -779,7 +801,7 @@ def policy_delete(args: argparse.Namespace) -> None:
             f"Policy {pol.name!r} is assigned to the following networks: {nets}. Must force."
         )
 
-    client.networkpolicy.delete(pol)
+    client.network.policy.delete(pol)
     OutputManager().add_ok(f"Deleted network policy {name!r}")
 
 
@@ -800,7 +822,7 @@ def policy_info(args: argparse.Namespace) -> None:
     client = get_client()
     name: str = args.name
 
-    policy = client.networkpolicy.get_by_name(name, required=True)
+    policy = client.network.policy.get_by_name(name, required=True)
     output_network_policy(policy)
 
 
@@ -828,9 +850,9 @@ def policy_list(args: argparse.Namespace) -> None:
     name: str | None = args.name
 
     if name:
-        policies = client.networkpolicy.list_by_name_regex(name)
+        policies = client.network.policy.list_by_name_regex(name)
     else:
-        policies = client.networkpolicy.list()
+        policies = client.network.policy.list()
     output_network_policies(policies)
 
 
@@ -853,8 +875,8 @@ def policy_rename(args: argparse.Namespace) -> None:
     oldname: str = args.oldname
     newname: str = args.newname
 
-    pol = client.networkpolicy.get_by_name(oldname, required=True)
-    client.networkpolicy.rename(pol, newname)
+    pol = client.network.policy.get_by_name(oldname, required=True)
+    client.network.policy.rename(pol, newname)
     OutputManager().add_ok(f"Renamed network policy {oldname!r} to {newname!r}")
 
 
@@ -904,8 +926,8 @@ def policy_set_description(args: argparse.Namespace) -> None:
     policy: str = args.policy
     description: str = args.description
 
-    pol = client.networkpolicy.get_by_name(policy, required=True)
-    client.networkpolicy.update(pol, description=description)
+    pol = client.network.policy.get_by_name(policy, required=True)
+    client.network.policy.update(pol, description=description)
     OutputManager().add_ok(f"Set new description for network policy {policy!r}")
 
 
@@ -928,8 +950,8 @@ def policy_set_pattern(args: argparse.Namespace) -> None:
     policy: str = args.policy
     pattern: str = args.pattern
 
-    pol = client.networkpolicy.get_by_name(policy, required=True)
-    client.networkpolicy.update(pol, community_template_pattern=pattern)
+    pol = client.network.policy.get_by_name(policy, required=True)
+    client.network.policy.update(pol, community_template_pattern=pattern)
     OutputManager().add_ok(
         f"Set new community mapping template pattern for network policy {policy!r}"
     )
@@ -955,8 +977,8 @@ def policy_unset_pattern(args: argparse.Namespace) -> None:
     client = get_client()
     policy: str = args.policy
 
-    pol = client.networkpolicy.get_by_name(policy, required=True)
-    client.networkpolicy.update(pol, community_template_pattern=None)
+    pol = client.network.policy.get_by_name(policy, required=True)
+    client.network.policy.update(pol, community_template_pattern=None)
     OutputManager().add_ok(
         f"Unset community mapping template pattern for network policy {policy!r}"
     )
@@ -986,13 +1008,13 @@ def policy_attribute_add(args: argparse.Namespace) -> None:
     attribute: str = args.attribute
     policy: str = args.policy
 
-    attr = client.networkpolicyattribute.get_by_name(attribute, required=True)
-    pol = client.networkpolicy.get_by_name(policy, required=True)
+    attr = client.network.policy.attribute.get_by_name(attribute, required=True)
+    pol = client.network.policy.get_by_name(policy, required=True)
 
     if pol.get_attribute(attribute):
         raise InputFailure(f"Policy {pol.name!r} already has attribute {attr.name!r}")
 
-    client.networkpolicy.add_attribute(pol, attr, value=True)
+    client.network.policy.add_attribute(pol, attr, value=True)
 
     OutputManager().add_ok(f"Added attribute {attr.name!r} to policy {pol.name!r}")
 
@@ -1016,9 +1038,9 @@ def policy_attribute_create(args: argparse.Namespace) -> None:
     name: str = args.name
     description: str = args.description
 
-    client.networkpolicyattribute.ensure_absent(name)
+    client.network.policy.attribute.ensure_absent(name)
 
-    client.networkpolicyattribute.create(name=name, description=description)
+    client.network.policy.attribute.create(name=name, description=description)
 
     OutputManager().add_ok(f"Created network policy attribute {name!r}")
 
@@ -1042,16 +1064,16 @@ def policy_attribute_delete(args: argparse.Namespace) -> None:
     attribute: str = args.attribute
     force: bool = args.force
 
-    attr = client.networkpolicyattribute.get_by_name(attribute, required=True)
+    attr = client.network.policy.attribute.get_by_name(attribute, required=True)
 
-    if not force and (pols := client.networkpolicyattribute.get_policies(attr)):
+    if not force and (pols := client.network.policy.attribute.get_policies(attr)):
         policy_names = ", ".join(f"{pol.name!r}" for pol in pols)
         raise ForceMissing(
             f"Attribute {attr.name!r} is used by the following policies: "
             f"{policy_names}. Must force."
         )
 
-    client.networkpolicyattribute.delete(attr)
+    client.network.policy.attribute.delete(attr)
     OutputManager().add_ok(f"Deleted network policy attribute {attribute!r}")
 
 
@@ -1072,7 +1094,7 @@ def policy_attribute_info(args: argparse.Namespace) -> None:
     client = get_client()
     attribute: str = args.attribute
 
-    attr = client.networkpolicyattribute.get_by_name(attribute, required=True)
+    attr = client.network.policy.attribute.get_by_name(attribute, required=True)
     output_network_policy_attribute(attr)
 
 
@@ -1100,9 +1122,9 @@ def policy_attribute_list(args: argparse.Namespace) -> None:
     name: str | None = args.name
 
     if name:
-        attributes = client.networkpolicyattribute.list_by_name_regex(name)
+        attributes = client.network.policy.attribute.list_by_name_regex(name)
     else:
-        attributes = client.networkpolicyattribute.list()
+        attributes = client.network.policy.attribute.list()
 
     if attributes:
         output_network_policy_attributes(attributes)
@@ -1129,13 +1151,13 @@ def policy_attribute_remove(args: argparse.Namespace) -> None:
     attribute: str = args.attribute
     policy: str = args.policy
 
-    attr = client.networkpolicyattribute.get_by_name(attribute, required=True)
-    pol = client.networkpolicy.get_by_name(policy, required=True)
+    attr = client.network.policy.attribute.get_by_name(attribute, required=True)
+    pol = client.network.policy.get_by_name(policy, required=True)
 
     if not pol.get_attribute(attribute):
         raise InputFailure(f"Policy {pol.name!r} does not have attribute {attr.name!r}")
 
-    client.networkpolicy.remove_attribute(pol, attribute)
+    client.network.policy.remove_attribute(pol, attribute)
 
     OutputManager().add_ok(f"Removed attribute {attr.name!r} from policy {pol.name!r}")
 
@@ -1158,14 +1180,24 @@ def policy_attribute_set_description(args: argparse.Namespace) -> None:
     attribute: str = args.attribute
     description: str = args.description
 
-    attr = client.networkpolicyattribute.get_by_name(attribute, required=True)
-    client.networkpolicyattribute.update(attr, description=description)
+    attr = client.network.policy.attribute.get_by_name(attribute, required=True)
+    client.network.policy.attribute.update(attr, description=description)
     OutputManager().add_ok(f"Set new description for network policy attribute {attribute!r}")
 
 
 ##########################################
 #           COMMUNITY COMMANDS           #
 ##########################################
+
+
+def get_network_community(network: Network, community: str) -> Community:
+    """Get a community with a given name from a Network object."""
+    com = network.get_community(community)
+    if not com:
+        raise EntityNotFound(
+            f"Community {community!r} does not exist for network {network.network}"
+        )
+    return com
 
 
 # TODO[rename]: network community create
@@ -1190,7 +1222,7 @@ def community_create(args: argparse.Namespace) -> None:
     description: str = args.description
 
     net = client.network.get(network, required=True)
-    com = client.network.communities.get_by_name(net, name)
+    com = net.get_community(name)
     if com:
         raise InputFailure(f"Community {name!r} already exists for network {network}")
     client.network.communities.create(net, name=name, description=description)
@@ -1219,12 +1251,11 @@ def community_delete(args: argparse.Namespace) -> None:
     force: bool = args.force
 
     net = client.network.get(network, required=True)
-    com = client.network.communities.get_by_name(net, community, required=True)
-
-    if not force and client.network.communities.get_hosts(net, com):
+    com = get_network_community(net, community)
+    if not force and client.network.communities.get_hosts(com, net):
         raise ForceMissing(f"Community {com.name!r} has hosts. Must force.")
 
-    client.network.communities.delete(net, com)
+    client.network.communities.delete(com, net)
     OutputManager().add_ok(f"Deleted community {community!r}")
 
 
@@ -1248,8 +1279,7 @@ def community_info(args: argparse.Namespace) -> None:
     community: str = args.community
 
     net = client.network.get(network, required=True)
-    com = client.network.communities.get_by_name(net, community, required=True)
-
+    com = get_network_community(net, community)
     output_community(com)
 
 
@@ -1306,11 +1336,8 @@ def community_rename(args: argparse.Namespace) -> None:
     newname: str = args.newname
 
     net = client.network.get(network, required=True)
-    com = client.network.communities.get_by_name(net, oldname, required=True)
-    client.patch(
-        f"/api/v1/networks/{net.network}/communities/{com.id}/",
-        json={"name": newname},
-    )
+    com = client.network.communities.get_by_name(oldname, net, required=True)
+    client.network.communities.update(com, net, name=newname)
     OutputManager().add_ok(f"Renamed community {oldname!r} to {newname!r}")
 
 
@@ -1336,11 +1363,8 @@ def community_set_description(args: argparse.Namespace) -> None:
     description: str = args.description
 
     net = client.network.get(network, required=True)
-    com = client.network.communities.get_by_name(net, community, required=True)
-    client.patch(
-        f"/api/v1/networks/{net.network}/communities/{com.id}/",
-        json={"description": description},
-    )
+    com = client.network.communities.get_by_name(community, net, required=True)
+    client.network.communities.update(com, net, description=description)
     OutputManager().add_ok(f"Set new description for community {community!r}")
 
 
@@ -1391,9 +1415,8 @@ def community_host_add(args: argparse.Namespace) -> None:
     if not net:
         raise EntityNotFound(f"{h.name!r} is not in a network controlled by MREG.")
 
-    com = client.network.communities.get_by_name(net, community, required=True)
-
-    client.network.communities.add_host(net, com, h, ipaddress=ipaddr.ipaddress)
+    com = get_network_community(net, community)
+    client.network.communities.add_host(com, net, h, ipaddress=ipaddr.ipaddress)
 
     OutputManager().add_ok(f"Added host {h.name!r} to community {com.name!r}")
 
@@ -1425,8 +1448,15 @@ def community_host_remove(args: argparse.Namespace) -> None:
     if not net:
         raise EntityNotFound(f"{h.name!r} is not in a network controlled by MREG.")
 
-    com = client.network.communities.get_by_name(net, community, required=True)
-    client.network.communities.remove_host(net, com, h)
+    com = h.get_community(community, ipaddr)
+    if not com:
+        msg = f"Community {community!r}"
+        if ipaddr:
+            msg += f" for IP address {ipaddr}"
+        raise EntityNotFound(f"{msg} not found.")
+
+    com = client.network.communities.get_by_name(community, net, required=True)
+    client.network.communities.remove_host(com, net, h)
 
     OutputManager().add_ok(
         f"Removed host {h.name!r} (IP: {ipaddr.ipaddress}) from community {com.name!r}"

--- a/mreg_cli/commands/network.py
+++ b/mreg_cli/commands/network.py
@@ -8,13 +8,12 @@ from typing import Any
 from mreg_api.models import (
     Host,
     IPAddress,
-    Network,
     NetworkOrIP,
-    NetworkPolicy,
-    NetworkPolicyAttribute,
+    NetworkPolicyAttributeValue,
 )
 
 from mreg_cli.choices import CommunitySortOrder
+from mreg_cli.client import get_client
 from mreg_cli.commands.base import BaseCommand
 from mreg_cli.commands.registry import CommandRegistry
 from mreg_cli.exceptions import (
@@ -38,6 +37,7 @@ from mreg_cli.output import (
 from mreg_cli.output.network import output_network_policy_attribute
 from mreg_cli.outputmanager import OutputManager
 from mreg_cli.types import Flag, QueryParams
+from mreg_cli.utilities.resolution import resolve_host, resolve_network
 from mreg_cli.utilities.shared import convert_wildcard_to_regex, string_to_int
 from mreg_cli.utilities.validators import is_valid_category_tag, is_valid_location_tag
 
@@ -81,6 +81,7 @@ def create(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (network, desc, vlan, category, location, frozen)
     """
+    client = get_client()
     network: str = args.network
     desc: str = args.desc
     vlan: str | None = args.vlan
@@ -97,30 +98,28 @@ def create(args: argparse.Namespace) -> None:
     if location and not is_valid_location_tag(location):
         raise InputFailure("Not a valid location tag")
     if policy:
-        policy_obj = NetworkPolicy.get_by_name_or_raise(policy)
+        policy_obj = client.networkpolicy.get_by_name(policy, required=True)
     else:
         policy_obj = None
 
     arg_network = NetworkOrIP.parse_or_raise(network, mode="network")
-    networks = Network.get_list()
+    networks = client.network.list()
     for nw in networks:
         if nw.overlaps(arg_network):
             raise NetworkOverlap(
                 f"New network {arg_network} overlaps existing network {nw.network}"
             )
 
-    net = Network.create(
-        {
-            "network": network,
-            "description": desc,
-            "vlan": vlan,
-            "category": category,
-            "location": location,
-            "frozen": frozen,
-        }
+    net = client.network.create(
+        network=network,
+        description=desc,
+        vlan=int(vlan) if vlan else None,
+        category=category,
+        location=location,
+        frozen=frozen,
     )
     if net and policy_obj:
-        net.set_policy(policy_obj)
+        client.network.update(net, policy=policy_obj.id)
 
     OutputManager().add_ok(f"created network {network}")
 
@@ -143,7 +142,8 @@ def info(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (networks)
     """
-    networks = [Network.get_by_any_means_or_raise(net) for net in args.networks]
+    client = get_client()
+    networks = [resolve_network(client, net) for net in args.networks]
     output_networks(networks)
 
 
@@ -226,20 +226,21 @@ def find(args: argparse.Namespace) -> None:
     :param args: argparse.Namespace (limit, silent, addr_only, ip, network, description, vlan,
                                      dns_delegated, category, location, frozen, reserved)
     """
+    client = get_client()
     addr_only: bool = args.addr_only
     args_dict = vars(args)
 
     if ip_arg := args_dict.get("ip"):
         addr = NetworkOrIP.parse_or_raise(ip_arg, mode="ip")
-        networks = [Network.get_by_ip_or_raise(addr)]
+        networks = [client.network.get_by_ip(addr, required=True)]
     elif host_arg := args_dict.get("host"):
-        host = Host.get_by_any_means_or_raise(host_arg)
-        ipaddrs = IPAddress.get_list_by_field("host", host.id)
-        networks: list[Network] = []
+        host = resolve_host(client, host_arg, required=True)
+        ipaddrs = client.ipaddress.list_by_host(host)
+        networks = []
         for ipaddr in ipaddrs:
             # Get the network for each IP address
             # IP might not be in a network managed by MREG, does not raise exception.
-            net = Network.get_by_ip(ipaddr.ipaddress)
+            net = client.network.get_by_ip(str(ipaddr.ipaddress))
             if net and net not in networks:
                 networks.append(net)
     else:
@@ -264,7 +265,7 @@ def find(args: argparse.Namespace) -> None:
         if not params:
             raise InputFailure("Need at least one search criteria")
 
-        networks = Network.get_by_query(params)
+        networks = client.network.list(**params)
 
     if not networks:
         raise EntityNotFound("No networks matching the query were found.")
@@ -294,7 +295,8 @@ def list_unused_addresses(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (network)
     """
-    net = Network.get_by_any_means_or_raise(args.network)
+    client = get_client()
+    net = resolve_network(client, args.network)
     output_network_unused_addresses(net)
 
 
@@ -311,7 +313,8 @@ def list_used_addresses(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (network)
     """
-    net = Network.get_by_any_means_or_raise(args.network)
+    client = get_client()
+    net = resolve_network(client, args.network)
     output_network_used_addresses(net)
 
 
@@ -329,18 +332,17 @@ def remove(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (network, force)
     """
-    net = Network.get_by_any_means_or_raise(args.network)
-    if net.get_used_count():
+    client = get_client()
+    net = resolve_network(client, args.network)
+    if client.network.get_used_count(net):
         raise DeleteError(
             "Network contains addresses that are in use. Remove hosts before deletion"
         )
 
     if not args.force:
         raise ForceMissing("Must force.")
-    if net.delete():
-        OutputManager().add_ok(f"Removed network {args.network}")
-    else:
-        raise DeleteError(f"Unable to delete network {args.network}")
+    client.network.delete(net)
+    OutputManager().add_ok(f"Removed network {args.network}")
 
 
 @command_registry.register_command(
@@ -358,8 +360,9 @@ def add_excluded_range(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (network, start_ip, end_ip)
     """
-    net = Network.get_by_any_means_or_raise(args.network)
-    net.add_excluded_range(args.start_ip, args.end_ip)
+    client = get_client()
+    net = resolve_network(client, args.network)
+    client.network.add_excluded_range(net, args.start_ip, args.end_ip)
     OutputManager().add_ok(f"Added exclude range to {net.network}")
 
 
@@ -378,8 +381,9 @@ def remove_excluded_range(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (network, start_ip, end_ip)
     """
-    net = Network.get_by_any_means_or_raise(args.network)
-    net.remove_excluded_range(args.start_ip, args.end_ip)
+    client = get_client()
+    net = resolve_network(client, args.network)
+    client.network.remove_excluded_range(net, args.start_ip, args.end_ip)
     OutputManager().add_ok(f"Removed exclude range from {net.network}")
 
 
@@ -396,7 +400,8 @@ def list_excluded_ranges(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (network, start_ip, end_ip)
     """
-    net = Network.get_by_any_means_or_raise(args.network)
+    client = get_client()
+    net = resolve_network(client, args.network)
     output_network_excluded_ranges(net.excluded_ranges)
 
 
@@ -414,8 +419,9 @@ def set_category(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (network, category)
     """
-    net = Network.get_by_any_means_or_raise(args.network)
-    net.set_category(args.category)
+    client = get_client()
+    net = resolve_network(client, args.network)
+    client.network.update(net, category=args.category)
     OutputManager().add_ok(f"Updated category tag to {args.category!r} for {net.network}")
 
 
@@ -433,8 +439,9 @@ def set_description(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (network, description)
     """
-    net = Network.get_by_any_means_or_raise(args.network)
-    net.set_description(args.description)
+    client = get_client()
+    net = resolve_network(client, args.network)
+    client.network.update(net, description=args.description)
     OutputManager().add_ok(f"Updated description to {args.description!r} for {net.network}")
 
 
@@ -451,8 +458,9 @@ def set_dns_delegated(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (network)
     """
-    net = Network.get_by_any_means_or_raise(args.network)
-    net.set_dns_delegation(True)
+    client = get_client()
+    net = resolve_network(client, args.network)
+    client.network.update(net, dns_delegated=True)
     OutputManager().add_ok(f"Set DNS delegation to 'True' for {net.network}")
 
 
@@ -469,8 +477,9 @@ def set_frozen(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (network)
     """
-    net = Network.get_by_any_means_or_raise(args.network)
-    net.set_frozen(True)
+    client = get_client()
+    net = resolve_network(client, args.network)
+    client.network.update(net, frozen=True)
     OutputManager().add_ok(f"Updated frozen to 'True' for {net.network}")
 
 
@@ -488,8 +497,9 @@ def set_location(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (network, location)
     """
-    net = Network.get_by_any_means_or_raise(args.network)
-    net.set_location(args.location)
+    client = get_client()
+    net = resolve_network(client, args.network)
+    client.network.update(net, location=args.location)
     OutputManager().add_ok(f"Updated location tag to '{args.location}' for {args.network}")
 
 
@@ -512,8 +522,9 @@ def set_reserved(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (network, number)
     """
-    net = Network.get_by_any_means_or_raise(args.network)
-    net.set_reserved(args.number)
+    client = get_client()
+    net = resolve_network(client, args.network)
+    client.network.update(net, reserved=args.number)
     OutputManager().add_ok(f"Updated reserved to '{args.number}' for {net.network}")
 
 
@@ -531,8 +542,9 @@ def set_vlan(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (network, vlan)
     """
-    net = Network.get_by_any_means_or_raise(args.network)
-    net.set_vlan(args.vlan)
+    client = get_client()
+    net = resolve_network(client, args.network)
+    client.network.update(net, vlan=args.vlan)
     OutputManager().add_ok(f"Updated vlan to {args.vlan} for {net.network}")
 
 
@@ -555,11 +567,12 @@ def set_max_communities(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (network, max_communities)
     """
+    client = get_client()
     max_coms: int = args.max_communities
     if max_coms < 0:
         raise InputFailure("Number of communities must be a non-negative integer")
 
-    net = Network.get_by_any_means_or_raise(args.network)
+    net = resolve_network(client, args.network)
 
     # Max communities requires a policy
     if not net.policy:
@@ -577,7 +590,7 @@ def set_max_communities(args: argparse.Namespace) -> None:
                 f"which is more than the requested max of {max_coms}."
             )
         )
-    net.set_max_communities(max_coms)
+    client.network.update(net, max_communities=max_coms)
     OutputManager().add_ok(f"Set max communities to {max_coms} for {net.network}")
 
 
@@ -594,8 +607,9 @@ def unset_dns_delegated(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (network)
     """
-    net = Network.get_by_any_means_or_raise(args.network)
-    net.set_dns_delegation(False)
+    client = get_client()
+    net = resolve_network(client, args.network)
+    client.network.update(net, dns_delegated=False)
     OutputManager().add_ok(f"Set DNS delegation to 'False' for {net.network}")
 
 
@@ -612,8 +626,9 @@ def unset_frozen(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (network)
     """
-    net = Network.get_by_any_means_or_raise(args.network)
-    net.set_frozen(False)
+    client = get_client()
+    net = resolve_network(client, args.network)
+    client.network.update(net, frozen=False)
     OutputManager().add_ok(f"Updated frozen to 'False' for {net.network}")
 
 
@@ -633,13 +648,14 @@ def unset_max_communities(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (network)
     """
-    net = Network.get_by_any_means_or_raise(args.network)
+    client = get_client()
+    net = resolve_network(client, args.network)
 
     # No change
     if net.max_communities is None:
         raise InputFailure(f"Network {net.network} already has no community limit.")
 
-    net.unset_max_communities()
+    client.network.update(net, max_communities=None)
     OutputManager().add_ok(f"Unset max communities for {net.network}")
 
 
@@ -664,12 +680,13 @@ def policy_add(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name, network, force)
     """
+    client = get_client()
     policy: str = args.policy
     network: str = args.network
     force: bool = args.force
 
-    pol = NetworkPolicy.get_by_name_or_raise(policy)
-    net = Network.get_by_network_or_raise(network)
+    pol = client.networkpolicy.get_by_name(policy, required=True)
+    net = client.network.get(network, required=True)
 
     if net.policy and net.policy.id == pol.id:
         raise InputFailure(f"Network {net.network} already has policy {pol.name!r}.")
@@ -680,7 +697,7 @@ def policy_add(args: argparse.Namespace) -> None:
             f"Network {net.network} already has the policy {net.policy.name!r}. Must force."
         )
 
-    net.set_policy(pol)
+    client.network.update(net, policy=pol.id)
     OutputManager().add_ok(f"Added network policy {pol.name!r} to {network}")
 
 
@@ -712,24 +729,24 @@ def policy_create(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name, description, attributes)
     """
+    client = get_client()
     name: str = args.name
     description: str = args.description
     attribute: list[str] = args.attribute or []
     pattern: str | None = args.pattern
 
-    NetworkPolicy.get_by_name_and_raise(name)
+    client.networkpolicy.ensure_absent(name)
 
-    attrs: list[NetworkPolicyAttribute] = []
-    for attr in attribute:
-        attrs.append(NetworkPolicyAttribute.get_by_name_or_raise(attr))
+    attrs: list[NetworkPolicyAttributeValue] = []
+    for attr_name in attribute:
+        attr = client.networkpolicyattribute.get_by_name(attr_name, required=True)
+        attrs.append(NetworkPolicyAttributeValue(name=attr.name, value=True))
 
-    NetworkPolicy.create(
-        {
-            "name": name,
-            "description": description,
-            "attributes": [{"name": attr.name, "value": True} for attr in attrs],
-            "community_template_pattern": pattern,
-        }
+    client.networkpolicy.create(
+        name=name,
+        description=description,
+        attributes=attrs if attrs else None,
+        community_template_pattern=pattern,
     )
     OutputManager().add_ok(f"Created network policy {name!r}")
 
@@ -749,11 +766,12 @@ def policy_delete(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name)
     """
+    client = get_client()
     name: str = args.name
     force: bool = args.force
 
-    pol = NetworkPolicy.get_by_name_or_raise(name)
-    networks = Network.get_list_by_field("policy", pol.id)
+    pol = client.networkpolicy.get_by_name(name, required=True)
+    networks = client.networkpolicy.networks(pol)
 
     if networks and not force:
         nets = ", ".join(f"{net.network!r}" for net in networks)
@@ -761,7 +779,7 @@ def policy_delete(args: argparse.Namespace) -> None:
             f"Policy {pol.name!r} is assigned to the following networks: {nets}. Must force."
         )
 
-    pol.delete()
+    client.networkpolicy.delete(pol)
     OutputManager().add_ok(f"Deleted network policy {name!r}")
 
 
@@ -779,9 +797,10 @@ def policy_info(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name, attributes)
     """
+    client = get_client()
     name: str = args.name
 
-    policy = NetworkPolicy.get_by_name_or_raise(name)
+    policy = client.networkpolicy.get_by_name(name, required=True)
     output_network_policy(policy)
 
 
@@ -805,12 +824,13 @@ def policy_list(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name)
     """
+    client = get_client()
     name: str | None = args.name
 
     if name:
-        policies = NetworkPolicy.get_list_by_name_regex(name)
+        policies = client.networkpolicy.list_by_name_regex(name)
     else:
-        policies = NetworkPolicy.get_list()
+        policies = client.networkpolicy.list()
     output_network_policies(policies)
 
 
@@ -829,11 +849,12 @@ def policy_rename(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (oldname, newname)
     """
+    client = get_client()
     oldname: str = args.oldname
     newname: str = args.newname
 
-    pol = NetworkPolicy.get_by_name_or_raise(oldname)
-    pol.rename(newname)
+    pol = client.networkpolicy.get_by_name(oldname, required=True)
+    client.networkpolicy.rename(pol, newname)
     OutputManager().add_ok(f"Renamed network policy {oldname!r} to {newname!r}")
 
 
@@ -852,14 +873,15 @@ def policy_remove(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (network, force)
     """
+    client = get_client()
     network: str = args.network
 
-    net = Network.get_by_network_or_raise(network)
+    net = client.network.get(network, required=True)
 
     if not net.policy:
         raise EntityNotFound(f"Network {net.network} does not have a policy assigned.")
 
-    net.unset_policy()
+    client.network.update(net, policy=None)
     OutputManager().add_ok(f"Removed network policy from {network}")
 
 
@@ -878,11 +900,12 @@ def policy_set_description(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name, description)
     """
+    client = get_client()
     policy: str = args.policy
     description: str = args.description
 
-    pol = NetworkPolicy.get_by_name_or_raise(policy)
-    pol.patch({"description": description}, validate=False)
+    pol = client.networkpolicy.get_by_name(policy, required=True)
+    client.networkpolicy.update(pol, description=description)
     OutputManager().add_ok(f"Set new description for network policy {policy!r}")
 
 
@@ -901,11 +924,12 @@ def policy_set_pattern(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name, pattern)
     """
+    client = get_client()
     policy: str = args.policy
     pattern: str = args.pattern
 
-    pol = NetworkPolicy.get_by_name_or_raise(policy)
-    pol.patch({"community_template_pattern": pattern})
+    pol = client.networkpolicy.get_by_name(policy, required=True)
+    client.networkpolicy.update(pol, community_template_pattern=pattern)
     OutputManager().add_ok(
         f"Set new community mapping template pattern for network policy {policy!r}"
     )
@@ -928,10 +952,11 @@ def policy_unset_pattern(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name, pattern)
     """
+    client = get_client()
     policy: str = args.policy
 
-    pol = NetworkPolicy.get_by_name_or_raise(policy)
-    pol.patch({"community_template_pattern": None})
+    pol = client.networkpolicy.get_by_name(policy, required=True)
+    client.networkpolicy.update(pol, community_template_pattern=None)
     OutputManager().add_ok(
         f"Unset community mapping template pattern for network policy {policy!r}"
     )
@@ -957,16 +982,17 @@ def policy_attribute_add(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (attribute, policy)
     """
+    client = get_client()
     attribute: str = args.attribute
     policy: str = args.policy
 
-    attr = NetworkPolicyAttribute.get_by_name_or_raise(attribute)
-    pol = NetworkPolicy.get_by_name_or_raise(policy)
+    attr = client.networkpolicyattribute.get_by_name(attribute, required=True)
+    pol = client.networkpolicy.get_by_name(policy, required=True)
 
     if pol.get_attribute(attribute):
         raise InputFailure(f"Policy {pol.name!r} already has attribute {attr.name!r}")
 
-    pol.add_attribute(attr, value=True)
+    client.networkpolicy.add_attribute(pol, attr, value=True)
 
     OutputManager().add_ok(f"Added attribute {attr.name!r} to policy {pol.name!r}")
 
@@ -986,12 +1012,13 @@ def policy_attribute_create(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name, description)
     """
+    client = get_client()
     name: str = args.name
     description: str = args.description
 
-    NetworkPolicyAttribute.get_by_name_and_raise(name)
+    client.networkpolicyattribute.ensure_absent(name)
 
-    NetworkPolicyAttribute.create({"name": name, "description": description})
+    client.networkpolicyattribute.create(name=name, description=description)
 
     OutputManager().add_ok(f"Created network policy attribute {name!r}")
 
@@ -1011,19 +1038,20 @@ def policy_attribute_delete(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (attribute, force)
     """
+    client = get_client()
     attribute: str = args.attribute
     force: bool = args.force
 
-    attr = NetworkPolicyAttribute.get_by_name_or_raise(attribute)
+    attr = client.networkpolicyattribute.get_by_name(attribute, required=True)
 
-    if not force and (pols := attr.get_policies()):
+    if not force and (pols := client.networkpolicyattribute.get_policies(attr)):
         policy_names = ", ".join(f"{pol.name!r}" for pol in pols)
         raise ForceMissing(
             f"Attribute {attr.name!r} is used by the following policies: "
             f"{policy_names}. Must force."
         )
 
-    attr.delete()
+    client.networkpolicyattribute.delete(attr)
     OutputManager().add_ok(f"Deleted network policy attribute {attribute!r}")
 
 
@@ -1041,9 +1069,10 @@ def policy_attribute_info(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (attribute)
     """
+    client = get_client()
     attribute: str = args.attribute
 
-    attr = NetworkPolicyAttribute.get_by_name_or_raise(attribute)
+    attr = client.networkpolicyattribute.get_by_name(attribute, required=True)
     output_network_policy_attribute(attr)
 
 
@@ -1067,12 +1096,13 @@ def policy_attribute_list(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name)
     """
+    client = get_client()
     name: str | None = args.name
 
     if name:
-        attributes = NetworkPolicyAttribute.get_list_by_name_regex(name)
+        attributes = client.networkpolicyattribute.list_by_name_regex(name)
     else:
-        attributes = NetworkPolicyAttribute.get_list()
+        attributes = client.networkpolicyattribute.list()
 
     if attributes:
         output_network_policy_attributes(attributes)
@@ -1095,16 +1125,17 @@ def policy_attribute_remove(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (attribute, policy)
     """
+    client = get_client()
     attribute: str = args.attribute
     policy: str = args.policy
 
-    attr = NetworkPolicyAttribute.get_by_name_or_raise(attribute)
-    pol = NetworkPolicy.get_by_name_or_raise(policy)
+    attr = client.networkpolicyattribute.get_by_name(attribute, required=True)
+    pol = client.networkpolicy.get_by_name(policy, required=True)
 
     if not pol.get_attribute(attribute):
         raise InputFailure(f"Policy {pol.name!r} does not have attribute {attr.name!r}")
 
-    pol.remove_attribute(attribute)
+    client.networkpolicy.remove_attribute(pol, attribute)
 
     OutputManager().add_ok(f"Removed attribute {attr.name!r} from policy {pol.name!r}")
 
@@ -1123,11 +1154,12 @@ def policy_attribute_set_description(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (attribute, description)
     """
+    client = get_client()
     attribute: str = args.attribute
     description: str = args.description
 
-    attr = NetworkPolicyAttribute.get_by_name_or_raise(attribute)
-    attr.patch({"description": description})
+    attr = client.networkpolicyattribute.get_by_name(attribute, required=True)
+    client.networkpolicyattribute.update(attr, description=description)
     OutputManager().add_ok(f"Set new description for network policy attribute {attribute!r}")
 
 
@@ -1152,15 +1184,16 @@ def community_create(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name, description)
     """
+    client = get_client()
     network: str = args.network
     name: str = args.name
     description: str = args.description
 
-    net = Network.get_by_network_or_raise(network)
-    com = net.get_community(name)
+    net = client.network.get(network, required=True)
+    com = client.network.communities.get_by_name(net, name)
     if com:
         raise InputFailure(f"Community {name!r} already exists for network {network}")
-    net.create_community(name, description)
+    client.network.communities.create(net, name=name, description=description)
     OutputManager().add_ok(f"Created community {name!r} for network {network}")
 
 
@@ -1180,17 +1213,18 @@ def community_delete(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (network, community, force)
     """
+    client = get_client()
     network: str = args.network
     community: str = args.community
     force: bool = args.force
 
-    net = Network.get_by_network_or_raise(network)
-    com = net.get_community_or_raise(community)
+    net = client.network.get(network, required=True)
+    com = client.network.communities.get_by_name(net, community, required=True)
 
-    if not force and com.get_hosts():
+    if not force and client.network.communities.get_hosts(net, com):
         raise ForceMissing(f"Community {com.name!r} has hosts. Must force.")
 
-    com.delete()
+    client.network.communities.delete(net, com)
     OutputManager().add_ok(f"Deleted community {community!r}")
 
 
@@ -1209,11 +1243,12 @@ def community_info(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (network, community)
     """
+    client = get_client()
     network: str = args.network
     community: str = args.community
 
-    net = Network.get_by_network_or_raise(network)
-    com = net.get_community_or_raise(community)
+    net = client.network.get(network, required=True)
+    com = client.network.communities.get_by_name(net, community, required=True)
 
     output_community(com)
 
@@ -1240,11 +1275,12 @@ def community_list(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (network, hosts)
     """
+    client = get_client()
     network: str = args.network
     hosts: bool = args.hosts
     sort: CommunitySortOrder = CommunitySortOrder(args.sort)
 
-    net = Network.get_by_network_or_raise(network)
+    net = client.network.get(network, required=True)
     output_communities(net.communities, show_hosts=hosts, sort=sort)
 
 
@@ -1264,13 +1300,17 @@ def community_rename(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (network, oldname, newname)
     """
+    client = get_client()
     network: str = args.network
     oldname: str = args.oldname
     newname: str = args.newname
 
-    net = Network.get_by_network_or_raise(network)
-    community = net.get_community_or_raise(oldname)
-    community.patch(({"name": newname}))
+    net = client.network.get(network, required=True)
+    com = client.network.communities.get_by_name(net, oldname, required=True)
+    client.patch(
+        f"/api/v1/networks/{net.network}/communities/{com.id}/",
+        json={"name": newname},
+    )
     OutputManager().add_ok(f"Renamed community {oldname!r} to {newname!r}")
 
 
@@ -1290,13 +1330,17 @@ def community_set_description(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (network, community, description)
     """
+    client = get_client()
     network: str = args.network
     community: str = args.community
     description: str = args.description
 
-    net = Network.get_by_network_or_raise(network)
-    com = net.get_community_or_raise(community)
-    com.patch({"description": description})
+    net = client.network.get(network, required=True)
+    com = client.network.communities.get_by_name(net, community, required=True)
+    client.patch(
+        f"/api/v1/networks/{net.network}/communities/{com.id}/",
+        json={"description": description},
+    )
     OutputManager().add_ok(f"Set new description for community {community!r}")
 
 
@@ -1335,19 +1379,21 @@ def community_host_add(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (host, community, network)
     """
+    client = get_client()
     host: str = args.host
     community: str = args.community
     ip: str | None = args.ip
 
-    h = Host.get_by_any_means_or_raise(host)
+    h = resolve_host(client, host, required=True)
     ipaddr = _check_host_ip(h, ip)
 
-    if not (net := ipaddr.network()):
+    net = client.network.get_by_ip(str(ipaddr.ipaddress))
+    if not net:
         raise EntityNotFound(f"{h.name!r} is not in a network controlled by MREG.")
 
-    com = net.get_community_or_raise(community)
+    com = client.network.communities.get_by_name(net, community, required=True)
 
-    com.add_host(h, ipaddress=ipaddr.ipaddress)
+    client.network.communities.add_host(net, com, h, ipaddress=ipaddr.ipaddress)
 
     OutputManager().add_ok(f"Added host {h.name!r} to community {com.name!r}")
 
@@ -1367,14 +1413,20 @@ def community_host_remove(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (network, community, host)
     """
+    client = get_client()
     host: str = args.host
     community: str = args.community
     ip: str | None = args.ip
 
-    h = Host.get_by_any_means_or_raise(host)
+    h = resolve_host(client, host, required=True)
     ipaddr = _check_host_ip(h, ip)
-    com = h.get_community_or_raise(community, ipaddr)
-    com.remove_host(h, ipaddr.ipaddress)
+
+    net = client.network.get_by_ip(str(ipaddr.ipaddress))
+    if not net:
+        raise EntityNotFound(f"{h.name!r} is not in a network controlled by MREG.")
+
+    com = client.network.communities.get_by_name(net, community, required=True)
+    client.network.communities.remove_host(net, com, h)
 
     OutputManager().add_ok(
         f"Removed host {h.name!r} (IP: {ipaddr.ipaddress}) from community {com.name!r}"

--- a/mreg_cli/commands/network.py
+++ b/mreg_cli/commands/network.py
@@ -114,7 +114,7 @@ def create(args: argparse.Namespace) -> None:
     if location and not is_valid_location_tag(location):
         raise InputFailure(f"Not a valid location tag: {location!r}")
     if policy:
-        policy_obj = client.networkpolicy.get_by_name(policy, required=True)
+        policy_obj = client.networkpolicy.get_by_name(policy)
     else:
         policy_obj = None
 
@@ -252,17 +252,17 @@ def find(args: argparse.Namespace) -> None:
     addr_only: bool = args.addr_only
     args_dict = vars(args)
 
+    networks: list[Network] = []
     if ip_arg := args_dict.get("ip"):
         addr = NetworkOrIP.parse_or_raise(ip_arg, mode="ip")
-        networks = [client.network.get_by_ip(addr, required=True)]
+        networks = [client.network.get_by_ip(addr)]
     elif host_arg := args_dict.get("host"):
-        host = resolve_host(client, host_arg, required=True)
+        host = resolve_host(client, host_arg)
         ipaddrs = client.ipaddress.list_by_host(host)
-        networks = []
         for ipaddr in ipaddrs:
             # Get the network for each IP address
             # IP might not be in a network managed by MREG, does not raise exception.
-            net = client.network.get_by_ip(str(ipaddr.ipaddress))
+            net = client.network.get_by_ip(str(ipaddr.ipaddress), required=False)
             if net and net not in networks:
                 networks.append(net)
     else:
@@ -707,8 +707,8 @@ def policy_add(args: argparse.Namespace) -> None:
     network: str = args.network
     force: bool = args.force
 
-    pol = client.networkpolicy.get_by_name(policy, required=True)
-    net = client.network.get(network, required=True)
+    pol = client.networkpolicy.get_by_name(policy)
+    net = client.network.get(network)
 
     if net.policy and net.policy.id == pol.id:
         raise InputFailure(f"Network {net.network} already has policy {pol.name!r}.")
@@ -761,7 +761,7 @@ def policy_create(args: argparse.Namespace) -> None:
 
     attrs: list[NetworkPolicyAttributeValue] = []
     for attr_name in attribute:
-        attr = client.network.policy.attribute.get_by_name(attr_name, required=True)
+        attr = client.network.policy.attribute.get_by_name(attr_name)
         attrs.append(NetworkPolicyAttributeValue(name=attr.name, value=True))
 
     client.network.policy.create(
@@ -792,7 +792,7 @@ def policy_delete(args: argparse.Namespace) -> None:
     name: str = args.name
     force: bool = args.force
 
-    pol = client.network.policy.get_by_name(name, required=True)
+    pol = client.network.policy.get_by_name(name)
     networks = client.network.policy.networks(pol)
 
     if networks and not force:
@@ -822,7 +822,7 @@ def policy_info(args: argparse.Namespace) -> None:
     client = get_client()
     name: str = args.name
 
-    policy = client.network.policy.get_by_name(name, required=True)
+    policy = client.network.policy.get_by_name(name)
     output_network_policy(policy)
 
 
@@ -875,7 +875,7 @@ def policy_rename(args: argparse.Namespace) -> None:
     oldname: str = args.oldname
     newname: str = args.newname
 
-    pol = client.network.policy.get_by_name(oldname, required=True)
+    pol = client.network.policy.get_by_name(oldname)
     client.network.policy.rename(pol, newname)
     OutputManager().add_ok(f"Renamed network policy {oldname!r} to {newname!r}")
 
@@ -898,7 +898,7 @@ def policy_remove(args: argparse.Namespace) -> None:
     client = get_client()
     network: str = args.network
 
-    net = client.network.get(network, required=True)
+    net = client.network.get(network)
 
     if not net.policy:
         raise EntityNotFound(f"Network {net.network} does not have a policy assigned.")
@@ -926,7 +926,7 @@ def policy_set_description(args: argparse.Namespace) -> None:
     policy: str = args.policy
     description: str = args.description
 
-    pol = client.network.policy.get_by_name(policy, required=True)
+    pol = client.network.policy.get_by_name(policy)
     client.network.policy.update(pol, description=description)
     OutputManager().add_ok(f"Set new description for network policy {policy!r}")
 
@@ -950,7 +950,7 @@ def policy_set_pattern(args: argparse.Namespace) -> None:
     policy: str = args.policy
     pattern: str = args.pattern
 
-    pol = client.network.policy.get_by_name(policy, required=True)
+    pol = client.network.policy.get_by_name(policy)
     client.network.policy.update(pol, community_template_pattern=pattern)
     OutputManager().add_ok(
         f"Set new community mapping template pattern for network policy {policy!r}"
@@ -977,7 +977,7 @@ def policy_unset_pattern(args: argparse.Namespace) -> None:
     client = get_client()
     policy: str = args.policy
 
-    pol = client.network.policy.get_by_name(policy, required=True)
+    pol = client.network.policy.get_by_name(policy)
     client.network.policy.update(pol, community_template_pattern=None)
     OutputManager().add_ok(
         f"Unset community mapping template pattern for network policy {policy!r}"
@@ -1008,8 +1008,8 @@ def policy_attribute_add(args: argparse.Namespace) -> None:
     attribute: str = args.attribute
     policy: str = args.policy
 
-    attr = client.network.policy.attribute.get_by_name(attribute, required=True)
-    pol = client.network.policy.get_by_name(policy, required=True)
+    attr = client.network.policy.attribute.get_by_name(attribute)
+    pol = client.network.policy.get_by_name(policy)
 
     if pol.get_attribute(attribute):
         raise InputFailure(f"Policy {pol.name!r} already has attribute {attr.name!r}")
@@ -1064,7 +1064,7 @@ def policy_attribute_delete(args: argparse.Namespace) -> None:
     attribute: str = args.attribute
     force: bool = args.force
 
-    attr = client.network.policy.attribute.get_by_name(attribute, required=True)
+    attr = client.network.policy.attribute.get_by_name(attribute)
 
     if not force and (pols := client.network.policy.attribute.get_policies(attr)):
         policy_names = ", ".join(f"{pol.name!r}" for pol in pols)
@@ -1094,7 +1094,7 @@ def policy_attribute_info(args: argparse.Namespace) -> None:
     client = get_client()
     attribute: str = args.attribute
 
-    attr = client.network.policy.attribute.get_by_name(attribute, required=True)
+    attr = client.network.policy.attribute.get_by_name(attribute)
     output_network_policy_attribute(attr)
 
 
@@ -1151,8 +1151,8 @@ def policy_attribute_remove(args: argparse.Namespace) -> None:
     attribute: str = args.attribute
     policy: str = args.policy
 
-    attr = client.network.policy.attribute.get_by_name(attribute, required=True)
-    pol = client.network.policy.get_by_name(policy, required=True)
+    attr = client.network.policy.attribute.get_by_name(attribute)
+    pol = client.network.policy.get_by_name(policy)
 
     if not pol.get_attribute(attribute):
         raise InputFailure(f"Policy {pol.name!r} does not have attribute {attr.name!r}")
@@ -1180,7 +1180,7 @@ def policy_attribute_set_description(args: argparse.Namespace) -> None:
     attribute: str = args.attribute
     description: str = args.description
 
-    attr = client.network.policy.attribute.get_by_name(attribute, required=True)
+    attr = client.network.policy.attribute.get_by_name(attribute)
     client.network.policy.attribute.update(attr, description=description)
     OutputManager().add_ok(f"Set new description for network policy attribute {attribute!r}")
 
@@ -1221,11 +1221,11 @@ def community_create(args: argparse.Namespace) -> None:
     name: str = args.name
     description: str = args.description
 
-    net = client.network.get(network, required=True)
+    net = client.network.get(network)
     com = net.get_community(name)
     if com:
         raise InputFailure(f"Community {name!r} already exists for network {network}")
-    client.network.communities.create(net, name=name, description=description)
+    client.network.community.create(net, name=name, description=description)
     OutputManager().add_ok(f"Created community {name!r} for network {network}")
 
 
@@ -1250,12 +1250,12 @@ def community_delete(args: argparse.Namespace) -> None:
     community: str = args.community
     force: bool = args.force
 
-    net = client.network.get(network, required=True)
+    net = client.network.get(network)
     com = get_network_community(net, community)
-    if not force and client.network.communities.get_hosts(com, net):
+    if not force and client.network.community.get_hosts(com, net):
         raise ForceMissing(f"Community {com.name!r} has hosts. Must force.")
 
-    client.network.communities.delete(com, net)
+    client.network.community.delete(com, net)
     OutputManager().add_ok(f"Deleted community {community!r}")
 
 
@@ -1278,7 +1278,7 @@ def community_info(args: argparse.Namespace) -> None:
     network: str = args.network
     community: str = args.community
 
-    net = client.network.get(network, required=True)
+    net = client.network.get(network)
     com = get_network_community(net, community)
     output_community(com)
 
@@ -1310,7 +1310,7 @@ def community_list(args: argparse.Namespace) -> None:
     hosts: bool = args.hosts
     sort: CommunitySortOrder = CommunitySortOrder(args.sort)
 
-    net = client.network.get(network, required=True)
+    net = client.network.get(network)
     output_communities(net.communities, show_hosts=hosts, sort=sort)
 
 
@@ -1335,9 +1335,9 @@ def community_rename(args: argparse.Namespace) -> None:
     oldname: str = args.oldname
     newname: str = args.newname
 
-    net = client.network.get(network, required=True)
-    com = client.network.communities.get_by_name(oldname, net, required=True)
-    client.network.communities.update(com, net, name=newname)
+    net = client.network.get(network)
+    com = client.network.community.get_by_name(oldname, net)
+    client.network.community.update(com, net, name=newname)
     OutputManager().add_ok(f"Renamed community {oldname!r} to {newname!r}")
 
 
@@ -1362,9 +1362,9 @@ def community_set_description(args: argparse.Namespace) -> None:
     community: str = args.community
     description: str = args.description
 
-    net = client.network.get(network, required=True)
-    com = client.network.communities.get_by_name(community, net, required=True)
-    client.network.communities.update(com, net, description=description)
+    net = client.network.get(network)
+    com = client.network.community.get_by_name(community, net)
+    client.network.community.update(com, net, description=description)
     OutputManager().add_ok(f"Set new description for community {community!r}")
 
 
@@ -1408,15 +1408,15 @@ def community_host_add(args: argparse.Namespace) -> None:
     community: str = args.community
     ip: str | None = args.ip
 
-    h = resolve_host(client, host, required=True)
+    h = resolve_host(client, host)
     ipaddr = _check_host_ip(h, ip)
 
-    net = client.network.get_by_ip(str(ipaddr.ipaddress))
+    net = client.network.get_by_ip(str(ipaddr.ipaddress), required=False)
     if not net:
         raise EntityNotFound(f"{h.name!r} is not in a network controlled by MREG.")
 
     com = get_network_community(net, community)
-    client.network.communities.add_host(com, net, h, ipaddress=ipaddr.ipaddress)
+    client.network.community.add_host(com, net, h, ipaddress=ipaddr.ipaddress)
 
     OutputManager().add_ok(f"Added host {h.name!r} to community {com.name!r}")
 
@@ -1441,10 +1441,10 @@ def community_host_remove(args: argparse.Namespace) -> None:
     community: str = args.community
     ip: str | None = args.ip
 
-    h = resolve_host(client, host, required=True)
+    h = resolve_host(client, host)
     ipaddr = _check_host_ip(h, ip)
 
-    net = client.network.get_by_ip(str(ipaddr.ipaddress))
+    net = client.network.get_by_ip(str(ipaddr.ipaddress), required=False)
     if not net:
         raise EntityNotFound(f"{h.name!r} is not in a network controlled by MREG.")
 
@@ -1455,8 +1455,8 @@ def community_host_remove(args: argparse.Namespace) -> None:
             msg += f" for IP address {ipaddr}"
         raise EntityNotFound(f"{msg} not found.")
 
-    com = client.network.communities.get_by_name(community, net, required=True)
-    client.network.communities.remove_host(com, net, h)
+    com = client.network.community.get_by_name(community, net)
+    client.network.community.remove_host(com, net, h)
 
     OutputManager().add_ok(
         f"Removed host {h.name!r} (IP: {ipaddr.ipaddress}) from community {com.name!r}"

--- a/mreg_cli/commands/permission.py
+++ b/mreg_cli/commands/permission.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 import argparse
 from typing import Any
 
-from mreg_api.models import Label, NetworkOrIP, Permission
+from mreg_api.models import NetworkOrIP
 
+from mreg_cli.client import get_client
 from mreg_cli.commands.base import BaseCommand
 from mreg_cli.commands.registry import CommandRegistry
-from mreg_cli.exceptions import DeleteError, EntityNotFound
+from mreg_cli.exceptions import EntityAlreadyExists, EntityNotFound
 from mreg_cli.outputmanager import OutputManager
 from mreg_cli.types import Flag, QueryParams
 from mreg_cli.utilities.shared import convert_wildcard_to_regex
@@ -45,7 +46,7 @@ def network_list(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (group, range)
     """
-    permission_list: list[Permission] = []
+    client = get_client()
 
     params: QueryParams = {}
     if args.group is not None:
@@ -54,8 +55,9 @@ def network_list(args: argparse.Namespace) -> None:
 
     # Well, this is effin' awful. We have to fetch all permissions, but the API wants to limit
     # the number of results. We should probably fix this in the API.
-    permissions = Permission.get_by_query(query=params, ordering="range,group", limit=None)
+    permissions = client.permission.list(**params)
 
+    permission_list = []
     if args.range is not None:
         argnetwork = NetworkOrIP.parse_or_raise(args.range, mode="network")
 
@@ -74,7 +76,7 @@ def network_list(args: argparse.Namespace) -> None:
     output: list[dict[str, str]] = []
     labelnames: dict[int, str] = {}
 
-    for label in Label.get_all():
+    for label in client.label.list(ordering="name"):
         labelnames[label.id] = label.name
 
     for permission in permission_list:
@@ -108,16 +110,17 @@ def network_add(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (range, group, regex)
     """
+    client = get_client()
+
     NetworkOrIP.parse_or_raise(args.range, mode="network")
 
-    query = {
-        "range": args.range,
-        "group": args.group,
-        "regex": args.regex,
-    }
+    existing = client.permission.get_by_triplet(args.group, args.range, args.regex)
+    if existing:
+        raise EntityAlreadyExists(
+            f"Permission already exists for group={args.group!r}, range={args.range!r}, regex={args.regex!r}."
+        )
 
-    Permission.get_by_query_unique_and_raise(query)
-    Permission.create(data=query)
+    client.permission.create(group=args.group, range=args.range, regex=args.regex)
     OutputManager().add_ok(f"Added permission to {args.range}")
 
 
@@ -136,17 +139,11 @@ def network_remove(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (range, group, regex)
     """
-    query = {
-        "group": args.group,
-        "range": args.range,
-        "regex": args.regex,
-    }
+    client = get_client()
 
-    permission = Permission.get_by_query_unique_or_raise(query)
-    if permission.delete():
-        OutputManager().add_ok(f"Removed permission for {args.range}")
-    else:
-        raise DeleteError(f"Failed to remove permission for {args.range}")
+    permission = client.permission.get_by_triplet(args.group, args.range, args.regex, required=True)
+    client.permission.delete(permission)
+    OutputManager().add_ok(f"Removed permission for {args.range}")
 
 
 @command_registry.register_command(
@@ -165,14 +162,10 @@ def add_label_to_permission(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (range, group, regex, label)
     """
-    # find the permission
-    query = {
-        "group": args.group,
-        "range": args.range,
-        "regex": args.regex,
-    }
-    permission = Permission.get_by_query_unique_or_raise(query)
-    permission.add_label(args.label)
+    client = get_client()
+
+    permission = client.permission.get_by_triplet(args.group, args.range, args.regex, required=True)
+    client.permission.add_label(permission, args.label)
     OutputManager().add_ok(f"Added the label {args.label!r} to the permission.")
 
 
@@ -192,12 +185,8 @@ def remove_label_from_permission(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (range, group, regex, label)
     """
-    # find the permission
-    query = {
-        "group": args.group,
-        "range": args.range,
-        "regex": args.regex,
-    }
-    permission = Permission.get_by_query_unique_or_raise(query)
-    permission.remove_label(args.label)
+    client = get_client()
+
+    permission = client.permission.get_by_triplet(args.group, args.range, args.regex, required=True)
+    client.permission.remove_label(permission, args.label)
     OutputManager().add_ok(f"Removed the label {args.label!r} from the permission.")

--- a/mreg_cli/commands/permission.py
+++ b/mreg_cli/commands/permission.py
@@ -48,14 +48,14 @@ def network_list(args: argparse.Namespace) -> None:
     """
     client = get_client()
 
-    params: QueryParams = {}
+    params: QueryParams = {"ordering": "range,group"}
     if args.group is not None:
         param, value = convert_wildcard_to_regex("group", args.group)
         params[param] = value
 
     # Well, this is effin' awful. We have to fetch all permissions, but the API wants to limit
     # the number of results. We should probably fix this in the API.
-    permissions = client.permission.list(**params)
+    permissions = client.permission.list(limit=None, **params)
 
     permission_list = []
     if args.range is not None:
@@ -141,7 +141,9 @@ def network_remove(args: argparse.Namespace) -> None:
     """
     client = get_client()
 
-    permission = client.permission.get_by_triplet(args.group, args.range, args.regex, required=True)
+    permission = client.permission.get_by_triplet(
+        args.group, args.range, args.regex, required=True
+    )
     client.permission.delete(permission)
     OutputManager().add_ok(f"Removed permission for {args.range}")
 
@@ -164,7 +166,9 @@ def add_label_to_permission(args: argparse.Namespace) -> None:
     """
     client = get_client()
 
-    permission = client.permission.get_by_triplet(args.group, args.range, args.regex, required=True)
+    permission = client.permission.get_by_triplet(
+        args.group, args.range, args.regex, required=True
+    )
     client.permission.add_label(permission, args.label)
     OutputManager().add_ok(f"Added the label {args.label!r} to the permission.")
 
@@ -187,6 +191,8 @@ def remove_label_from_permission(args: argparse.Namespace) -> None:
     """
     client = get_client()
 
-    permission = client.permission.get_by_triplet(args.group, args.range, args.regex, required=True)
+    permission = client.permission.get_by_triplet(
+        args.group, args.range, args.regex, required=True
+    )
     client.permission.remove_label(permission, args.label)
     OutputManager().add_ok(f"Removed the label {args.label!r} from the permission.")

--- a/mreg_cli/commands/permission.py
+++ b/mreg_cli/commands/permission.py
@@ -114,7 +114,7 @@ def network_add(args: argparse.Namespace) -> None:
 
     NetworkOrIP.parse_or_raise(args.range, mode="network")
 
-    existing = client.permission.get_by_triplet(args.group, args.range, args.regex)
+    existing = client.permission.get_by_triplet(args.group, args.range, args.regex, required=False)
     if existing:
         raise EntityAlreadyExists(
             f"Permission already exists for group={args.group!r}, range={args.range!r}, regex={args.regex!r}."
@@ -141,9 +141,7 @@ def network_remove(args: argparse.Namespace) -> None:
     """
     client = get_client()
 
-    permission = client.permission.get_by_triplet(
-        args.group, args.range, args.regex, required=True
-    )
+    permission = client.permission.get_by_triplet(args.group, args.range, args.regex)
     client.permission.delete(permission)
     OutputManager().add_ok(f"Removed permission for {args.range}")
 
@@ -166,9 +164,7 @@ def add_label_to_permission(args: argparse.Namespace) -> None:
     """
     client = get_client()
 
-    permission = client.permission.get_by_triplet(
-        args.group, args.range, args.regex, required=True
-    )
+    permission = client.permission.get_by_triplet(args.group, args.range, args.regex)
     client.permission.add_label(permission, args.label)
     OutputManager().add_ok(f"Added the label {args.label!r} to the permission.")
 
@@ -191,8 +187,6 @@ def remove_label_from_permission(args: argparse.Namespace) -> None:
     """
     client = get_client()
 
-    permission = client.permission.get_by_triplet(
-        args.group, args.range, args.regex, required=True
-    )
+    permission = client.permission.get_by_triplet(args.group, args.range, args.regex)
     client.permission.remove_label(permission, args.label)
     OutputManager().add_ok(f"Removed the label {args.label!r} from the permission.")

--- a/mreg_cli/commands/policy.py
+++ b/mreg_cli/commands/policy.py
@@ -64,7 +64,7 @@ def atom_create(args: argparse.Namespace) -> None:
     description: str = args.description
 
     # Check if atom with that name already exists
-    client.atom.ensure_absent(name)
+    client.atom.assert_absent(name)
     client.atom.create(name=name, description=description)
     OutputManager().add_ok(f"Created new atom {name}")
 
@@ -110,7 +110,7 @@ def role_create(args: argparse.Namespace) -> None:
     description: str = args.description
 
     # Check if role with that name already exists
-    client.role.ensure_absent(name)
+    client.role.assert_absent(name)
     client.role.create(name=name, description=description)
     OutputManager().add_ok(f"Created new role {name!r}")
 

--- a/mreg_cli/commands/policy.py
+++ b/mreg_cli/commands/policy.py
@@ -97,7 +97,7 @@ def atom_delete(args: argparse.Namespace) -> None:
     flags=[
         Flag("name", description="Role name", metavar="NAME"),
         Flag("description", description="Description", metavar="DESCRIPTION"),
-        Flag("-created", description="Created date", hidden=True, metavar="CREATED"),
+        Flag("-created", description="DEPRECATED: Created date", hidden=True, metavar="CREATED"),
     ],
 )
 def role_create(args: argparse.Namespace) -> None:

--- a/mreg_cli/commands/policy.py
+++ b/mreg_cli/commands/policy.py
@@ -46,7 +46,12 @@ class PolicyCommands(BaseCommand):
     flags=[
         Flag("name", description="Atom name", metavar="NAME"),
         Flag("description", description="Description", metavar="DESCRIPTION"),
-        Flag("-created", description="Created date", metavar="CREATED"),
+        Flag(
+            "-created",
+            description="DEPRECATED: Created date.",
+            metavar="CREATED",
+            hidden=True,
+        ),
     ],
 )
 def atom_create(args: argparse.Namespace) -> None:

--- a/mreg_cli/commands/policy.py
+++ b/mreg_cli/commands/policy.py
@@ -86,7 +86,7 @@ def atom_delete(args: argparse.Namespace) -> None:
     client = get_client()
     name: str = args.name
 
-    atom = client.atom.get_by_name(name, required=True)
+    atom = client.atom.get_by_name(name)
     client.atom.delete(atom)
     OutputManager().add_ok(f"Deleted atom {name}")
 
@@ -138,7 +138,7 @@ def role_delete(args: argparse.Namespace) -> None:
     client = get_client()
     name: str = args.name
 
-    role = client.role.get_by_name(name, required=True)
+    role = client.role.get_by_name(name)
     client.role.delete(role)
     OutputManager().add_ok(f"Deleted role {name!r}")
 
@@ -161,7 +161,7 @@ def add_atom(args: argparse.Namespace) -> None:
     role_name: str = args.role
     atom_name: str = args.atom
 
-    role = client.role.get_by_name(role_name, required=True)
+    role = client.role.get_by_name(role_name)
     client.role.add_atom(role, atom_name)
     OutputManager().add_ok(f"Added atom {atom_name!r} to role {role_name!r}")
 
@@ -184,7 +184,7 @@ def remove_atom(args: argparse.Namespace) -> None:
     role_name: str = args.role
     atom_name: str = args.atom
 
-    role = client.role.get_by_name(role_name, required=True)
+    role = client.role.get_by_name(role_name)
     client.role.remove_atom(role, atom_name)
     OutputManager().add_ok(f"Removed atom {atom_name!r} from role {role_name!r}")
 
@@ -205,7 +205,7 @@ def info(args: argparse.Namespace) -> None:
     client = get_client()
     names: list[str] = args.name
     for name in names:
-        role_or_atom = resolve_policy(client, name, required=True)
+        role_or_atom = resolve_policy(client, name)
         output_host_policy(role_or_atom)
 
 
@@ -289,7 +289,7 @@ def list_hosts(args: argparse.Namespace) -> None:
     name: str = args.name
     exclude: list[str] = args.exclude if args.exclude else []
 
-    role = client.role.get_by_name(name, required=True)
+    role = client.role.get_by_name(name)
 
     exclude_roles = list(
         itertools.chain.from_iterable(client.role.list_by_name_regex(r) for r in exclude)
@@ -313,7 +313,7 @@ def list_members(args: argparse.Namespace) -> None:
     client = get_client()
     name: str = args.name
 
-    role = client.role.get_by_name(name, required=True)
+    role = client.role.get_by_name(name)
     output_role_atoms(role)
 
 
@@ -335,7 +335,7 @@ def host_add(args: argparse.Namespace) -> None:
     role_name: str = args.role
     host_names: list[str] = args.hosts
 
-    role = client.role.get_by_name(role_name, required=True)
+    role = client.role.get_by_name(role_name)
     hosts = [resolve_host(client, host) for host in host_names]
 
     for host in hosts:
@@ -426,7 +426,7 @@ def host_remove(args: argparse.Namespace) -> None:
     role_name: str = args.role
     host_names: list[str] = args.hosts
 
-    role = client.role.get_by_name(role_name, required=True)
+    role = client.role.get_by_name(role_name)
     hosts = [resolve_host(client, host) for host in host_names]
 
     for host in hosts:
@@ -456,10 +456,12 @@ def rename(args: argparse.Namespace) -> None:
         raise EntityAlreadyExists("Old and new names are the same")
 
     # Check if role or atom with the new name already exists
-    if client.atom.get_by_name(newname) or client.role.get_by_name(newname):
+    if client.atom.get_by_name(newname, required=False) or client.role.get_by_name(
+        newname, required=False
+    ):
         raise EntityAlreadyExists(f"An atom or role named {newname!r} already exists")
 
-    role_or_atom = resolve_policy(client, oldname, required=True)
+    role_or_atom = resolve_policy(client, oldname)
     if isinstance(role_or_atom, Role):
         client.role.rename(role_or_atom, newname)
     else:
@@ -485,7 +487,7 @@ def set_description(args: argparse.Namespace) -> None:
     name: str = args.name
     description: str = args.description
 
-    role_or_atom = resolve_policy(client, name, required=True)
+    role_or_atom = resolve_policy(client, name)
     if isinstance(role_or_atom, Role):
         client.role.set_description(role_or_atom, description)
     else:
@@ -511,7 +513,7 @@ def add_label_to_role(args: argparse.Namespace) -> None:
     role_name: str = args.role
     label_name: str = args.label
 
-    role = client.role.get_by_name(role_name, required=True)
+    role = client.role.get_by_name(role_name)
     client.role.add_label(role, label_name)
     OutputManager().add_ok(f"Added the label {label_name!r} to the role {role_name!r}.")
 
@@ -534,7 +536,7 @@ def remove_label_from_role(args: argparse.Namespace) -> None:
     role_name: str = args.role
     label_name: str = args.label
 
-    role = client.role.get_by_name(role_name, required=True)
+    role = client.role.get_by_name(role_name)
     client.role.remove_label(role, label_name)
     OutputManager().add_ok(f"Removed the label {label_name!r} from the role {role_name!r}.")
 

--- a/mreg_cli/commands/policy.py
+++ b/mreg_cli/commands/policy.py
@@ -6,17 +6,13 @@ import argparse
 import itertools
 from typing import Any
 
-from mreg_api.exceptions import APIError, DeleteError, EntityAlreadyExists, PostError
-from mreg_api.models import (
-    Atom,
-    Host,
-    HostPolicy,
-    Role,
-)
+from mreg_api.exceptions import APIError
+from mreg_api.models import Role
 
+from mreg_cli.client import get_client
 from mreg_cli.commands.base import BaseCommand
 from mreg_cli.commands.registry import CommandRegistry
-from mreg_cli.exceptions import handle_exception
+from mreg_cli.exceptions import EntityAlreadyExists, handle_exception
 from mreg_cli.output import (
     output_atoms_lines,
     output_host_policy,
@@ -28,6 +24,7 @@ from mreg_cli.output import (
 from mreg_cli.output.history import output_atom_history, output_role_history
 from mreg_cli.outputmanager import OutputManager
 from mreg_cli.types import Flag
+from mreg_cli.utilities.resolution import resolve_host, resolve_policy
 
 command_registry = CommandRegistry()
 
@@ -57,18 +54,19 @@ def atom_create(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name, description, created)
     """
+    client = get_client()
     name: str = args.name
     description: str = args.description
     created: str = args.created
 
     # Check if atom with that name already exists
-    Atom.get_by_name_and_raise(name)
+    client.atom.ensure_absent(name)
 
     params = {"name": name, "description": description}
     if created:
         params["create_date"] = created
 
-    Atom.create(params)
+    client.atom.create(name=params["name"], description=params.get("description", ""))
     OutputManager().add_ok(f"Created new atom {name}")
 
 
@@ -85,13 +83,12 @@ def atom_delete(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name)
     """
+    client = get_client()
     name: str = args.name
 
-    atom = Atom.get_by_name_or_raise(name)
-    if atom.delete():
-        OutputManager().add_ok(f"Deleted atom {name}")
-    else:
-        raise DeleteError(f"Failed to delete atom {name}")
+    atom = client.atom.get_by_name(name, required=True)
+    client.atom.delete(atom)
+    OutputManager().add_ok(f"Deleted atom {name}")
 
 
 @command_registry.register_command(
@@ -109,18 +106,19 @@ def role_create(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name, description, created)
     """
+    client = get_client()
     name: str = args.name
     description: str = args.description
     created: str = args.created
 
     # Check if role with that name already exists
-    Role.get_by_name_and_raise(name)
+    client.role.ensure_absent(name)
 
     params = {"name": name, "description": description}
     if created:
         params["create_date"] = created
 
-    Role.create(params)
+    client.role.create(name=params["name"], description=params.get("description", ""))
     OutputManager().add_ok(f"Created new role {name!r}")
 
 
@@ -137,13 +135,12 @@ def role_delete(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name)
     """
+    client = get_client()
     name: str = args.name
 
-    role = Role.get_by_name_or_raise(name)
-    if role.delete():
-        OutputManager().add_ok(f"Deleted role {name!r}")
-    else:
-        raise DeleteError(f"Failed to delete role {name!r}")
+    role = client.role.get_by_name(name, required=True)
+    client.role.delete(role)
+    OutputManager().add_ok(f"Deleted role {name!r}")
 
 
 @command_registry.register_command(
@@ -160,14 +157,13 @@ def add_atom(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (role, atom)
     """
+    client = get_client()
     role_name: str = args.role
     atom_name: str = args.atom
 
-    role = Role.get_by_name_or_raise(role_name)
-    if role.add_atom(atom_name):
-        OutputManager().add_ok(f"Added atom {atom_name!r} to role {role_name!r}")
-    else:
-        raise PostError(f"Failed to add atom {atom_name!r} to role {role_name!r}")
+    role = client.role.get_by_name(role_name, required=True)
+    client.role.add_atom(role, atom_name)
+    OutputManager().add_ok(f"Added atom {atom_name!r} to role {role_name!r}")
 
 
 @command_registry.register_command(
@@ -184,14 +180,13 @@ def remove_atom(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (role, atom)
     """
+    client = get_client()
     role_name: str = args.role
     atom_name: str = args.atom
 
-    role = Role.get_by_name_or_raise(role_name)
-    if role.remove_atom(atom_name):
-        OutputManager().add_ok(f"Removed atom {atom_name!r} from role {role_name!r}")
-    else:
-        raise DeleteError(f"Failed to remove atom {atom_name!r} from role {role_name!r}")
+    role = client.role.get_by_name(role_name, required=True)
+    client.role.remove_atom(role, atom_name)
+    OutputManager().add_ok(f"Removed atom {atom_name!r} from role {role_name!r}")
 
 
 @command_registry.register_command(
@@ -207,9 +202,10 @@ def info(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name)
     """
+    client = get_client()
     names: list[str] = args.name
     for name in names:
-        role_or_atom = HostPolicy.get_role_or_atom_or_raise(name)
+        role_or_atom = resolve_policy(client, name, required=True)
         output_host_policy(role_or_atom)
 
 
@@ -230,9 +226,10 @@ def list_atoms(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name)
     """
+    client = get_client()
     name: str = args.name
 
-    atoms = Atom.get_list_by_name_regex(name)
+    atoms = client.atom.list_by_name_regex(name)
     if atoms:
         output_atoms_lines(atoms)
     else:
@@ -256,9 +253,10 @@ def list_roles(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name)
     """
+    client = get_client()
     name: str = args.name
 
-    roles = Role.get_list_by_name_regex(name)
+    roles = client.role.list_by_name_regex(name)
     if not roles:
         OutputManager().add_line("No match")
         return
@@ -287,13 +285,14 @@ def list_hosts(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name)
     """
+    client = get_client()
     name: str = args.name
     exclude: list[str] = args.exclude if args.exclude else []
 
-    role = Role.get_by_name_or_raise(name)
+    role = client.role.get_by_name(name, required=True)
 
     exclude_roles = list(
-        itertools.chain.from_iterable(Role.get_list_by_name_regex(r) for r in exclude)
+        itertools.chain.from_iterable(client.role.list_by_name_regex(r) for r in exclude)
     )
     output_role_hosts(role, exclude_roles=exclude_roles)
 
@@ -311,9 +310,10 @@ def list_members(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name)
     """
+    client = get_client()
     name: str = args.name
 
-    role = Role.get_by_name_or_raise(name)
+    role = client.role.get_by_name(name, required=True)
     output_role_atoms(role)
 
 
@@ -331,16 +331,17 @@ def host_add(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (role, hosts)
     """
+    client = get_client()
     role_name: str = args.role
     host_names: list[str] = args.hosts
 
-    role = Role.get_by_name_or_raise(role_name)
-    hosts = [Host.get_by_any_means_or_raise(host) for host in host_names]
+    role = client.role.get_by_name(role_name, required=True)
+    hosts = [resolve_host(client, host) for host in host_names]
 
     for host in hosts:
-        # Best-effort approach – try to assign roles to all hosts
+        # Best-effort approach -- try to assign roles to all hosts
         try:
-            role.add_host(host.name)
+            client.role.add_host(role, host.name)
             OutputManager().add_ok(f"Added host {host.name} to role {role_name!r}")
         except APIError as e:
             if e.response and e.response.status_code == 409:
@@ -366,13 +367,14 @@ def host_copy(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (source, destination)
     """
+    client = get_client()
     source_name: str = args.source
-    source = Host.get_by_any_means_or_raise(source_name)
-    source_roles = set(source.get_roles())
+    source = resolve_host(client, source_name)
+    source_roles = set(client.role.list_by_host(source))
 
     for destination_name in args.destination:
-        destination = Host.get_by_any_means_or_raise(destination_name)
-        destination_roles = set(destination.get_roles())
+        destination = resolve_host(client, destination_name)
+        destination_roles = set(client.role.list_by_host(destination))
         OutputManager().add_line(f"Copying roles from from {source_name} to {destination_name}")
 
         # Check if role already exists in destination
@@ -381,7 +383,7 @@ def host_copy(args: argparse.Namespace) -> None:
 
         # Check what roles need to be added
         for role in source_roles - destination_roles:
-            role.add_host(destination.name)
+            client.role.add_host(role, destination.name)
             OutputManager().add_line(f"    + {role.name}")
 
 
@@ -398,10 +400,11 @@ def host_list(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (hosts)
     """
+    client = get_client()
     hosts: list[str] = args.hosts
 
     for name in hosts:
-        host = Host.get_by_any_means_or_raise(name)
+        host = resolve_host(client, name)
         output_host_roles(host)
 
 
@@ -419,14 +422,15 @@ def host_remove(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (role, hosts)
     """
+    client = get_client()
     role_name: str = args.role
     host_names: list[str] = args.hosts
 
-    role = Role.get_by_name_or_raise(role_name)
-    hosts = [Host.get_by_any_means_or_raise(host) for host in host_names]
+    role = client.role.get_by_name(role_name, required=True)
+    hosts = [resolve_host(client, host) for host in host_names]
 
     for host in hosts:
-        role.remove_host(host.name)
+        client.role.remove_host(role, host.name)
         OutputManager().add_ok(f"Removed host {host.name!r} from role {role_name!r}")
 
 
@@ -444,6 +448,7 @@ def rename(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (oldname, newname)
     """
+    client = get_client()
     oldname: str = args.oldname
     newname: str = args.newname
 
@@ -451,10 +456,14 @@ def rename(args: argparse.Namespace) -> None:
         raise EntityAlreadyExists("Old and new names are the same")
 
     # Check if role or atom with the new name already exists
-    HostPolicy.get_role_or_atom_and_raise(newname)
+    if client.atom.get_by_name(newname) or client.role.get_by_name(newname):
+        raise EntityAlreadyExists(f"An atom or role named {newname!r} already exists")
 
-    role_or_atom = HostPolicy.get_role_or_atom_or_raise(oldname)
-    role_or_atom.rename(newname)
+    role_or_atom = resolve_policy(client, oldname, required=True)
+    if isinstance(role_or_atom, Role):
+        client.role.rename(role_or_atom, newname)
+    else:
+        client.atom.rename(role_or_atom, newname)
     OutputManager().add_ok(f"Renamed {oldname!r} to {newname!r}")
 
 
@@ -472,11 +481,15 @@ def set_description(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (name, description)
     """
+    client = get_client()
     name: str = args.name
     description: str = args.description
 
-    role_or_atom = HostPolicy.get_role_or_atom_or_raise(name)
-    role_or_atom.set_description(description)
+    role_or_atom = resolve_policy(client, name, required=True)
+    if isinstance(role_or_atom, Role):
+        client.role.set_description(role_or_atom, description)
+    else:
+        client.atom.set_description(role_or_atom, description)
     OutputManager().add_ok(f"updated description to {description!r} for {name!r}")
 
 
@@ -494,11 +507,12 @@ def add_label_to_role(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (role, label)
     """
+    client = get_client()
     role_name: str = args.role
     label_name: str = args.label
 
-    role = Role.get_by_name_or_raise(role_name)
-    role.add_label(label_name)
+    role = client.role.get_by_name(role_name, required=True)
+    client.role.add_label(role, label_name)
     OutputManager().add_ok(f"Added the label {label_name!r} to the role {role_name!r}.")
 
 
@@ -516,11 +530,12 @@ def remove_label_from_role(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (role, label)
     """
+    client = get_client()
     role_name: str = args.role
     label_name: str = args.label
 
-    role = Role.get_by_name_or_raise(role_name)
-    role.remove_label(label_name)
+    role = client.role.get_by_name(role_name, required=True)
+    client.role.remove_label(role, label_name)
     OutputManager().add_ok(f"Removed the label {label_name!r} from the role {role_name!r}.")
 
 

--- a/mreg_cli/commands/policy.py
+++ b/mreg_cli/commands/policy.py
@@ -62,16 +62,10 @@ def atom_create(args: argparse.Namespace) -> None:
     client = get_client()
     name: str = args.name
     description: str = args.description
-    created: str = args.created
 
     # Check if atom with that name already exists
     client.atom.ensure_absent(name)
-
-    params = {"name": name, "description": description}
-    if created:
-        params["create_date"] = created
-
-    client.atom.create(name=params["name"], description=params.get("description", ""))
+    client.atom.create(name=name, description=description)
     OutputManager().add_ok(f"Created new atom {name}")
 
 
@@ -103,7 +97,7 @@ def atom_delete(args: argparse.Namespace) -> None:
     flags=[
         Flag("name", description="Role name", metavar="NAME"),
         Flag("description", description="Description", metavar="DESCRIPTION"),
-        Flag("-created", description="Created date", metavar="CREATED"),
+        Flag("-created", description="Created date", hidden=True, metavar="CREATED"),
     ],
 )
 def role_create(args: argparse.Namespace) -> None:
@@ -114,16 +108,10 @@ def role_create(args: argparse.Namespace) -> None:
     client = get_client()
     name: str = args.name
     description: str = args.description
-    created: str = args.created
 
     # Check if role with that name already exists
     client.role.ensure_absent(name)
-
-    params = {"name": name, "description": description}
-    if created:
-        params["create_date"] = created
-
-    client.role.create(name=params["name"], description=params.get("description", ""))
+    client.role.create(name=name, description=description)
     OutputManager().add_ok(f"Created new role {name!r}")
 
 

--- a/mreg_cli/commands/root.py
+++ b/mreg_cli/commands/root.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 import argparse
 from typing import Any, NoReturn
 
-from mreg_api import MregClient
-
+from mreg_cli.client import get_client
 from mreg_cli.commands.base import BaseCommand
 from mreg_cli.commands.registry import CommandRegistry
 from mreg_cli.exceptions import CliExit
@@ -55,5 +54,5 @@ def exit_mreg_cli(_: argparse.Namespace) -> NoReturn:
 )
 def logout(_: argparse.Namespace):
     """Log out from mreg and exit. Will delete token."""
-    MregClient().logout()
+    get_client().logout()
     raise CliExit

--- a/mreg_cli/commands/zone.py
+++ b/mreg_cli/commands/zone.py
@@ -6,6 +6,7 @@ import argparse
 from typing import Any
 
 from mreg_api.models import ForwardZone, ReverseZone
+from typing_extensions import NotRequired, TypedDict
 
 from mreg_cli.client import get_client
 from mreg_cli.commands.base import BaseCommand
@@ -265,6 +266,18 @@ def set_ns(args: argparse.Namespace) -> None:
     OutputManager().add_ok(f"Updated nameservers for {args.zone}")
 
 
+class ZoneSetSoaKwargs(TypedDict, total=False):
+    """Keyword arguments for creating a network."""
+
+    primary_ns: NotRequired[str]
+    email: NotRequired[str]
+    serialno: NotRequired[int]
+    refresh: NotRequired[int]
+    retry: NotRequired[int]
+    expire: NotRequired[int]
+    soa_ttl: NotRequired[int]
+
+
 @command_registry.register_command(
     prog="set_soa",
     description="Updated the SOA of a zone.",
@@ -286,18 +299,39 @@ def set_soa(args: argparse.Namespace) -> None:
     :param args: argparse.Namespace (zone, ns, email, serialno, retry, expire, soa_ttl)
     """
     client = get_client()
-    zone = client.zone.get_by_name(args.zone, required=True)
-    client.zone.update_soa(
-        zone,
-        primary_ns=args.ns,
-        email=args.email,
-        serialno=args.serialno,
-        refresh=args.refresh,
-        retry=args.retry,
-        expire=args.expire,
-        soa_ttl=args.soa_ttl,
-    )
-    OutputManager().add_ok(f"Updated SOA for {args.zone}")
+    zone: str = args.zone
+    primary_ns: str | None = args.ns
+    email: str | None = args.email
+    serialno: int | None = args.serialno
+    refresh: int | None = args.refresh
+    retry: int | None = args.retry
+    expire: int | None = args.expire
+    soa_ttl: int | None = args.soa_ttl
+
+    kwargs: ZoneSetSoaKwargs = {}
+    if primary_ns is not None:
+        kwargs["primary_ns"] = primary_ns
+    if email is not None:
+        kwargs["email"] = email
+    if serialno is not None:
+        kwargs["serialno"] = serialno
+    if refresh is not None:
+        kwargs["refresh"] = refresh
+    if retry is not None:
+        kwargs["retry"] = retry
+    if expire is not None:
+        kwargs["expire"] = expire
+    if soa_ttl is not None:
+        kwargs["soa_ttl"] = soa_ttl
+
+    if not kwargs:
+        raise InputFailure(
+            "At least one of the following must be provided: ns, email, serialno, refresh, retry, expire, soa_ttl"
+        )
+
+    zone_obj = client.zone.get_by_name(zone, required=True)
+    client.zone.update_soa(zone_obj, **kwargs)
+    OutputManager().add_ok(f"Updated SOA for {zone}")
 
 
 @command_registry.register_command(

--- a/mreg_cli/commands/zone.py
+++ b/mreg_cli/commands/zone.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 import argparse
 from typing import Any
 
-from mreg_api.models import ForwardZone, ReverseZone, Zone
+from mreg_api.models import ForwardZone, ReverseZone
 
+from mreg_cli.client import get_client
 from mreg_cli.commands.base import BaseCommand
 from mreg_cli.commands.registry import CommandRegistry
-from mreg_cli.exceptions import DeleteError, InputFailure
+from mreg_cli.exceptions import InputFailure
 from mreg_cli.output import output_delegations, output_zone, output_zones
 from mreg_cli.outputmanager import OutputManager
 from mreg_cli.types import Flag
@@ -23,11 +24,12 @@ def _output_zones_by_type(forward: bool, reverse: bool) -> None:
     :param forward: Whether to list forward zones.
     :param reverse: Whether to list reverse zones.
     """
+    client = get_client()
     zones: list[ForwardZone | ReverseZone] = []
     if forward:
-        zones.extend(ForwardZone.get_list())
+        zones.extend(client.zone.list_forward())
     if reverse:
-        zones.extend(ReverseZone.get_list())
+        zones.extend(client.zone.list_reverse())
     output_zones(zones)
 
 
@@ -55,7 +57,8 @@ def create(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (ns, force, zone, email)
     """
-    Zone.create_zone(args.zone, args.email, args.ns, args.force)
+    client = get_client()
+    client.zone.create(name=args.zone, email=args.email, primary_ns=args.ns, force=args.force)
     OutputManager().add_ok(f"Created zone {args.zone}")
 
 
@@ -78,8 +81,15 @@ def delegation_create(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (ns, force, zone, delegation, comment)
     """
-    zone = Zone.get_zone_or_raise(args.zone)
-    zone.create_delegation(args.delegation, args.ns, args.comment, args.force)
+    client = get_client()
+    zone = client.zone.get_by_name(args.zone, required=True)
+    client.delegation.create(
+        zone,
+        name=args.delegation,
+        nameservers=args.ns,
+        comment=args.comment or "",
+        force=args.force,
+    )
     OutputManager().add_ok(f"Created zone delegation {args.delegation}")
 
 
@@ -97,11 +107,10 @@ def zone_delete(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (zone, force)
     """
-    zone = Zone.get_zone_or_raise(args.zone)
-    if zone.delete_zone(args.force):
-        OutputManager().add_ok(f"Deleted zone {zone.name}")
-    else:
-        raise DeleteError(f"Unable to delete zone {zone.name}")
+    client = get_client()
+    zone = client.zone.get_by_name(args.zone, required=True)
+    client.zone.delete(zone, force=args.force)
+    OutputManager().add_ok(f"Deleted zone {zone.name}")
 
 
 @command_registry.register_command(
@@ -121,11 +130,10 @@ def delegation_delete(args: argparse.Namespace) -> None:
     # NOTE: how to handle delegation that has delegation?
     # i.e. uio.no -> pederhan.uio.no -> sub.pederhan.uio.no
     # and we try to delete pederhan.uio.no?
-    zone = Zone.get_zone_or_raise(args.zone)
-    if zone.delete_delegation(args.delegation):
-        OutputManager().add_ok(f"Removed zone delegation {args.delegation}")
-    else:
-        raise DeleteError(f"Unable to delete delegation {args.delegation}")
+    client = get_client()
+    zone = client.zone.get_by_name(args.zone, required=True)
+    client.delegation.delete(zone, args.delegation)
+    OutputManager().add_ok(f"Removed zone delegation {args.delegation}")
 
 
 @command_registry.register_command(
@@ -141,7 +149,8 @@ def info(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (zone)
     """
-    zone = Zone.get_zone_or_raise(args.zone)
+    client = get_client()
+    zone = client.zone.get_by_name(args.zone, required=True)
     output_zone(zone)
 
 
@@ -187,7 +196,8 @@ def zone_delegation_list(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (zone)
     """
-    zone = Zone.get_zone_or_raise(args.zone)
+    client = get_client()
+    zone = client.zone.get_by_name(args.zone, required=True)
     output_delegations(zone)
 
 
@@ -206,8 +216,9 @@ def zone_delegation_comment_set(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (zone, delegation, comment)
     """
-    zone = Zone.get_zone_or_raise(args.zone)
-    zone.set_delegation_comment(args.delegation, args.comment)
+    client = get_client()
+    zone = client.zone.get_by_name(args.zone, required=True)
+    client.delegation.set_comment(zone, args.delegation, args.comment)
     OutputManager().add_ok(f"Updated comment for {args.delegation}")
 
 
@@ -225,8 +236,9 @@ def zone_delegation_comment_remove(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (zone, delegation)
     """
-    zone = Zone.get_zone_or_raise(args.zone)
-    zone.set_delegation_comment(args.delegation, "")
+    client = get_client()
+    zone = client.zone.get_by_name(args.zone, required=True)
+    client.delegation.set_comment(zone, args.delegation, "")
     OutputManager().add_ok(f"Removed comment for {args.delegation}")
 
 
@@ -247,8 +259,9 @@ def set_ns(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (zone, ns, force)
     """
-    zone = Zone.get_zone_or_raise(args.zone)
-    zone.update_nameservers(args.ns, args.force)
+    client = get_client()
+    zone = client.zone.get_by_name(args.zone, required=True)
+    client.zone.set_nameservers(zone, args.ns, force=args.force)
     OutputManager().add_ok(f"Updated nameservers for {args.zone}")
 
 
@@ -272,8 +285,10 @@ def set_soa(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (zone, ns, email, serialno, retry, expire, soa_ttl)
     """
-    zone = Zone.get_zone_or_raise(args.zone)
-    zone.update_soa(
+    client = get_client()
+    zone = client.zone.get_by_name(args.zone, required=True)
+    client.zone.update_soa(
+        zone,
         primary_ns=args.ns,
         email=args.email,
         serialno=args.serialno,
@@ -299,6 +314,7 @@ def set_default_ttl(args: argparse.Namespace) -> None:
 
     :param args: argparse.Namespace (zone, ttl)
     """
-    zone = Zone.get_zone_or_raise(args.zone)
-    zone.set_default_ttl(args.ttl)
+    client = get_client()
+    zone = client.zone.get_by_name(args.zone, required=True)
+    client.zone.set_default_ttl(zone, args.ttl)
     OutputManager().add_ok(f"Set default TTL for {args.zone}")

--- a/mreg_cli/commands/zone.py
+++ b/mreg_cli/commands/zone.py
@@ -83,7 +83,7 @@ def delegation_create(args: argparse.Namespace) -> None:
     :param args: argparse.Namespace (ns, force, zone, delegation, comment)
     """
     client = get_client()
-    zone = client.zone.get_by_name(args.zone, required=True)
+    zone = client.zone.get_by_name(args.zone)
     client.delegation.create(
         zone,
         name=args.delegation,
@@ -109,7 +109,7 @@ def zone_delete(args: argparse.Namespace) -> None:
     :param args: argparse.Namespace (zone, force)
     """
     client = get_client()
-    zone = client.zone.get_by_name(args.zone, required=True)
+    zone = client.zone.get_by_name(args.zone)
     client.zone.delete(zone, force=args.force)
     OutputManager().add_ok(f"Deleted zone {zone.name}")
 
@@ -132,7 +132,7 @@ def delegation_delete(args: argparse.Namespace) -> None:
     # i.e. uio.no -> pederhan.uio.no -> sub.pederhan.uio.no
     # and we try to delete pederhan.uio.no?
     client = get_client()
-    zone = client.zone.get_by_name(args.zone, required=True)
+    zone = client.zone.get_by_name(args.zone)
     client.delegation.delete(zone, args.delegation)
     OutputManager().add_ok(f"Removed zone delegation {args.delegation}")
 
@@ -151,7 +151,7 @@ def info(args: argparse.Namespace) -> None:
     :param args: argparse.Namespace (zone)
     """
     client = get_client()
-    zone = client.zone.get_by_name(args.zone, required=True)
+    zone = client.zone.get_by_name(args.zone)
     output_zone(zone)
 
 
@@ -198,7 +198,7 @@ def zone_delegation_list(args: argparse.Namespace) -> None:
     :param args: argparse.Namespace (zone)
     """
     client = get_client()
-    zone = client.zone.get_by_name(args.zone, required=True)
+    zone = client.zone.get_by_name(args.zone)
     output_delegations(zone)
 
 
@@ -218,7 +218,7 @@ def zone_delegation_comment_set(args: argparse.Namespace) -> None:
     :param args: argparse.Namespace (zone, delegation, comment)
     """
     client = get_client()
-    zone = client.zone.get_by_name(args.zone, required=True)
+    zone = client.zone.get_by_name(args.zone)
     client.delegation.set_comment(zone, args.delegation, args.comment)
     OutputManager().add_ok(f"Updated comment for {args.delegation}")
 
@@ -238,7 +238,7 @@ def zone_delegation_comment_remove(args: argparse.Namespace) -> None:
     :param args: argparse.Namespace (zone, delegation)
     """
     client = get_client()
-    zone = client.zone.get_by_name(args.zone, required=True)
+    zone = client.zone.get_by_name(args.zone)
     client.delegation.set_comment(zone, args.delegation, "")
     OutputManager().add_ok(f"Removed comment for {args.delegation}")
 
@@ -261,7 +261,7 @@ def set_ns(args: argparse.Namespace) -> None:
     :param args: argparse.Namespace (zone, ns, force)
     """
     client = get_client()
-    zone = client.zone.get_by_name(args.zone, required=True)
+    zone = client.zone.get_by_name(args.zone)
     client.zone.set_nameservers(zone, args.ns, force=args.force)
     OutputManager().add_ok(f"Updated nameservers for {args.zone}")
 
@@ -329,7 +329,7 @@ def set_soa(args: argparse.Namespace) -> None:
             "At least one of the following must be provided: ns, email, serialno, refresh, retry, expire, soa_ttl"
         )
 
-    zone_obj = client.zone.get_by_name(zone, required=True)
+    zone_obj = client.zone.get_by_name(zone)
     client.zone.update_soa(zone_obj, **kwargs)
     OutputManager().add_ok(f"Updated SOA for {zone}")
 
@@ -349,6 +349,6 @@ def set_default_ttl(args: argparse.Namespace) -> None:
     :param args: argparse.Namespace (zone, ttl)
     """
     client = get_client()
-    zone = client.zone.get_by_name(args.zone, required=True)
+    zone = client.zone.get_by_name(args.zone)
     client.zone.set_default_ttl(zone, args.ttl)
     OutputManager().add_ok(f"Set default TTL for {args.zone}")

--- a/mreg_cli/exceptions.py
+++ b/mreg_cli/exceptions.py
@@ -92,6 +92,10 @@ class EntityOwnershipMismatch(mreg_api.exceptions.EntityOwnershipMismatch):
     """Warning class for an entity that already exists but owned by someone else."""
 
 
+class MultipleEntitiesFound(mreg_api.exceptions.MultipleEntitiesFound):
+    """Multiple entities found when only one was expected."""
+
+
 class InputFailure(mreg_api.exceptions.InputFailure):
     """Warning class for input failure."""
 

--- a/mreg_cli/main.py
+++ b/mreg_cli/main.py
@@ -14,6 +14,7 @@ from rich.panel import Panel
 
 from mreg_cli.__about__ import __version__
 from mreg_cli.cli import cli, get_cli_history, source
+from mreg_cli.client import set_client
 from mreg_cli.config import MregCliConfig
 from mreg_cli.exceptions import CliException, LoginFailedError, handle_exception
 from mreg_cli.log import MregCliLogger
@@ -181,7 +182,6 @@ def main():
         print("mreg url not set in config or as argument")
         return
 
-    # Initialize MregClient singleton with config settings
     client = MregClient(
         url=config.url,
         domain=config.domain,
@@ -193,6 +193,7 @@ def main():
             # other cache settings from config should go here
         ),
     )
+    set_client(client)
     client.events.subscribe(mreg_client_event_hook)
 
     try:

--- a/mreg_cli/main.py
+++ b/mreg_cli/main.py
@@ -6,7 +6,7 @@ import argparse
 import functools
 import logging
 
-from mreg_api import CacheConfig, MregClient
+from mreg_api import MregClient
 from mreg_api.events import Event, EventKind, EventLevel
 from prompt_toolkit.shortcuts import CompleteStyle, PromptSession
 from rich.console import Console, Group
@@ -14,7 +14,7 @@ from rich.panel import Panel
 
 from mreg_cli.__about__ import __version__
 from mreg_cli.cli import cli, get_cli_history, source
-from mreg_cli.client import set_client
+from mreg_cli.client import init_client
 from mreg_cli.config import MregCliConfig
 from mreg_cli.exceptions import CliException, LoginFailedError, handle_exception
 from mreg_cli.log import MregCliLogger
@@ -182,19 +182,7 @@ def main():
         print("mreg url not set in config or as argument")
         return
 
-    client = MregClient(
-        url=config.url,
-        domain=config.domain,
-        timeout=config.http_timeout,
-        user_agent=f"mreg-cli/{__version__}",
-        cache=CacheConfig(
-            enable=config.cache,
-            ttl=config.cache_ttl,
-            # other cache settings from config should go here
-        ),
-    )
-    set_client(client)
-    client.events.subscribe(mreg_client_event_hook)
+    client = bootstrap_client(config)
 
     try:
         try_token_or_login(
@@ -286,7 +274,19 @@ def print_greeting(config: MregCliConfig) -> None:
     console.print()  # blank line
 
 
-def mreg_client_event_hook(event: Event) -> None:
+def bootstrap_client(config: MregCliConfig) -> MregClient:
+    """Configure global client instance and set up event hooks.
+
+    :param config: MregCliConfig object
+    :return: MregClient object
+    """
+    client = init_client(config)
+    client.events.subscribe(_mreg_client_event_hook)
+    # Expand with further per-client config here
+    return client
+
+
+def _mreg_client_event_hook(event: Event) -> None:
     """Event hook for MregClient to record events in the OutputManager."""
     om = OutputManager()
     if om.is_suppressing_events():

--- a/mreg_cli/main.py
+++ b/mreg_cli/main.py
@@ -289,6 +289,9 @@ def print_greeting(config: MregCliConfig) -> None:
 def mreg_client_event_hook(event: Event) -> None:
     """Event hook for MregClient to record events in the OutputManager."""
     om = OutputManager()
+    if om.is_suppressing_events():
+        return
+
     if event.level >= EventLevel.WARNING:
         om.add_warning(event.message)
     elif event.kind == EventKind.MUTATION:

--- a/mreg_cli/output/group.py
+++ b/mreg_cli/output/group.py
@@ -6,6 +6,7 @@ from collections.abc import Sequence
 
 from mreg_api.models import HostGroup
 
+from mreg_cli.client import get_client
 from mreg_cli.output.base import output_timestamps
 from mreg_cli.outputmanager import OutputManager
 
@@ -18,10 +19,11 @@ def output_hostgroup(hostgroup: HostGroup, padding: int = 14) -> None:
     """
     manager = OutputManager()
 
+    client = get_client()
     parents = hostgroup.parent
     inherited: list[str] = []
 
-    for p in hostgroup.get_all_parents():
+    for p in client.hostgroup.list_parents(hostgroup):
         if p.name not in parents:
             inherited.append(p.name)
 
@@ -108,10 +110,11 @@ def _output_members_expanded(hostgroup: HostGroup) -> None:
 
     :param hostgroup: HostGroup whose members to output.
     """
+    client = get_client()
     manager = OutputManager()
     manager.add_formatted_line_with_source("Type", "Name", "Source")
 
-    for parent in hostgroup.get_all_parents():
+    for parent in client.hostgroup.list_parents(hostgroup):
         for host in parent.hosts:
             manager.add_formatted_line_with_source("host", host, parent.name)
 

--- a/mreg_cli/output/history.py
+++ b/mreg_cli/output/history.py
@@ -2,11 +2,9 @@
 
 from __future__ import annotations
 
-from mreg_api.models import Atom, Host, HostGroup, Role
 from mreg_api.models.history import HistoryItem
-from mreg_api.models.models import WithHistory
 
-from mreg_cli.exceptions import InternalError
+from mreg_cli.exceptions import CliWarning, InternalError
 from mreg_cli.outputmanager import OutputManager
 
 
@@ -64,27 +62,45 @@ def _output_history_items(basename: str, items: list[HistoryItem]) -> None:
         _output_object_history(basename, item)
 
 
-def output_history(name: str, obj: type[WithHistory]) -> None:
-    """Output the history for the object."""
-    history = HistoryItem.get(name, obj.history_resource)
-    _output_history_items(name, history)
-
-
 def output_atom_history(name: str) -> None:
     """Output the history for an atom."""
-    output_history(name, Atom)
+    from mreg_cli.client import get_client  # noqa: PLC0415
+
+    client = get_client()
+    history = client.atom.history(name)
+    if not history:
+        raise CliWarning(f"No history found for atom {name!r}.")
+    _output_history_items(name, history)
 
 
 def output_role_history(name: str) -> None:
     """Output the history for a role."""
-    output_history(name, Role)
+    from mreg_cli.client import get_client  # noqa: PLC0415
+
+    client = get_client()
+    history = client.role.history(name)
+    if not history:
+        raise CliWarning(f"No history found for role {name!r}.")
+    _output_history_items(name, history)
 
 
 def output_host_history(name: str) -> None:
     """Output the history for a host."""
-    output_history(name, Host)
+    from mreg_cli.client import get_client  # noqa: PLC0415
+
+    client = get_client()
+    history = client.host.history(name)
+    if not history:
+        raise CliWarning(f"No history found for host {name!r}.")
+    _output_history_items(name, history)
 
 
 def output_hostgroup_history(name: str) -> None:
     """Output the history for a hostgroup."""
-    output_history(name, HostGroup)
+    from mreg_cli.client import get_client  # noqa: PLC0415
+
+    client = get_client()
+    history = client.hostgroup.history(name)
+    if not history:
+        raise CliWarning(f"No history found for hostgroup {name!r}.")
+    _output_history_items(name, history)

--- a/mreg_cli/output/host.py
+++ b/mreg_cli/output/host.py
@@ -6,8 +6,6 @@ from collections.abc import Sequence
 from typing import Literal, NamedTuple
 
 from mreg_api.endpoints import Endpoint
-
-from mreg_cli.client import get_client
 from mreg_api.models import (
     CNAME,
     MX,
@@ -18,7 +16,6 @@ from mreg_api.models import (
     Community,
     HInfo,
     Host,
-    HostList,
     IPAddress,
     Location,
     Network,
@@ -26,6 +23,7 @@ from mreg_api.models import (
     Srv,
 )
 
+from mreg_cli.client import get_client
 from mreg_cli.exceptions import EntityNotFound
 from mreg_cli.output.base import output_timestamps, output_ttl
 from mreg_cli.outputmanager import OutputManager

--- a/mreg_cli/output/host.py
+++ b/mreg_cli/output/host.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import Literal, NamedTuple
 
-from mreg_api import MregClient
 from mreg_api.endpoints import Endpoint
+
+from mreg_cli.client import get_client
 from mreg_api.models import (
     CNAME,
     MX,
@@ -84,8 +85,9 @@ def output_host(
 
     output_roles(host.roles, padding=padding)
 
+    client = get_client()
     if traverse_hostgroups:
-        hostgroups = host.get_hostgroups(traverse=True)
+        hostgroups = client.hostgroup.list_by_host(host, traverse=True)
     else:
         hostgroups = host.hostgroups
     output_hostgroups(hostgroups, padding=padding)
@@ -168,7 +170,8 @@ def output_host_networks(
     :param padding: Number of spaces for left-padding the output.
     :param only: If 4, only output IPv4; if 6, only output IPv6.
     """
-    networks = host.networks()
+    client = get_client()
+    networks = client.host.networks(host)
     if not networks:
         return
 
@@ -202,7 +205,9 @@ def output_host_networks(
         ip_to_community: dict[IPAddress, Community] = {}
         if host.communities:
             for com in host.communities:
-                ip = host.get_ip_by_id(com.ipaddress)
+                ip = next((i for i in host.ipaddresses if i.id == com.ipaddress), None)
+                if ip is None:
+                    continue
                 ip = IPAddress.model_validate(ip, from_attributes=True)
 
                 if ip:
@@ -337,7 +342,7 @@ def output_ipaddress(
 
     name = ""
     if names:
-        host = Host.get_by_id(ip.host)
+        host = get_client().host.get_by_id(ip.host)
         name = host.name if host else "<Not found>"
 
     OutputManager().add_line(f"{name:<{len_names}}{ip_str:<{len_ip}}{mac}")
@@ -412,10 +417,9 @@ def output_cname(
     """
     if host:
         hostname = host.name
-    elif actual_host := cname.resolve_host():
-        hostname = actual_host.name
     else:
-        hostname = "<Not found>"
+        actual_host = get_client().host.get_by_id(cname.host)
+        hostname = actual_host.name if actual_host else "<Not found>"
     OutputManager().add_line(f"{'Cname:':<{padding}}{cname.name} -> {hostname}")
 
 
@@ -562,7 +566,7 @@ def output_srv(
     if host_id_name_map and srv.host in host_id_name_map:
         host_name = host_id_name_map[srv.host]
     elif not host_id_name_map or srv.host not in host_id_name_map:
-        host = srv.resolve_host()
+        host = get_client().host.get_by_id(srv.host)
         if host:
             host_name = host.name
 
@@ -594,7 +598,7 @@ def output_srvs(srvs: Sequence[Srv], padding: int = 14) -> None:
 
     # FIXME: refactor to not require Endpoint! API library should handle this
     # Surely we can use some variant of `Host.get_list_by_id`?
-    host_data = MregClient().get_list_in(Endpoint.Hosts, "id", list(host_ids))
+    host_data = get_client().get_list_in(Endpoint.Hosts, "id", list(host_ids))
     hosts = [Host.model_validate(host) for host in host_data]
 
     host_id_name_map = {host.id: str(host.name) for host in hosts}
@@ -621,7 +625,7 @@ def output_ptr_override(ptr: PTR_override, padding: int = 14) -> None:
     :param ptr: PTR override to output.
     :param padding: Number of spaces for left-padding the output.
     """
-    host = ptr.resolve_host()
+    host = get_client().host.get_by_id(ptr.host)
     hostname = host.name if host else "<Not found>"
     OutputManager().add_line(f"{'PTR override:':<{padding}}{ptr.ipaddress} -> {hostname}")
 

--- a/mreg_cli/output/host.py
+++ b/mreg_cli/output/host.py
@@ -112,13 +112,15 @@ def output_hosts(
             OutputManager().add_line("")
 
 
-def output_hostlist(hostlist: HostList) -> None:
-    """Output a list of hosts to the console.
+# NOTE: we used to distinguish between `list[Host]` and `HostList`
+# this is no longer the case. No client methods return `HostList` anymore.
+def output_hostlist(hostlist: list[Host]) -> None:
+    """Output a table of hosts, showing only the most relevant info.
 
-    :param hostlist: HostList object containing hosts to output.
+    :param hostlist: List of Host objects to output.
     :raises EntityNotFound: If no hosts are found.
     """
-    if not hostlist.results:
+    if not hostlist:
         raise EntityNotFound("No hosts found.")
 
     max_name = max_contacts = max_ips = 20
@@ -131,12 +133,12 @@ def output_hostlist(hostlist: HostList) -> None:
 
     hosts = [
         HostOutput(
-            name=str(i.name),
-            contacts=", ".join(i.contact_emails),
-            comment=i.comment or "",
-            ips=", ".join(str(ip.ipaddress) for ip in i.ipaddresses),
+            name=str(host.name),
+            contacts=", ".join(host.contact_emails),
+            comment=host.comment or "",
+            ips=", ".join(str(ip.ipaddress) for ip in host.ipaddresses),
         )
-        for i in hostlist.results
+        for host in hostlist
     ]
     max_name = max(max_name, max(len(host.name) for host in hosts))
     max_contacts = max(max_contacts, max(len(host.contacts) for host in hosts))
@@ -625,6 +627,8 @@ def output_ptr_override(ptr: PTR_override, padding: int = 14) -> None:
     :param ptr: PTR override to output.
     :param padding: Number of spaces for left-padding the output.
     """
+    # FIXME: surely the ptr.host is the host we got the PTR override from in `ptr_show`?
+    # We should pass in the host object to avoid this extra lookup.
     host = get_client().host.get_by_id(ptr.host)
     hostname = host.name if host else "<Not found>"
     OutputManager().add_line(f"{'PTR override:':<{padding}}{ptr.ipaddress} -> {hostname}")

--- a/mreg_cli/output/network.py
+++ b/mreg_cli/output/network.py
@@ -75,7 +75,10 @@ def output_network(network: Network, padding: int = 25) -> None:
         fmt("Excluded ranges:", f"{excluded_ips} ipaddresses")
         output_network_excluded_ranges(network.excluded_ranges, padding=padding)
     fmt("Used addresses:", client.network.get_used_count(network))
-    fmt("Unused addresses:", f"{client.network.get_unused_count(network)} (excluding reserved adr.)")
+    fmt(
+        "Unused addresses:",
+        f"{client.network.get_unused_count(network)} (excluding reserved adr.)",
+    )
 
 
 def output_networks(

--- a/mreg_cli/output/network.py
+++ b/mreg_cli/output/network.py
@@ -15,6 +15,7 @@ from mreg_api.models import (
 )
 
 from mreg_cli.choices import CommunitySortOrder
+from mreg_cli.client import get_client
 from mreg_cli.output.base import output_timestamps
 from mreg_cli.outputmanager import OutputManager
 
@@ -34,8 +35,9 @@ def output_network(network: Network, padding: int = 25) -> None:
     def fmt(label: str, value: Any) -> None:
         manager.add_line(f"{label:<{padding}}{value}")
 
+    client = get_client()
     ipnet = NetworkOrIP.parse_or_raise(network.network, mode="network")
-    reserved_ips = network.get_reserved_ips()
+    reserved_ips = client.network.get_reserved_ips(network)
     # Remove network address and broadcast address from reserved IPs
     reserved_ips_filtered = [
         ip for ip in reserved_ips if ip not in (ipnet.network_address, ipnet.broadcast_address)
@@ -72,8 +74,8 @@ def output_network(network: Network, padding: int = 25) -> None:
             excluded_ips += ex_range.excluded_ips()
         fmt("Excluded ranges:", f"{excluded_ips} ipaddresses")
         output_network_excluded_ranges(network.excluded_ranges, padding=padding)
-    fmt("Used addresses:", network.get_used_count())
-    fmt("Unused addresses:", f"{network.get_unused_count()} (excluding reserved adr.)")
+    fmt("Used addresses:", client.network.get_used_count(network))
+    fmt("Unused addresses:", f"{client.network.get_unused_count(network)} (excluding reserved adr.)")
 
 
 def output_networks(
@@ -97,7 +99,8 @@ def output_network_unused_addresses(network: Network, padding: int = 25) -> None
     :param network: Network whose unused addresses to output.
     :param padding: Number of spaces for left-padding the output.
     """
-    unused = network.get_unused_list()
+    client = get_client()
+    unused = client.network.get_unused_list(network)
 
     manager = OutputManager()
     if not unused:
@@ -114,8 +117,9 @@ def output_network_used_addresses(network: Network, padding: int = 46) -> None:
     :param network: Network whose used addresses to output.
     :param padding: Width for the IP address column (46 for IPv6 max length).
     """
-    used = network.get_used_host_list()
-    ptr_overrides = network.get_ptroverride_host_list()
+    client = get_client()
+    used = client.network.get_used_host_list(network)
+    ptr_overrides = client.network.get_ptroverride_host_list(network)
     ips = set(list(used.keys()) + list(ptr_overrides.keys()))
     ips_sorted = sorted(ips, key=ipaddress.ip_address)
 
@@ -231,7 +235,8 @@ def output_network_policy(policy: NetworkPolicy) -> None:
         for attribute in policy.attributes:
             manager.add_line(f" {attribute.name}: {attribute.value}")
 
-    networks = policy.networks()
+    client = get_client()
+    networks = client.networkpolicy.networks(policy)
     if networks:
         manager.add_line("Networks:")
         for network in networks:

--- a/mreg_cli/output/policy.py
+++ b/mreg_cli/output/policy.py
@@ -7,6 +7,7 @@ from collections.abc import Sequence
 from mreg_api.models import Atom, Label, Permission, Role
 from pydantic import BaseModel
 
+from mreg_cli.client import get_client
 from mreg_cli.output.base import output_timestamps
 from mreg_cli.outputmanager import OutputManager
 
@@ -46,10 +47,11 @@ def output_role(role: Role, padding: int = 14) -> None:
     output_timestamps(role)
     manager.add_line(f"{'Description:':<{padding}}{role.description}")
 
+    client = get_client()
     manager.add_line("Atom members:")
     for atom in role.atoms:
         manager.add_formatted_line("", atom, padding)
-    labels = role.get_labels()
+    labels = client.role.get_labels(role)
     manager.add_line("Labels:")
     for label in labels:
         manager.add_formatted_line("", label.name, padding)
@@ -92,9 +94,10 @@ def output_roles_table(roles: Sequence[Role], padding: int = 14) -> None:
         description: str
         labels: str
 
+    client = get_client()
     rows: list[RoleTableRow] = []
     for role in roles:
-        labels = role.get_labels()
+        labels = client.role.get_labels(role)
         row = RoleTableRow(
             name=role.name,
             description=role.description,
@@ -221,14 +224,15 @@ def output_label(label: Label, padding: int = 14) -> None:
     manager.add_line(f"{'Description:':<{padding}}{label.description}")
     manager.add_line("Roles with this label:")
 
-    roles = Role.get_list_by_field("labels", label.id)
+    client = get_client()
+    roles = client.role.list(labels=label.id)
     if roles:
         for role in roles:
             manager.add_line(f"{'':<{short_padding}}{role.name}")
     else:
         manager.add_line(f"{'None':<{short_padding}}")
 
-    permission_list = Permission.get_list_by_field("labels", label.id)
+    permission_list = client.permission.list(labels=label.id)
 
     manager.add_line("Permissions with this label:")
     if permission_list:

--- a/mreg_cli/output/zone.py
+++ b/mreg_cli/output/zone.py
@@ -6,6 +6,7 @@ from collections.abc import Sequence
 
 from mreg_api.models import ForwardZone, NameServer, ReverseZone, Zone
 
+from mreg_cli.client import get_client
 from mreg_cli.output.base import output_ttl
 from mreg_cli.outputmanager import OutputManager
 
@@ -76,7 +77,8 @@ def output_delegations(zone: Zone, padding: int = 20) -> None:
     :param zone: Zone whose delegations to output.
     :param padding: Number of spaces for left-padding the output.
     """
-    delegations = zone.get_delegations()
+    client = get_client()
+    delegations = client.delegation.list_by_zone(zone)
 
     manager = OutputManager()
     if not delegations:

--- a/mreg_cli/outputmanager.py
+++ b/mreg_cli/outputmanager.py
@@ -8,12 +8,12 @@ command.
 from __future__ import annotations
 
 import atexit
-from contextlib import contextmanager
 import datetime
 import json
 import logging
 import re
 from collections.abc import Iterable
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Generator, Literal, overload
 from urllib.parse import urlencode, urlparse

--- a/mreg_cli/outputmanager.py
+++ b/mreg_cli/outputmanager.py
@@ -165,6 +165,7 @@ class OutputManager:
     @contextmanager
     def suppress_events(self) -> Generator[None, None, None]:
         """Context manager to suppress events."""
+        # NOTE: could expand this with a list of event types to suppress!
         self._suppressing_events = True
         try:
             yield

--- a/mreg_cli/outputmanager.py
+++ b/mreg_cli/outputmanager.py
@@ -8,13 +8,14 @@ command.
 from __future__ import annotations
 
 import atexit
+from contextlib import contextmanager
 import datetime
 import json
 import logging
 import re
 from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Literal, overload
+from typing import Any, Generator, Literal, overload
 from urllib.parse import urlencode, urlparse
 
 import httpx
@@ -127,6 +128,7 @@ class OutputManager:
         "serialno",
         "create_date",
     ]
+    _suppressing_events: bool = False
 
     def __new__(cls):
         """Create a new instance of the class, or return the existing one."""
@@ -159,6 +161,19 @@ class OutputManager:
         self._recording: bool = False
         self._file: Path | None = None
         self._record_timestamps: bool = True
+
+    @contextmanager
+    def suppress_events(self) -> Generator[None, None, None]:
+        """Context manager to suppress events."""
+        self._suppressing_events = True
+        try:
+            yield
+        finally:
+            self._suppressing_events = False
+
+    def is_suppressing_events(self) -> bool:
+        """Return True if MregClient events should be suppressed."""
+        return self._suppressing_events
 
     def record_timestamps(self, state: bool) -> None:
         """Set whether to record timestamps in the recording.

--- a/mreg_cli/types.py
+++ b/mreg_cli/types.py
@@ -75,6 +75,7 @@ class Flag:
         required: bool = False,
         metavar: str | None = None,
         action: str | None = None,
+        hidden: bool = False,
     ):
         """Initialize a Flag object."""
         self.name = name
@@ -87,6 +88,7 @@ class Flag:
         self.required = required
         self.metavar = metavar
         self.action = action
+        self.hidden = hidden
 
 
 class Command(NamedTuple):

--- a/mreg_cli/types.py
+++ b/mreg_cli/types.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import argparse
 import logging
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, MutableMapping, Sequence
 from enum import StrEnum
 from functools import lru_cache
 from typing import (
@@ -56,7 +56,7 @@ NargsType = int | NargsStr
 
 
 Json = mreg_api.types.Json
-JsonMapping = mreg_api.types.JsonMapping
+JsonMapping = MutableMapping[str, Json]
 QueryParams = mreg_api.types.QueryParams
 
 

--- a/mreg_cli/utilities/api.py
+++ b/mreg_cli/utilities/api.py
@@ -13,9 +13,9 @@ from urllib.parse import urljoin
 
 import httpx
 import mreg_api
-from mreg_api import MregClient
 from prompt_toolkit import prompt
 
+from mreg_cli.client import get_client
 from mreg_cli.config import MregCliConfig
 from mreg_cli.exceptions import CliError, LoginFailedError
 from mreg_cli.tokenfile import TokenFile
@@ -32,7 +32,7 @@ def disable_cache(func: Callable[P, T]) -> Callable[P, T]:
 
     @functools.wraps(func)
     def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
-        with MregClient().caching(enable=False):
+        with get_client().caching(enable=False):
             return func(*args, **kwargs)
 
     return wrapper
@@ -51,7 +51,7 @@ def try_token_or_login(user: str, url: str, fail_without_token: bool = False) ->
     :returns: Nothing.
     """
     token = TokenFile.get_entry(user, url)
-    client = MregClient()
+    client = get_client()
 
     if token and token.token:
         client.set_token(token.token)
@@ -109,7 +109,7 @@ def prompt_for_password_and_try_update_token() -> None:
 
 def auth_and_update_token(username: str, password: str) -> None:
     """Perform the actual token update."""
-    client = MregClient()
+    client = get_client()
 
     base_url = MregCliConfig().url
     tokenurl = urljoin(base_url, "/api/token-auth/")

--- a/mreg_cli/utilities/resolution.py
+++ b/mreg_cli/utilities/resolution.py
@@ -1,0 +1,208 @@
+"""Host, network, and policy resolution helpers for mreg-cli.
+
+These replace the old get_by_any_means* class methods that lived on the mreg_api models.
+The CLI is responsible for composing the heuristic lookup chain.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal, overload
+
+from mreg_api import MregClient
+from mreg_api.exceptions import EntityNotFound
+from mreg_api.models import Atom, Host, Network, Role
+
+from mreg_cli.exceptions import EntityNotFound as CliEntityNotFound
+
+if TYPE_CHECKING:
+    pass
+
+
+@overload
+def resolve_host(
+    client: MregClient,
+    identifier: str | int,
+    *,
+    required: Literal[False],
+    inform_if_cname: bool = ...,
+) -> Host | None: ...
+
+
+@overload
+def resolve_host(
+    client: MregClient,
+    identifier: str | int,
+    *,
+    required: Literal[True] = ...,
+    inform_if_cname: bool = ...,
+) -> Host: ...
+
+
+@overload
+def resolve_host(
+    client: MregClient,
+    identifier: str | int,
+    *,
+    required: bool = ...,
+    inform_if_cname: bool = ...,
+) -> Host | None: ...
+
+
+def resolve_host(
+    client: MregClient,
+    identifier: str | int,
+    *,
+    required: bool = True,
+    inform_if_cname: bool = False,
+) -> Host | None:
+    """Resolve a host by id, IP, MAC, name, or CNAME target.
+
+    Replaces Host.get_by_any_means() / get_by_any_means_or_raise().
+
+    Resolution order: numeric id → IP → MAC → name → CNAME target.
+    """
+    from mreg_cli.outputmanager import OutputManager
+
+    if isinstance(identifier, int):
+        host = client.host.get_by_id(identifier)
+        if host is not None:
+            return host
+    else:
+        ident_str = str(identifier)
+        for getter in [
+            lambda s: client.host.get_by_ip(s),
+            lambda s: client.host.get_by_mac(s),
+            lambda s: client.host.get_by_name(s),
+        ]:
+            try:
+                host = getter(ident_str)
+                if host is not None:
+                    return host
+            except Exception:
+                continue
+
+        # Fall back to CNAME
+        cname = client.cname.get_by_name(ident_str)
+        if cname is not None:
+            host = client.host.get_by_id(cname.host)
+            if host is not None:
+                if inform_if_cname:
+                    OutputManager().add_line(f"{ident_str!r} is a CNAME for {host.name!r}")
+                return host
+
+    if required:
+        raise CliEntityNotFound(f"Host {identifier!r} not found.")
+    return None
+
+
+@overload
+def resolve_network(
+    client: MregClient,
+    identifier: str,
+    *,
+    required: Literal[False],
+) -> Network | None: ...
+
+
+@overload
+def resolve_network(
+    client: MregClient,
+    identifier: str,
+    *,
+    required: Literal[True] = ...,
+) -> Network: ...
+
+
+@overload
+def resolve_network(
+    client: MregClient,
+    identifier: str,
+    *,
+    required: bool = ...,
+) -> Network | None: ...
+
+
+def resolve_network(
+    client: MregClient,
+    identifier: str,
+    *,
+    required: bool = True,
+) -> Network | None:
+    """Resolve a network by IP address, CIDR notation, or numeric id.
+
+    Replaces Network.get_by_any_means() / get_by_any_means_or_raise().
+    """
+    from mreg_cli.exceptions import EntityNotFound as CliEntityNotFound
+
+    network: Network | None = None
+    try:
+        # Try as IP first
+        network = client.network.get_by_ip(identifier)
+    except Exception:
+        pass
+
+    if network is None:
+        try:
+            # Try as CIDR / network address
+            network = client.network.get(identifier)
+        except Exception:
+            pass
+
+    if network is None and identifier.isdigit():
+        try:
+            network = client.network.first(id=int(identifier))
+        except Exception:
+            pass
+
+    if network is None and required:
+        raise CliEntityNotFound(f"Network {identifier!r} not found.")
+    return network
+
+
+@overload
+def resolve_policy(
+    client: MregClient,
+    name: str,
+    *,
+    required: Literal[False],
+) -> Atom | Role | None: ...
+
+
+@overload
+def resolve_policy(
+    client: MregClient,
+    name: str,
+    *,
+    required: Literal[True] = ...,
+) -> Atom | Role: ...
+
+
+@overload
+def resolve_policy(
+    client: MregClient,
+    name: str,
+    *,
+    required: bool = ...,
+) -> Atom | Role | None: ...
+
+
+def resolve_policy(
+    client: MregClient,
+    name: str,
+    *,
+    required: bool = True,
+) -> Atom | Role | None:
+    """Resolve a host policy name to an Atom or Role.
+
+    Replaces HostPolicy.get_role_or_atom_or_raise().
+    Atom is checked first (old order).
+    """
+    atom = client.atom.get_by_name(name)
+    if atom is not None:
+        return atom
+    role = client.role.get_by_name(name)
+    if role is not None:
+        return role
+    if required:
+        raise CliEntityNotFound(f"No atom or role named {name!r}.")
+    return None

--- a/mreg_cli/utilities/resolution.py
+++ b/mreg_cli/utilities/resolution.py
@@ -70,8 +70,8 @@ def resolve_host(
     getters: list[Callable[[str], Host | None]] = []
     ident_str = str(identifier)
 
-    # Try by ID first if the identifier is a digit
-    if ident_str.isdigit():
+    # Try by ID first if the identifier is a decimal number
+    if ident_str.isdecimal():
         getters.append(lambda s: client.host.get_by_id(int(s), required=False))
 
     # Try by IP → MAC → name

--- a/mreg_cli/utilities/resolution.py
+++ b/mreg_cli/utilities/resolution.py
@@ -7,7 +7,7 @@ The CLI is responsible for composing the heuristic lookup chain.
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Literal, Protocol, overload
+from typing import TYPE_CHECKING, Literal, overload
 
 from mreg_api import MregClient
 from mreg_api.models import Atom, Host, Network, Role

--- a/mreg_cli/utilities/resolution.py
+++ b/mreg_cli/utilities/resolution.py
@@ -7,7 +7,7 @@ The CLI is responsible for composing the heuristic lookup chain.
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Literal, overload
+from typing import TYPE_CHECKING, Literal, Protocol, overload
 
 from mreg_api import MregClient
 from mreg_api.models import Atom, Host, Network, Role
@@ -72,14 +72,14 @@ def resolve_host(
 
     # Try by ID first if the identifier is a digit
     if ident_str.isdigit():
-        getters.append(lambda s: client.host.get_by_id(int(s)))
+        getters.append(lambda s: client.host.get_by_id(int(s), required=False))
 
     # Try by IP → MAC → name
     getters.extend(
         [
-            client.host.get_by_ip,
-            client.host.get_by_mac,
-            client.host.get_by_name,
+            lambda s: client.host.get_by_ip(s, required=False),
+            lambda s: client.host.get_by_mac(s, required=False),
+            lambda s: client.host.get_by_name(s, required=False),
         ]
     )
 
@@ -92,9 +92,9 @@ def resolve_host(
             pass
 
     # Fall back to CNAME
-    cname = client.cname.get_by_name(ident_str)
+    cname = client.cname.get_by_name(ident_str, required=False)
     if cname is not None:
-        host = client.host.get_by_id(cname.host)
+        host = client.host.get_by_id(cname.host, required=False)
         # NOTE: should it be an error if CNAME has host ID that doesn't exist? Probably.
         # At the very least produce a warning if CNAME host ID cannot be resolved.
         if host is not None:
@@ -150,20 +150,21 @@ def resolve_network(
     network: Network | None = None
     try:
         # Try as IP first
-        network = client.network.get_by_ip(identifier)
+        network = client.network.get_by_ip(identifier, required=False)
     except Exception:
         pass
 
     if network is None:
         try:
             # Try as CIDR / network address
-            network = client.network.get(identifier)
+            network = client.network.get(identifier, required=False)
         except Exception:
             pass
 
     if network is None and identifier.isdigit():
         try:
-            network = client.network.first(id=int(identifier))
+            network = client.network.first(id=int(identifier), required=False)
+            # network = client.network.get(int(identifier), required=False)
         except Exception:
             pass
 
@@ -210,10 +211,10 @@ def resolve_policy(
     Replaces HostPolicy.get_role_or_atom_or_raise().
     Atom is checked first (old order).
     """
-    atom = client.atom.get_by_name(name)
+    atom = client.atom.get_by_name(name, required=False)
     if atom is not None:
         return atom
-    role = client.role.get_by_name(name)
+    role = client.role.get_by_name(name, required=False)
     if role is not None:
         return role
     if required:

--- a/mreg_cli/utilities/resolution.py
+++ b/mreg_cli/utilities/resolution.py
@@ -6,10 +6,10 @@ The CLI is responsible for composing the heuristic lookup chain.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Literal, overload
 
 from mreg_api import MregClient
-from mreg_api.exceptions import EntityNotFound
 from mreg_api.models import Atom, Host, Network, Role
 
 from mreg_cli.exceptions import EntityNotFound as CliEntityNotFound
@@ -63,35 +63,48 @@ def resolve_host(
     """
     from mreg_cli.outputmanager import OutputManager
 
+    # We got passed an integer, assume host ID
     if isinstance(identifier, int):
-        host = client.host.get_by_id(identifier)
-        if host is not None:
-            return host
-    else:
-        ident_str = str(identifier)
-        for getter in [
-            lambda s: client.host.get_by_ip(s),
-            lambda s: client.host.get_by_mac(s),
-            lambda s: client.host.get_by_name(s),
-        ]:
-            try:
-                host = getter(ident_str)
-                if host is not None:
-                    return host
-            except Exception:
-                continue
+        return client.host.get_by_id(identifier, required=required)
 
-        # Fall back to CNAME
-        cname = client.cname.get_by_name(ident_str)
-        if cname is not None:
-            host = client.host.get_by_id(cname.host)
+    getters: list[Callable[[str], Host | None]] = []
+    ident_str = str(identifier)
+
+    # Try by ID first if the identifier is a digit
+    if ident_str.isdigit():
+        getters.append(lambda s: client.host.get_by_id(int(s)))
+
+    # Try by IP → MAC → name
+    getters.extend(
+        [
+            client.host.get_by_ip,
+            client.host.get_by_mac,
+            client.host.get_by_name,
+        ]
+    )
+
+    for getter in getters:
+        try:
+            host = getter(ident_str)
             if host is not None:
-                if inform_if_cname:
-                    OutputManager().add_line(f"{ident_str!r} is a CNAME for {host.name!r}")
                 return host
+        except Exception:
+            pass
+
+    # Fall back to CNAME
+    cname = client.cname.get_by_name(ident_str)
+    if cname is not None:
+        host = client.host.get_by_id(cname.host)
+        # NOTE: should it be an error if CNAME has host ID that doesn't exist? Probably.
+        # At the very least produce a warning if CNAME host ID cannot be resolved.
+        if host is not None:
+            if inform_if_cname:
+                OutputManager().add_line(f"{ident_str!r} is a CNAME for {host.name!r}")
+            return host
 
     if required:
         raise CliEntityNotFound(f"Host {identifier!r} not found.")
+
     return None
 
 

--- a/mreg_cli/utilities/shared.py
+++ b/mreg_cli/utilities/shared.py
@@ -12,7 +12,7 @@ def string_to_int(value: Any, error_tag: str) -> int:
     try:
         return int(value)
     except ValueError as e:
-        raise InputFailure("%s: Not a valid integer" % error_tag) from e
+        raise InputFailure(f"{error_tag}: Not a valid integer") from e
 
 
 def convert_wildcard_to_regex(

--- a/mreg_cli/utilities/shared.py
+++ b/mreg_cli/utilities/shared.py
@@ -12,7 +12,7 @@ def string_to_int(value: Any, error_tag: str) -> int:
     try:
         return int(value)
     except ValueError as e:
-        raise InputFailure(f"{error_tag}: Not a valid integer") from e
+        raise InputFailure(f"{error_tag}: Not a valid integer: {value!r}") from e
 
 
 def convert_wildcard_to_regex(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -236,3 +236,4 @@ version_file = "mreg_cli/_version.py"
 # is not up to date with most recent mreg-api git main commit.
 [tool.uv.sources]
 mreg-api = { git = "https://github.com/unioslo/mreg-api", branch = "remove-singleton-pattern" }
+# mreg-api = { path = "/Users/pederhan/repos/mreg-api", editable = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "platformdirs>=4.3.0",
     "pydantic-settings>=2.10.1",
     "rich>=13.9.4",
-    "mreg-api>=0.2.4,<0.4.0",      # prevent breaking changes in pre-1.0.0 minor versions
+    "mreg-api>=0.3.0,<0.4.0",      # prevent breaking changes in pre-1.0.0 minor versions
 ]
 dynamic = ["version"]
 
@@ -234,5 +234,5 @@ version_file = "mreg_cli/_version.py"
 
 # Uncomment to activate git installation for local development if PyPI version
 # is not up to date with most recent mreg-api git main commit.
-[tool.uv.sources]
-mreg-api = { git = "https://github.com/unioslo/mreg-api", branch = "main" }
+# [tool.uv.sources]
+# mreg-api = { git = "https://github.com/unioslo/mreg-api", branch = "main" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "platformdirs>=4.3.0",
     "pydantic-settings>=2.10.1",
     "rich>=13.9.4",
-    "mreg-api>=0.2.0,<0.3.0",      # prevent breaking changes in pre-1.0.0 minor versions
+    "mreg-api>=0.2.4,<0.4.0",      # prevent breaking changes in pre-1.0.0 minor versions
 ]
 dynamic = ["version"]
 
@@ -234,5 +234,5 @@ version_file = "mreg_cli/_version.py"
 
 # Uncomment to activate git installation for local development if PyPI version
 # is not up to date with most recent mreg-api git main commit.
-# [tool.uv.sources]
-# mreg-api = { git = "https://github.com/unioslo/mreg-api" }
+[tool.uv.sources]
+mreg-api = { git = "https://github.com/unioslo/mreg-api", branch = "remove-singleton-pattern" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -235,5 +235,4 @@ version_file = "mreg_cli/_version.py"
 # Uncomment to activate git installation for local development if PyPI version
 # is not up to date with most recent mreg-api git main commit.
 [tool.uv.sources]
-mreg-api = { git = "https://github.com/unioslo/mreg-api", branch = "remove-singleton-pattern" }
-# mreg-api = { path = "/Users/pederhan/repos/mreg-api", editable = true }
+mreg-api = { git = "https://github.com/unioslo/mreg-api", branch = "main" }

--- a/tests/api/test_client.py
+++ b/tests/api/test_client.py
@@ -11,7 +11,7 @@ def test_client_cache_readonly_fs_dir() -> None:
     """Test that client caching handles read-only filesystem gracefully (with directory arg)."""
     with patch("os.makedirs") as mock_makedirs:
         mock_makedirs.side_effect = PermissionError("Read-only directory")
-        client = MregClient(cache=CacheConfig(enable=True, directory="/readonly/path"))
+        client = MregClient(url="https://mreg.example.com", cache=CacheConfig(enable=True, directory="/readonly/path"))
     assert not client.cache.is_enabled
     assert client.cache._cache is None  # pyright: ignore[reportPrivateUsage]
 
@@ -20,7 +20,7 @@ def test_client_cache_readonly_fs_no_dir() -> None:
     """Test that client caching handles read-only filesystem gracefully."""
     with patch("tempfile.mkdtemp") as mock_mkdtemp:
         mock_mkdtemp.side_effect = PermissionError("Read-only directory")
-        client = MregClient(cache=CacheConfig(enable=True))
+        client = MregClient(url="https://mreg.example.com", cache=CacheConfig(enable=True))
     assert not client.cache.is_enabled
     assert client.cache._cache is None  # pyright: ignore[reportPrivateUsage]
 
@@ -28,6 +28,6 @@ def test_client_cache_readonly_fs_no_dir() -> None:
 def test_client_cache_default_enabled() -> None:
     """Test that client caching is enabled by default."""
     cliconf = MregCliConfig()
-    client = MregClient(cache=CacheConfig(enable=cliconf.cache))
+    client = MregClient(url="https://mreg.example.com", cache=CacheConfig(enable=cliconf.cache))
     assert client.cache.is_enabled
     assert client.cache._cache is not None  # pyright: ignore[reportPrivateUsage

--- a/tests/commands/test_host.py
+++ b/tests/commands/test_host.py
@@ -215,7 +215,7 @@ def test_host_add_payload_omits_empty_contacts() -> None:
 
     assert payload == {
         "name": "foo.example.org",
-        "comment": None,
+        "comment": "",
     }
 
 
@@ -229,6 +229,6 @@ def test_host_add_payload_includes_supplied_contacts() -> None:
 
     assert payload == {
         "name": "foo.example.org",
-        "comment": None,
+        "comment": "",
         "contacts": ["foo@example.org", "bar@example.org"],
     }

--- a/tests/commands/test_host.py
+++ b/tests/commands/test_host.py
@@ -169,7 +169,7 @@ def test_get_record_identifier_unknown() -> None:
         ttl=3600,
     )
     assert get_record_identifier(record) == snapshot(  # pyright: ignore[reportArgumentType]
-        "SSHFP(host=123, created_at=datetime.datetime(2026, 1, 1, 0, 0), updated_at=datetime.datetime(2026, 1, 1, 0, 0), id=1, algorithm=1, hash_type=2, fingerprint='abc123', ttl=3600)"
+        "SSHFP(created_at=datetime.datetime(2026, 1, 1, 0, 0), updated_at=datetime.datetime(2026, 1, 1, 0, 0), id=1, algorithm=1, hash_type=2, fingerprint='abc123', host=123, ttl=3600)"
     )
 
 

--- a/tests/commands/test_network.py
+++ b/tests/commands/test_network.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import datetime
+from ipaddress import IPv4Address
+
+import pytest
+from mreg_api.models import Community, Host, HostCommunity, IPAddress
+from mreg_api.models.fields import HostName
+
+from mreg_cli.commands.network import _get_host_community_and_ip_to_remove
+
+DT = datetime.datetime(2026, 1, 1)
+
+
+def make_community(id_: int, name: str) -> Community:
+    """Build a Community for testing."""
+    return Community(
+        id=id_,
+        name=name,
+        description="",
+        network=1,
+        created_at=DT,
+        updated_at=DT,
+    )
+
+
+def make_ip(id_: int, ipaddress: str, host: int = 123) -> IPAddress:
+    """Build an IPAddress for testing."""
+    return IPAddress(
+        id=id_,
+        ipaddress=IPv4Address(ipaddress),
+        host=host,
+        created_at=DT,
+        updated_at=DT,
+    )
+
+
+def make_host(ipaddresses: list[IPAddress], communities: list[HostCommunity]) -> Host:
+    """Build a Host for testing."""
+    return Host(
+        id=123,
+        name=HostName("testhost.example.com"),
+        comment="",
+        ipaddresses=ipaddresses,
+        communities=communities,
+        created_at=DT,
+        updated_at=DT,
+    )
+
+
+# Shared fixtures for the parametrized cases
+IP1 = make_ip(1, "10.0.0.1")
+IP2 = make_ip(2, "10.0.0.2")
+RED = make_community(1, "red")
+BLUE = make_community(2, "blue")
+
+
+@pytest.mark.parametrize(
+    "communities,ipaddresses,community_name,ip,expected_ip_id",
+    [
+        # Single association, no IP arg -> OK, returns that association
+        pytest.param(
+            [HostCommunity(ipaddress=1, community=RED)],
+            [IP1, IP2],
+            "red",
+            None,
+            1,
+            id="single-assoc-no-ip",
+        ),
+        # Single association, correct IP arg -> OK
+        pytest.param(
+            [HostCommunity(ipaddress=1, community=RED)],
+            [IP1, IP2],
+            "red",
+            "10.0.0.1",
+            1,
+            id="single-assoc-with-ip",
+        ),
+        # Community name match is case-insensitive
+        pytest.param(
+            [HostCommunity(ipaddress=1, community=RED)],
+            [IP1, IP2],
+            "RED",
+            None,
+            1,
+            id="single-assoc-casefold",
+        ),
+        # Multiple associations, IP arg disambiguates -> OK
+        pytest.param(
+            [
+                HostCommunity(ipaddress=1, community=RED),
+                HostCommunity(ipaddress=2, community=RED),
+            ],
+            [IP1, IP2],
+            "red",
+            "10.0.0.2",
+            2,
+            id="multi-assoc-with-ip",
+        ),
+        # Zero associations (host not in community) -> EntityNotFound
+        pytest.param(
+            [HostCommunity(ipaddress=1, community=BLUE)],
+            [IP1, IP2],
+            "red",
+            None,
+            None,
+            id="zero-assoc",
+            marks=pytest.mark.xfail(strict=True, reason="EntityNotFound: not in community"),
+        ),
+        # Multiple associations, no IP arg -> InputFailure (ambiguous)
+        pytest.param(
+            [
+                HostCommunity(ipaddress=1, community=RED),
+                HostCommunity(ipaddress=2, community=RED),
+            ],
+            [IP1, IP2],
+            "red",
+            None,
+            None,
+            id="multi-assoc-no-ip",
+            marks=pytest.mark.xfail(strict=True, reason="InputFailure: must specify IP"),
+        ),
+        # Multiple associations, IP arg not on host at all -> EntityNotFound (from _get_host_ip)
+        pytest.param(
+            [
+                HostCommunity(ipaddress=1, community=RED),
+                HostCommunity(ipaddress=2, community=RED),
+            ],
+            [IP1, IP2],
+            "red",
+            "10.0.0.99",
+            None,
+            id="multi-assoc-ip-not-on-host",
+            marks=pytest.mark.xfail(strict=True, reason="EntityNotFound: IP not on host"),
+        ),
+        # Multiple associations, IP arg on host but not in this community -> EntityNotFound
+        pytest.param(
+            [
+                HostCommunity(ipaddress=1, community=RED),
+            ],
+            [IP1, IP2],
+            "red",
+            "10.0.0.2",
+            None,
+            id="ip-on-host-not-in-community",
+            marks=pytest.mark.xfail(strict=True, reason="EntityNotFound: IP not in community"),
+        ),
+    ],
+)
+def test_get_host_community_and_ip_to_remove(
+    communities: list[HostCommunity],
+    ipaddresses: list[IPAddress],
+    community_name: str,
+    ip: str | None,
+    expected_ip_id: int | None,
+) -> None:
+    host = make_host(ipaddresses=ipaddresses, communities=communities)
+
+    community, ipaddr = _get_host_community_and_ip_to_remove(host, community_name, ip)
+
+    assert community.name.casefold() == community_name.casefold()
+    assert ipaddr.id == expected_ip_id

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ from collections.abc import Iterator
 import pytest
 from mreg_api.client import last_request_method, last_request_url
 
-from mreg_cli.client import set_client
+from mreg_cli.client import _reset_client  # pyright: ignore[reportPrivateUsage]
 from mreg_cli.config import MregCliConfig
 from mreg_cli.outputmanager import OutputManager
 
@@ -54,7 +54,7 @@ def reset_context_vars() -> Iterator[None]:
 def reset_mreg_client() -> Iterator[None]:
     """Reset the global MregClient after each test."""
     yield
-    set_client(None)  # type: ignore[arg-type]
+    _reset_client()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,9 +4,9 @@ import os
 from collections.abc import Iterator
 
 import pytest
-from mreg_api import MregClient
 from mreg_api.client import last_request_method, last_request_url
 
+from mreg_cli.client import set_client
 from mreg_cli.config import MregCliConfig
 from mreg_cli.outputmanager import OutputManager
 
@@ -52,12 +52,9 @@ def reset_context_vars() -> Iterator[None]:
 
 @pytest.fixture(autouse=True)
 def reset_mreg_client() -> Iterator[None]:
-    """Reset the MregClient after each test."""
+    """Reset the global MregClient after each test."""
     yield
-    try:
-        MregClient.reset_instance()
-    except KeyError:
-        pass
+    set_client(None)  # type: ignore[arg-type]
 
 
 @pytest.fixture(autouse=True)

--- a/uv.lock
+++ b/uv.lock
@@ -252,8 +252,8 @@ wheels = [
 
 [[package]]
 name = "mreg-api"
-version = "0.2.4.dev88+gdd75f51ab"
-source = { git = "https://github.com/unioslo/mreg-api?branch=remove-singleton-pattern#dd75f51ab307efec3d35aa8d21927f7b0a0b4bf8" }
+version = "0.2.4.dev17+gae3fd5bbe"
+source = { git = "https://github.com/unioslo/mreg-api?branch=main#ae3fd5bbe9f98c2b24b0d0fea16c1634ba755fac" }
 dependencies = [
     { name = "diskcache" },
     { name = "httpx", extra = ["socks"] },
@@ -303,7 +303,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mreg-api", git = "https://github.com/unioslo/mreg-api?branch=remove-singleton-pattern" },
+    { name = "mreg-api", git = "https://github.com/unioslo/mreg-api?branch=main" },
     { name = "platformdirs", specifier = ">=4.3.0" },
     { name = "prompt-toolkit", specifier = ">=3.0.0" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.7.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -252,8 +252,8 @@ wheels = [
 
 [[package]]
 name = "mreg-api"
-version = "0.2.4.dev77+gd76ffbb94"
-source = { git = "https://github.com/unioslo/mreg-api?branch=remove-singleton-pattern#d76ffbb94a7a1261a9c380373a2172c795282ca2" }
+version = "0.2.4.dev78+gb4873acd8"
+source = { git = "https://github.com/unioslo/mreg-api?branch=remove-singleton-pattern#b4873acd8bad998325c429537c3e1e7eb5709324" }
 dependencies = [
     { name = "diskcache" },
     { name = "httpx", extra = ["socks"] },

--- a/uv.lock
+++ b/uv.lock
@@ -252,8 +252,8 @@ wheels = [
 
 [[package]]
 name = "mreg-api"
-version = "0.2.4.dev79+gf5e30412e"
-source = { git = "https://github.com/unioslo/mreg-api?branch=remove-singleton-pattern#f5e30412e0d0c885be4195215653b4a253a035aa" }
+version = "0.2.4.dev80+gace300ea2"
+source = { git = "https://github.com/unioslo/mreg-api?branch=remove-singleton-pattern#ace300ea2ec05b78b7c80eef8902d437ad599372" }
 dependencies = [
     { name = "diskcache" },
     { name = "httpx", extra = ["socks"] },
@@ -812,11 +812,11 @@ wheels = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.15.0"
+version = "4.16.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -252,8 +252,8 @@ wheels = [
 
 [[package]]
 name = "mreg-api"
-version = "0.2.4.dev50+gb715e1f00"
-source = { git = "https://github.com/unioslo/mreg-api?branch=remove-singleton-pattern#b715e1f00d19a0a35e33a8d80f26f783365e9088" }
+version = "0.2.4.dev53+g14b24196b"
+source = { git = "https://github.com/unioslo/mreg-api?branch=remove-singleton-pattern#14b24196ba2e981acbf4bceed48098ee1f4b3f0c" }
 dependencies = [
     { name = "diskcache" },
     { name = "httpx", extra = ["socks"] },

--- a/uv.lock
+++ b/uv.lock
@@ -252,8 +252,8 @@ wheels = [
 
 [[package]]
 name = "mreg-api"
-version = "0.2.3"
-source = { registry = "https://pypi.org/simple" }
+version = "0.2.4.dev50+gb715e1f00"
+source = { git = "https://github.com/unioslo/mreg-api?branch=remove-singleton-pattern#b715e1f00d19a0a35e33a8d80f26f783365e9088" }
 dependencies = [
     { name = "diskcache" },
     { name = "httpx", extra = ["socks"] },
@@ -261,10 +261,6 @@ dependencies = [
     { name = "pydantic-extra-types" },
     { name = "pydantic-settings" },
     { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/70/e6727f685d9603cf482e186b51144b7726cdd9bd70a9289f0051541af4a4/mreg_api-0.2.3.tar.gz", hash = "sha256:6aa83d4ed04f0f7648be8efd32b28b2b173f5911d7a6e67ff8262d7efde2687d", size = 154018, upload-time = "2026-05-21T09:18:40.411Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/fb/22ab4eabfc3d5e72da8cf5753274cc57cc5aef2ab1fc2ca0971c3407d8a8/mreg_api-0.2.3-py3-none-any.whl", hash = "sha256:f7247b55cb794c5b9cec763949f744392ae2ee62be62c3f6359c3450c5c573ce", size = 83426, upload-time = "2026-05-21T09:18:39.012Z" },
 ]
 
 [[package]]
@@ -307,7 +303,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mreg-api", specifier = ">=0.2.0,<0.3.0" },
+    { name = "mreg-api", git = "https://github.com/unioslo/mreg-api?branch=remove-singleton-pattern" },
     { name = "platformdirs", specifier = ">=4.3.0" },
     { name = "prompt-toolkit", specifier = ">=3.0.0" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.7.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -252,8 +252,8 @@ wheels = [
 
 [[package]]
 name = "mreg-api"
-version = "0.2.4.dev80+gace300ea2"
-source = { git = "https://github.com/unioslo/mreg-api?branch=remove-singleton-pattern#ace300ea2ec05b78b7c80eef8902d437ad599372" }
+version = "0.2.4.dev87+gc14bdaa0a"
+source = { git = "https://github.com/unioslo/mreg-api?branch=remove-singleton-pattern#c14bdaa0a922752043b77bcd1cf7cb7fa963e968" }
 dependencies = [
     { name = "diskcache" },
     { name = "httpx", extra = ["socks"] },

--- a/uv.lock
+++ b/uv.lock
@@ -252,8 +252,8 @@ wheels = [
 
 [[package]]
 name = "mreg-api"
-version = "0.2.4.dev72+ge7c92418a"
-source = { git = "https://github.com/unioslo/mreg-api?branch=remove-singleton-pattern#e7c92418a66c78b9034fe6f4d4ab5f3e6ed327d3" }
+version = "0.2.4.dev76+g9a88bac8c"
+source = { git = "https://github.com/unioslo/mreg-api?branch=remove-singleton-pattern#9a88bac8c555ebb2d979b7ab27d6a7903dd91778" }
 dependencies = [
     { name = "diskcache" },
     { name = "httpx", extra = ["socks"] },

--- a/uv.lock
+++ b/uv.lock
@@ -252,8 +252,8 @@ wheels = [
 
 [[package]]
 name = "mreg-api"
-version = "0.2.4.dev87+gc14bdaa0a"
-source = { git = "https://github.com/unioslo/mreg-api?branch=remove-singleton-pattern#c14bdaa0a922752043b77bcd1cf7cb7fa963e968" }
+version = "0.2.4.dev88+gdd75f51ab"
+source = { git = "https://github.com/unioslo/mreg-api?branch=remove-singleton-pattern#dd75f51ab307efec3d35aa8d21927f7b0a0b4bf8" }
 dependencies = [
     { name = "diskcache" },
     { name = "httpx", extra = ["socks"] },

--- a/uv.lock
+++ b/uv.lock
@@ -252,8 +252,8 @@ wheels = [
 
 [[package]]
 name = "mreg-api"
-version = "0.2.4.dev76+g9a88bac8c"
-source = { git = "https://github.com/unioslo/mreg-api?branch=remove-singleton-pattern#9a88bac8c555ebb2d979b7ab27d6a7903dd91778" }
+version = "0.2.4.dev77+gd76ffbb94"
+source = { git = "https://github.com/unioslo/mreg-api?branch=remove-singleton-pattern#d76ffbb94a7a1261a9c380373a2172c795282ca2" }
 dependencies = [
     { name = "diskcache" },
     { name = "httpx", extra = ["socks"] },

--- a/uv.lock
+++ b/uv.lock
@@ -252,8 +252,8 @@ wheels = [
 
 [[package]]
 name = "mreg-api"
-version = "0.2.4.dev17+gae3fd5bbe"
-source = { git = "https://github.com/unioslo/mreg-api?branch=main#ae3fd5bbe9f98c2b24b0d0fea16c1634ba755fac" }
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "diskcache" },
     { name = "httpx", extra = ["socks"] },
@@ -261,6 +261,10 @@ dependencies = [
     { name = "pydantic-extra-types" },
     { name = "pydantic-settings" },
     { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/30/8267b17e5964d39522fe5098ec7e738b11aac497fae7411f403e4ec0ce0a/mreg_api-0.3.0.tar.gz", hash = "sha256:6fd7b1e2b7f0bda1947759a0029808c6a4163da0ab05d4bcacd1a21d9012965c", size = 189106, upload-time = "2026-08-12T13:07:41.949Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/66/19b35fe46f27432cb70d9f15bd56260e3362dcfa4cdcef6c544b9ee7145d/mreg_api-0.3.0-py3-none-any.whl", hash = "sha256:2b9f2015ba7b04747f49786a5300130eebf270064549630c103e5d4f233dd868", size = 94280, upload-time = "2026-08-12T13:07:40.72Z" },
 ]
 
 [[package]]
@@ -303,7 +307,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mreg-api", git = "https://github.com/unioslo/mreg-api?branch=main" },
+    { name = "mreg-api", specifier = ">=0.3.0,<0.4.0" },
     { name = "platformdirs", specifier = ">=4.3.0" },
     { name = "prompt-toolkit", specifier = ">=3.0.0" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.7.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -252,8 +252,8 @@ wheels = [
 
 [[package]]
 name = "mreg-api"
-version = "0.2.4.dev78+gb4873acd8"
-source = { git = "https://github.com/unioslo/mreg-api?branch=remove-singleton-pattern#b4873acd8bad998325c429537c3e1e7eb5709324" }
+version = "0.2.4.dev79+gf5e30412e"
+source = { git = "https://github.com/unioslo/mreg-api?branch=remove-singleton-pattern#f5e30412e0d0c885be4195215653b4a253a035aa" }
 dependencies = [
     { name = "diskcache" },
     { name = "httpx", extra = ["socks"] },

--- a/uv.lock
+++ b/uv.lock
@@ -252,8 +252,8 @@ wheels = [
 
 [[package]]
 name = "mreg-api"
-version = "0.2.4.dev53+g14b24196b"
-source = { git = "https://github.com/unioslo/mreg-api?branch=remove-singleton-pattern#14b24196ba2e981acbf4bceed48098ee1f4b3f0c" }
+version = "0.2.4.dev72+ge7c92418a"
+source = { git = "https://github.com/unioslo/mreg-api?branch=remove-singleton-pattern#e7c92418a66c78b9034fe6f4d4ab5f3e6ed327d3" }
 dependencies = [
     { name = "diskcache" },
     { name = "httpx", extra = ["socks"] },


### PR DESCRIPTION
Uses new non-singleton client with dotted manager attribute access. 

Adds a `mreg_cli.client.get_client` function for accessing a globally configured client object shared by commands.


----

Numerous API calls have been removed from the testsuite because of more consistent host fetching (uses `/hosts/<name>` instead of `/hosts/?id=<id>`). This is a positive thing in practice, but it highlights the need to potentially disable caching in tests, because caching (and cache invalidation) makes it harder to see differences in API calls when a command suddenly hits the cached data set by a previous command. When an API call disappears from the test suite log, we can't verify at a glance whether the command didn't send the request or if it hit the cache.