### PR TITLE
CI: support local-only MREG images

### DIFF
--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -13,6 +13,13 @@ If you would like to contribute to this project, please follow these steps:
 
 To run tests locally, just run the script `ci/run_testsuite_and_record_V2.sh` from anywhere. The only prerequisite is a working installation of docker or podman.
 
+CI jobs that provide an already loaded MREG image can prevent Docker Compose from
+pulling a replacement image from a registry:
+
+```bash
+MREG_IMAGE=mreg:ci MREG_IMAGE_PULL_POLICY=never ci/run_testsuite_and_record_V2.sh
+```
+
 ## Publishing
 
 Publishing new versions is automatically handled by GitHub actions for versions tagged with `x.y.z[.prerelease]` (`1.2.3`, `1.2.3.rc1`, etc.). If you are a maintainer, you can create a new release by following these steps:

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -14,6 +14,7 @@ services:
 
   mreg:
     image: ${MREG_IMAGE:?MREG_IMAGE environment variable not set}
+    pull_policy: ${MREG_IMAGE_PULL_POLICY:-missing}
     container_name: mreg
     depends_on:
       postgres:

--- a/ci/run_testsuite_and_record_V2.sh
+++ b/ci/run_testsuite_and_record_V2.sh
@@ -48,12 +48,24 @@ if [ -n "$2" ]; then
 elif [ -z "$MREG_IMAGE" ]; then
 	MREG_IMAGE="ghcr.io/unioslo/mreg:master"
 fi
-export MREG_IMAGE
+
+# Allow callers to require an already loaded local image. The default keeps
+# existing local usage unchanged and pulls the image only when it is missing.
+MREG_IMAGE_PULL_POLICY="${MREG_IMAGE_PULL_POLICY:-missing}"
+export MREG_IMAGE MREG_IMAGE_PULL_POLICY
+
+if [[ "$MREG_IMAGE_PULL_POLICY" == "never" ]] &&
+	! docker image inspect "$MREG_IMAGE" >/dev/null 2>&1; then
+	echo "MREG image '$MREG_IMAGE' is not available locally, but pulling is disabled."
+	exit 1
+fi
 
 if [[ -n "$GITHUB_ACTIONS" ]]; then
 	echo "::notice::Using MREG image: $MREG_IMAGE"
+	echo "::notice::MREG image pull policy: $MREG_IMAGE_PULL_POLICY"
 else
 	echo "Using MREG image: $MREG_IMAGE"
+	echo "MREG image pull policy: $MREG_IMAGE_PULL_POLICY"
 fi
 
 # build a container image for mreg-cli


### PR DESCRIPTION
## Summary

- make the MREG image pull policy configurable in the CI Compose service
- fail early when a caller requires a local image that is unavailable
- document how upstream CI can prohibit replacement registry pulls

## Why

The MREG compatibility workflow loads an image built in the same workflow. It must be able to guarantee that Docker Compose uses that local image instead of pulling another image from a registry.

Existing local usage is unchanged because the default pull policy remains `missing`.

## Validation

- `bash -n ci/run_testsuite_and_record_V2.sh`
- Compose configuration resolves `MREG_IMAGE_PULL_POLICY=never`
- Compose configuration defaults to `pull_policy: missing`